### PR TITLE
refactor(llm): remove tool call ID remapping, flatten on model switch

### DIFF
--- a/src/main/java/me/golemcore/bot/domain/model/ContextAttributes.java
+++ b/src/main/java/me/golemcore/bot/domain/model/ContextAttributes.java
@@ -49,4 +49,10 @@ public final class ContextAttributes {
 
     /** List&lt;Attachment&gt; — attachments pending delivery to channel. */
     public static final String PENDING_ATTACHMENTS = "pendingAttachments";
+
+    /**
+     * String — LLM model name that last generated tool calls in the session
+     * (persisted in session metadata).
+     */
+    public static final String LLM_MODEL = "llm.model";
 }

--- a/src/main/java/me/golemcore/bot/domain/service/SessionService.java
+++ b/src/main/java/me/golemcore/bot/domain/service/SessionService.java
@@ -132,9 +132,12 @@ public class SessionService implements SessionPort {
         }
 
         int toRemove = total - keepLast;
-        messages.subList(0, toRemove).clear();
+        List<Message> kept = Message.flattenToolMessages(
+                new ArrayList<>(messages.subList(toRemove, total)));
+        messages.clear();
+        messages.addAll(kept);
         save(session);
-        log.info("Compacted session {}: removed {} messages, kept {}", sessionId, toRemove, keepLast);
+        log.info("Compacted session {}: removed {} messages, kept {}", sessionId, toRemove, kept.size());
         return toRemove;
     }
 
@@ -151,13 +154,14 @@ public class SessionService implements SessionPort {
         }
 
         int toRemove = total - keepLast;
-        List<Message> kept = new ArrayList<>(messages.subList(toRemove, total));
+        List<Message> kept = Message.flattenToolMessages(
+                new ArrayList<>(messages.subList(toRemove, total)));
         messages.clear();
         messages.add(summaryMessage);
         messages.addAll(kept);
         save(session);
         log.info("Compacted session {} with summary: removed {} messages, kept {} + summary",
-                sessionId, toRemove, keepLast);
+                sessionId, toRemove, kept.size());
         return toRemove;
     }
 

--- a/src/test/java/me/golemcore/bot/adapter/outbound/llm/Langchain4jAdapterRetryTest.java
+++ b/src/test/java/me/golemcore/bot/adapter/outbound/llm/Langchain4jAdapterRetryTest.java
@@ -3,7 +3,6 @@ package me.golemcore.bot.adapter.outbound.llm;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -13,7 +12,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class Langchain4jAdapterRetryTest {
 
     private static final String IS_RATE_LIMIT_ERROR = "isRateLimitError";
-    private static final String SANITIZE_FUNCTION_NAME = "sanitizeFunctionName";
 
     @Test
     void isRateLimitError_detectsTokenQuotaExceeded() {
@@ -73,66 +71,6 @@ class Langchain4jAdapterRetryTest {
 
         RuntimeException ex = new RuntimeException((String) null);
         assertFalse((boolean) ReflectionTestUtils.invokeMethod(adapter, IS_RATE_LIMIT_ERROR, ex));
-    }
-
-    // ===== sanitizeFunctionName =====
-
-    @Test
-    void sanitizeFunctionName_validName() {
-        Langchain4jAdapter adapter = createMinimalAdapter();
-        String result = ReflectionTestUtils.invokeMethod(adapter, SANITIZE_FUNCTION_NAME, "my_tool");
-        assertEquals("my_tool", result);
-    }
-
-    @Test
-    void sanitizeFunctionName_validNameWithDash() {
-        Langchain4jAdapter adapter = createMinimalAdapter();
-        String result = ReflectionTestUtils.invokeMethod(adapter, SANITIZE_FUNCTION_NAME, "my-tool");
-        assertEquals("my-tool", result);
-    }
-
-    @Test
-    void sanitizeFunctionName_replacesDotsWithUnderscore() {
-        Langchain4jAdapter adapter = createMinimalAdapter();
-        String result = ReflectionTestUtils.invokeMethod(adapter, SANITIZE_FUNCTION_NAME, "tools.read_file");
-        assertEquals("tools_read_file", result);
-    }
-
-    @Test
-    void sanitizeFunctionName_replacesSpacesAndSpecialChars() {
-        Langchain4jAdapter adapter = createMinimalAdapter();
-        String result = ReflectionTestUtils.invokeMethod(adapter, SANITIZE_FUNCTION_NAME, "my tool/v2!");
-        assertEquals("my_tool_v2_", result);
-    }
-
-    @Test
-    void sanitizeFunctionName_nullReturnsUnknown() {
-        Langchain4jAdapter adapter = createMinimalAdapter();
-        String result = ReflectionTestUtils.invokeMethod(adapter, SANITIZE_FUNCTION_NAME, (String) null);
-        assertEquals("unknown", result);
-    }
-
-    @Test
-    void sanitizeFunctionName_allInvalidCharsReplacedWithUnderscore() {
-        Langchain4jAdapter adapter = createMinimalAdapter();
-        // Dots -> underscores, result is "___" (not empty)
-        String result = ReflectionTestUtils.invokeMethod(adapter, SANITIZE_FUNCTION_NAME, "...");
-        assertEquals("___", result);
-    }
-
-    @Test
-    void sanitizeFunctionName_alreadyValid() {
-        Langchain4jAdapter adapter = createMinimalAdapter();
-        String result = ReflectionTestUtils.invokeMethod(adapter, SANITIZE_FUNCTION_NAME, "filesystem_read");
-        assertEquals("filesystem_read", result);
-    }
-
-    @Test
-    void sanitizeFunctionName_unicodeReplaced() {
-        Langchain4jAdapter adapter = createMinimalAdapter();
-        String result = ReflectionTestUtils.invokeMethod(adapter, SANITIZE_FUNCTION_NAME,
-                "tool_\u0444\u044B\u0432\u0430");
-        assertTrue(result.matches("^[a-zA-Z0-9_-]+$"));
     }
 
     private Langchain4jAdapter createMinimalAdapter() {

--- a/src/test/java/me/golemcore/bot/domain/model/MessageFlattenTest.java
+++ b/src/test/java/me/golemcore/bot/domain/model/MessageFlattenTest.java
@@ -1,0 +1,306 @@
+package me.golemcore.bot.domain.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MessageFlattenTest {
+
+    private static final String ROLE_USER = "user";
+    private static final String ROLE_ASSISTANT = "assistant";
+    private static final String ROLE_TOOL = "tool";
+    private static final Instant NOW = Instant.parse("2026-02-09T12:00:00Z");
+    private static final String TC1 = "tc1";
+    private static final String TC2 = "tc2";
+    private static final String TOOL_SHELL = "shell";
+    private static final String TOOL_FILESYSTEM = "filesystem";
+    private static final String ARG_COMMAND = "command";
+    private static final String CONTENT_FILE1 = "file1.txt";
+    private static final String CONTAINS_TOOL_SHELL = "[Tool: shell";
+
+    @Test
+    void shouldPassThroughMessagesWithoutToolCalls() {
+        List<Message> messages = List.of(
+                Message.builder().id("m1").role(ROLE_USER).content("Hello").timestamp(NOW).build(),
+                Message.builder().id("m2").role(ROLE_ASSISTANT).content("Hi there!").timestamp(NOW).build());
+
+        List<Message> result = Message.flattenToolMessages(new ArrayList<>(messages));
+
+        assertEquals(2, result.size());
+        assertSame(messages.get(0), result.get(0));
+        assertSame(messages.get(1), result.get(1));
+    }
+
+    @Test
+    void shouldFlattenSingleToolCallRound() {
+        List<Message> messages = new ArrayList<>(List.of(
+                Message.builder().id("m1").role(ROLE_USER).content("List files").timestamp(NOW).build(),
+                Message.builder().id("m2").role(ROLE_ASSISTANT)
+                        .toolCalls(List.of(Message.ToolCall.builder()
+                                .id(TC1).name(TOOL_SHELL)
+                                .arguments(Map.of(ARG_COMMAND, "ls -la"))
+                                .build()))
+                        .timestamp(NOW).build(),
+                Message.builder().id("m3").role(ROLE_TOOL)
+                        .toolCallId(TC1).toolName(TOOL_SHELL)
+                        .content("file1.txt\nfile2.txt")
+                        .timestamp(NOW).build()));
+
+        List<Message> result = Message.flattenToolMessages(messages);
+
+        assertEquals(2, result.size());
+        assertEquals(ROLE_USER, result.get(0).getRole());
+        assertEquals(ROLE_ASSISTANT, result.get(1).getRole());
+        assertTrue(result.get(1).getContent().contains(CONTAINS_TOOL_SHELL));
+        assertTrue(result.get(1).getContent().contains(CONTENT_FILE1));
+        assertNull(result.get(1).getToolCalls());
+    }
+
+    @Test
+    void shouldFlattenMultipleToolCallsInOneRound() {
+        List<Message> messages = new ArrayList<>(List.of(
+                Message.builder().id("m1").role(ROLE_USER).content("Do stuff").timestamp(NOW).build(),
+                Message.builder().id("m2").role(ROLE_ASSISTANT)
+                        .toolCalls(List.of(
+                                Message.ToolCall.builder()
+                                        .id(TC1).name(TOOL_SHELL)
+                                        .arguments(Map.of(ARG_COMMAND, "ls"))
+                                        .build(),
+                                Message.ToolCall.builder()
+                                        .id(TC2).name(TOOL_FILESYSTEM)
+                                        .arguments(Map.of("operation", "read", "path", "config.yml"))
+                                        .build()))
+                        .timestamp(NOW).build(),
+                Message.builder().id("m3").role(ROLE_TOOL)
+                        .toolCallId(TC1).toolName(TOOL_SHELL)
+                        .content(CONTENT_FILE1)
+                        .timestamp(NOW).build(),
+                Message.builder().id("m4").role(ROLE_TOOL)
+                        .toolCallId(TC2).toolName(TOOL_FILESYSTEM)
+                        .content("key: value")
+                        .timestamp(NOW).build()));
+
+        List<Message> result = Message.flattenToolMessages(messages);
+
+        assertEquals(2, result.size());
+        String content = result.get(1).getContent();
+        assertTrue(content.contains(CONTAINS_TOOL_SHELL));
+        assertTrue(content.contains(CONTENT_FILE1));
+        assertTrue(content.contains("[Tool: filesystem"));
+        assertTrue(content.contains("key: value"));
+    }
+
+    @Test
+    void shouldFlattenMultipleRounds() {
+        List<Message> messages = new ArrayList<>(List.of(
+                Message.builder().id("m1").role(ROLE_USER).content("Hi").timestamp(NOW).build(),
+                Message.builder().id("m2").role(ROLE_ASSISTANT)
+                        .toolCalls(List.of(Message.ToolCall.builder()
+                                .id(TC1).name(TOOL_SHELL)
+                                .arguments(Map.of(ARG_COMMAND, "date"))
+                                .build()))
+                        .timestamp(NOW).build(),
+                Message.builder().id("m3").role(ROLE_TOOL)
+                        .toolCallId(TC1).toolName(TOOL_SHELL)
+                        .content("2026-02-09")
+                        .timestamp(NOW).build(),
+                Message.builder().id("m4").role(ROLE_ASSISTANT).content("Today is Feb 9").timestamp(NOW).build(),
+                Message.builder().id("m5").role(ROLE_USER).content("Now read file").timestamp(NOW).build(),
+                Message.builder().id("m6").role(ROLE_ASSISTANT)
+                        .toolCalls(List.of(Message.ToolCall.builder()
+                                .id(TC2).name(TOOL_FILESYSTEM)
+                                .arguments(Map.of("path", "test.txt"))
+                                .build()))
+                        .timestamp(NOW).build(),
+                Message.builder().id("m7").role(ROLE_TOOL)
+                        .toolCallId(TC2).toolName(TOOL_FILESYSTEM)
+                        .content("hello world")
+                        .timestamp(NOW).build()));
+
+        List<Message> result = Message.flattenToolMessages(messages);
+
+        // m1(user) + m2+m3(flattened) + m4(assistant text) + m5(user) +
+        // m6+m7(flattened)
+        assertEquals(5, result.size());
+        assertEquals(ROLE_USER, result.get(0).getRole());
+        assertTrue(result.get(1).getContent().contains(CONTAINS_TOOL_SHELL));
+        assertEquals("Today is Feb 9", result.get(2).getContent());
+        assertEquals(ROLE_USER, result.get(3).getRole());
+        assertTrue(result.get(4).getContent().contains("[Tool: filesystem"));
+    }
+
+    @Test
+    void shouldPreserveAssistantContentBeforeToolCalls() {
+        List<Message> messages = new ArrayList<>(List.of(
+                Message.builder().id("m1").role(ROLE_ASSISTANT)
+                        .content("Let me check that for you.")
+                        .toolCalls(List.of(Message.ToolCall.builder()
+                                .id(TC1).name(TOOL_SHELL)
+                                .arguments(Map.of(ARG_COMMAND, "whoami"))
+                                .build()))
+                        .timestamp(NOW).build(),
+                Message.builder().id("m2").role(ROLE_TOOL)
+                        .toolCallId(TC1).toolName(TOOL_SHELL)
+                        .content("alex")
+                        .timestamp(NOW).build()));
+
+        List<Message> result = Message.flattenToolMessages(messages);
+
+        assertEquals(1, result.size());
+        assertTrue(result.get(0).getContent().startsWith("Let me check that for you."));
+        assertTrue(result.get(0).getContent().contains(CONTAINS_TOOL_SHELL));
+        assertTrue(result.get(0).getContent().contains("alex"));
+    }
+
+    @Test
+    void shouldHandleEmptyToolResultContent() {
+        List<Message> messages = new ArrayList<>(List.of(
+                Message.builder().id("m1").role(ROLE_ASSISTANT)
+                        .toolCalls(List.of(Message.ToolCall.builder()
+                                .id(TC1).name(TOOL_SHELL)
+                                .arguments(Map.of(ARG_COMMAND, "true"))
+                                .build()))
+                        .timestamp(NOW).build(),
+                Message.builder().id("m2").role(ROLE_TOOL)
+                        .toolCallId(TC1).toolName(TOOL_SHELL)
+                        .content("")
+                        .timestamp(NOW).build()));
+
+        List<Message> result = Message.flattenToolMessages(messages);
+
+        assertEquals(1, result.size());
+        assertTrue(result.get(0).getContent().contains("[Result: <empty>]"));
+    }
+
+    @Test
+    void shouldHandleMissingToolResult() {
+        List<Message> messages = new ArrayList<>(List.of(
+                Message.builder().id("m1").role(ROLE_ASSISTANT)
+                        .toolCalls(List.of(Message.ToolCall.builder()
+                                .id(TC1).name(TOOL_SHELL)
+                                .arguments(Map.of(ARG_COMMAND, "test"))
+                                .build()))
+                        .timestamp(NOW).build()));
+        // No tool result message
+
+        List<Message> result = Message.flattenToolMessages(messages);
+
+        assertEquals(1, result.size());
+        assertTrue(result.get(0).getContent().contains("[Result: <no response>]"));
+    }
+
+    @Test
+    void shouldTruncateLongResults() {
+        String longResult = "x".repeat(3000);
+        List<Message> messages = new ArrayList<>(List.of(
+                Message.builder().id("m1").role(ROLE_ASSISTANT)
+                        .toolCalls(List.of(Message.ToolCall.builder()
+                                .id(TC1).name(TOOL_SHELL)
+                                .arguments(Map.of(ARG_COMMAND, "cat bigfile"))
+                                .build()))
+                        .timestamp(NOW).build(),
+                Message.builder().id("m2").role(ROLE_TOOL)
+                        .toolCallId(TC1).toolName(TOOL_SHELL)
+                        .content(longResult)
+                        .timestamp(NOW).build()));
+
+        List<Message> result = Message.flattenToolMessages(messages);
+
+        assertEquals(1, result.size());
+        // Result should be truncated to ~2000 chars + "..."
+        assertTrue(result.get(0).getContent().length() < longResult.length());
+        assertTrue(result.get(0).getContent().contains("..."));
+    }
+
+    @Test
+    void shouldHandleOrphanedToolMessage() {
+        List<Message> messages = new ArrayList<>(List.of(
+                Message.builder().id("m1").role(ROLE_USER).content("Hi").timestamp(NOW).build(),
+                Message.builder().id("m2").role(ROLE_TOOL)
+                        .toolCallId("orphan-id").toolName(TOOL_SHELL)
+                        .content("orphaned result")
+                        .timestamp(NOW).build()));
+
+        List<Message> result = Message.flattenToolMessages(messages);
+
+        assertEquals(2, result.size());
+        assertEquals(ROLE_USER, result.get(0).getRole());
+        // Orphaned tool message should be converted to assistant
+        assertEquals(ROLE_ASSISTANT, result.get(1).getRole());
+        assertTrue(result.get(1).getContent().contains("[Tool: shell]"));
+        assertTrue(result.get(1).getContent().contains("orphaned result"));
+    }
+
+    @Test
+    void shouldBeIdempotent() {
+        List<Message> messages = new ArrayList<>(List.of(
+                Message.builder().id("m1").role(ROLE_USER).content("Hello").timestamp(NOW).build(),
+                Message.builder().id("m2").role(ROLE_ASSISTANT)
+                        .toolCalls(List.of(Message.ToolCall.builder()
+                                .id(TC1).name(TOOL_SHELL)
+                                .arguments(Map.of(ARG_COMMAND, "ls"))
+                                .build()))
+                        .timestamp(NOW).build(),
+                Message.builder().id("m3").role(ROLE_TOOL)
+                        .toolCallId(TC1).toolName(TOOL_SHELL)
+                        .content(CONTENT_FILE1)
+                        .timestamp(NOW).build()));
+
+        List<Message> first = Message.flattenToolMessages(messages);
+        List<Message> second = Message.flattenToolMessages(new ArrayList<>(first));
+
+        assertEquals(first.size(), second.size());
+        for (int i = 0; i < first.size(); i++) {
+            assertEquals(first.get(i).getContent(), second.get(i).getContent());
+            assertEquals(first.get(i).getRole(), second.get(i).getRole());
+        }
+        // After second pass, no tool calls should exist
+        assertFalse(second.stream().anyMatch(Message::hasToolCalls));
+        assertFalse(second.stream().anyMatch(Message::isToolMessage));
+    }
+
+    @Test
+    void shouldHandleNullInput() {
+        assertNull(Message.flattenToolMessages(null));
+    }
+
+    @Test
+    void shouldHandleEmptyList() {
+        List<Message> result = Message.flattenToolMessages(new ArrayList<>());
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void shouldPreserveMessageMetadata() {
+        Map<String, Object> metadata = Map.of("key", "value");
+        List<Message> messages = new ArrayList<>(List.of(
+                Message.builder().id("m1").role(ROLE_ASSISTANT)
+                        .toolCalls(List.of(Message.ToolCall.builder()
+                                .id(TC1).name(TOOL_SHELL)
+                                .arguments(Map.of(ARG_COMMAND, "ls"))
+                                .build()))
+                        .timestamp(NOW)
+                        .metadata(metadata)
+                        .build(),
+                Message.builder().id("m2").role(ROLE_TOOL)
+                        .toolCallId(TC1).toolName(TOOL_SHELL)
+                        .content("ok")
+                        .timestamp(NOW).build()));
+
+        List<Message> result = Message.flattenToolMessages(messages);
+
+        assertEquals(1, result.size());
+        assertEquals("m1", result.get(0).getId());
+        assertEquals(NOW, result.get(0).getTimestamp());
+        assertEquals(metadata, result.get(0).getMetadata());
+    }
+}

--- a/src/test/java/me/golemcore/bot/domain/system/ToolExecutionSystemTest.java
+++ b/src/test/java/me/golemcore/bot/domain/system/ToolExecutionSystemTest.java
@@ -609,26 +609,6 @@ class ToolExecutionSystemTest {
     }
 
     @Test
-    void longToolCallIdNormalized() {
-        String longId = "call_" + "a".repeat(50);
-        Message.ToolCall toolCall = Message.ToolCall.builder()
-                .id(longId)
-                .name(TOOL_DATETIME)
-                .arguments(Map.of(ARG_OPERATION, ARG_NOW))
-                .build();
-
-        when(confirmationPolicy.requiresConfirmation(toolCall)).thenReturn(false);
-        when(dateTimeTool.execute(any())).thenReturn(CompletableFuture.completedFuture(ToolResult.success("ok")));
-
-        AgentContext context = createContextWithToolCalls(List.of(toolCall));
-        system.process(context);
-
-        // Tool result message should have normalized (shorter) ID
-        Message toolMsg = context.getMessages().get(1);
-        assertTrue(toolMsg.getToolCallId().length() <= 40);
-    }
-
-    @Test
     void confirmationFailureDefaultsToDeny() {
         Message.ToolCall toolCall = Message.ToolCall.builder()
                 .id(TOOL_CALL_ID)


### PR DESCRIPTION
## Summary

- Replace complex tool call ID remapping/sanitization in `Langchain4jAdapter` and `ToolExecutionSystem` with a simpler approach: track the active LLM model in session metadata and flatten tool call messages to plain text on model switch or compaction
- Add `Message.flattenToolMessages()` — converts assistant+tool message pairs into human-readable `[Tool: name | Args: {...}] / [Result: ...]` text
- Add `LlmExecutionSystem.flattenOnModelSwitch()` — detects model changes via `ContextAttributes.LLM_MODEL` in session metadata
- Remove `Langchain4jAdapter.sanitizeFunctionName()`, `idRemap` HashMap, ID length constants
- Remove `ToolExecutionSystem.normalizeToolCallIds()`
- Flatten kept messages during `SessionService` compaction to strip provider-specific metadata
- Fix wildcard imports in `LlmExecutionSystem` and `Langchain4jAdapter`

## Test plan

- [x] New `MessageFlattenTest` — 13 tests (single round, multi-round, orphaned, idempotent, truncation, metadata preservation, etc.)
- [x] `LlmExecutionSystemTest` — 5 new tests for model tracking and flattening (model switch, same model, legacy session, first run)
- [x] `Langchain4jAdapterTest` — removed remap/sanitize tests, added passthrough test
- [x] `ToolExecutionSystemTest` — removed `longToolCallIdNormalized` test
- [x] `Langchain4jAdapterRetryTest` — removed sanitize tests
- [x] `./mvnw clean verify -P strict` passes (tests + PMD + SpotBugs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)