### PR TITLE
feat(auto): add delete/clear operations to goal and task management

### DIFF
--- a/src/test/java/me/golemcore/bot/tools/GoalManagementToolTest.java
+++ b/src/test/java/me/golemcore/bot/tools/GoalManagementToolTest.java
@@ -489,6 +489,74 @@ class GoalManagementToolTest {
         assertTrue(result.getError().contains(TITLE));
     }
 
+    // ===== delete_goal =====
+
+    @Test
+    void deleteGoalSuccess() throws Exception {
+        ToolResult result = tool.execute(Map.of(
+                OPERATION, "delete_goal",
+                GOAL_ID, GOAL_ID_G1)).get();
+
+        assertTrue(result.isSuccess());
+        assertTrue(result.getOutput().contains("deleted"));
+        verify(autoModeService).deleteGoal(GOAL_ID_G1);
+    }
+
+    @Test
+    void deleteGoalMissingGoalId() throws Exception {
+        ToolResult result = tool.execute(Map.of(
+                OPERATION, "delete_goal")).get();
+
+        assertFalse(result.isSuccess());
+        assertTrue(result.getError().contains(GOAL_ID));
+        verifyNoInteractions(autoModeService);
+    }
+
+    // ===== delete_task =====
+
+    @Test
+    void deleteTaskSuccess() throws Exception {
+        ToolResult result = tool.execute(Map.of(
+                OPERATION, "delete_task",
+                GOAL_ID, GOAL_ID_G1,
+                TASK_ID, TASK_ID_T1)).get();
+
+        assertTrue(result.isSuccess());
+        assertTrue(result.getOutput().contains("deleted"));
+        verify(autoModeService).deleteTask(GOAL_ID_G1, TASK_ID_T1);
+    }
+
+    @Test
+    void deleteTaskMissingParams() throws Exception {
+        ToolResult result = tool.execute(Map.of(
+                OPERATION, "delete_task",
+                GOAL_ID, GOAL_ID_G1)).get();
+
+        assertFalse(result.isSuccess());
+        assertTrue(result.getError().contains(TASK_ID));
+
+        ToolResult result2 = tool.execute(Map.of(
+                OPERATION, "delete_task",
+                TASK_ID, TASK_ID_T1)).get();
+
+        assertFalse(result2.isSuccess());
+        assertTrue(result2.getError().contains(GOAL_ID));
+    }
+
+    // ===== clear_completed =====
+
+    @Test
+    void clearCompletedSuccess() throws Exception {
+        when(autoModeService.clearCompletedGoals()).thenReturn(3);
+
+        ToolResult result = tool.execute(Map.of(
+                OPERATION, "clear_completed")).get();
+
+        assertTrue(result.isSuccess());
+        assertTrue(result.getOutput().contains("3"));
+        verify(autoModeService).clearCompletedGoals();
+    }
+
     // ===== getDefinition =====
 
     @Test


### PR DESCRIPTION
## Summary

- Add `deleteGoal()`, `deleteTask()`, and `clearCompletedGoals()` methods to `AutoModeService`
- Expose as `delete_goal`, `delete_task`, `clear_completed` operations in `GoalManagementTool`
- Fix SpotBugs `REC_CATCH_EXCEPTION` by narrowing catch from `Exception` to `RuntimeException`
- Extract duplicate string literals to constants (PMD `AvoidDuplicateLiterals`)

## Test plan

- [x] 6 new tests in `AutoModeServiceTest` (delete goal, delete task, clear completed — happy + error paths)
- [x] 5 new tests in `GoalManagementToolTest` (all 3 operations — success + missing params)
- [x] `./mvnw clean verify -P strict` passes (PMD + SpotBugs clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)