### PR TITLE
feat(tools): add configurable env var whitelist to ShellTool

### DIFF
--- a/src/main/java/me/golemcore/bot/infrastructure/config/BotProperties.java
+++ b/src/main/java/me/golemcore/bot/infrastructure/config/BotProperties.java
@@ -395,6 +395,7 @@ public class BotProperties {
         private String workspace = "${user.home}/.golemcore/sandbox";
         private int defaultTimeout = 30;
         private int maxTimeout = 300;
+        private String allowedEnvVars = "";
     }
 
     @Data

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -145,6 +145,7 @@ bot.tools.shell.enabled=${SHELL_TOOL_ENABLED:true}
 bot.tools.shell.workspace=${TOOLS_WORKSPACE:${user.home}/.golemcore/sandbox}
 bot.tools.shell.default-timeout=${SHELL_DEFAULT_TIMEOUT:30}
 bot.tools.shell.max-timeout=${SHELL_MAX_TIMEOUT:300}
+bot.tools.shell.allowed-env-vars=${SHELL_ALLOWED_ENV_VARS:}
 # Skill management tool - create/list/delete skills via LLM
 bot.tools.skill-management.enabled=${SKILL_MANAGEMENT_TOOL_ENABLED:true}
 # Skill transition tool - allows LLM to transition between skills in a pipeline


### PR DESCRIPTION
## Summary
- Add `bot.tools.shell.allowed-env-vars` config property (comma-separated list of additional env var names to pass through to shell processes)
- Default set (PATH, LANG, LC_ALL, LC_CTYPE, TERM, TMPDIR, TZ, SHELL, USER, LOGNAME) is always included
- Allows operators to expose vars like `JAVA_HOME`, `NODE_PATH`, `GOPATH` without source changes

## Test plan
- [x] Verify default env vars (PATH) are preserved in shell process
- [x] Verify non-whitelisted env vars (LD_PRELOAD) are stripped
- [x] Verify empty config preserves default behavior
- [x] Verify whitespace-padded config values are parsed correctly
- [x] Full `./mvnw clean verify -P strict` passes (1310 tests, PMD, SpotBugs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)