### PR TITLE
refactor(runtime): extract runtime settings application layer

### DIFF
--- a/src/main/java/me/golemcore/bot/adapter/inbound/web/controller/SettingsController.java
+++ b/src/main/java/me/golemcore/bot/adapter/inbound/web/controller/SettingsController.java
@@ -1,19 +1,14 @@
 package me.golemcore.bot.adapter.inbound.web.controller;
 
-import lombok.extern.slf4j.Slf4j;
 import me.golemcore.bot.adapter.inbound.web.dto.PreferencesUpdateRequest;
 import me.golemcore.bot.adapter.inbound.web.dto.SettingsResponse;
+import me.golemcore.bot.application.settings.RuntimeSettingsFacade;
 import me.golemcore.bot.domain.model.MemoryPreset;
 import me.golemcore.bot.domain.model.ModelTierCatalog;
 import me.golemcore.bot.domain.model.RuntimeConfig;
-import me.golemcore.bot.domain.model.Secret;
 import me.golemcore.bot.domain.model.UserPreferences;
-import me.golemcore.bot.domain.service.MemoryPresetService;
 import me.golemcore.bot.domain.service.ModelSelectionService;
-import me.golemcore.bot.domain.service.RuntimeConfigService;
 import me.golemcore.bot.domain.service.UserPreferencesService;
-import me.golemcore.bot.plugin.runtime.SttProviderRegistry;
-import me.golemcore.bot.plugin.runtime.TtsProviderRegistry;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -27,84 +22,30 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 import reactor.core.publisher.Mono;
 
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
+import java.util.NoSuchElementException;
 import java.util.function.Supplier;
-import java.util.regex.Pattern;
 
 /**
  * Settings and preferences management endpoints.
  */
 @RestController
 @RequestMapping("/api/settings")
-@Slf4j
 public class SettingsController {
-
-    private static final String TELEGRAM_AUTH_MODE_INVITE_ONLY = "invite_only";
-    private static final String STT_PROVIDER_ELEVENLABS = "golemcore/elevenlabs";
-    private static final String STT_PROVIDER_WHISPER = "golemcore/whisper";
-    private static final String LEGACY_STT_PROVIDER_ELEVENLABS = "elevenlabs";
-    private static final String LEGACY_STT_PROVIDER_WHISPER = "whisper";
-    private static final Set<String> VALID_API_TYPES = Set.of("openai", "anthropic", "gemini");
-    private static final String DEFAULT_COMPACTION_TRIGGER_MODE = "model_ratio";
-    private static final String COMPACTION_TRIGGER_MODE_TOKEN_THRESHOLD = "token_threshold";
-    private static final Set<String> VALID_COMPACTION_TRIGGER_MODES = Set.of(
-            DEFAULT_COMPACTION_TRIGGER_MODE,
-            COMPACTION_TRIGGER_MODE_TOKEN_THRESHOLD);
-    private static final double DEFAULT_COMPACTION_MODEL_THRESHOLD_RATIO = 0.95d;
-    private static final int MEMORY_SOFT_BUDGET_MIN = 200;
-    private static final int MEMORY_SOFT_BUDGET_MAX = 10000;
-    private static final int MEMORY_MAX_BUDGET_MIN = 200;
-    private static final int MEMORY_MAX_BUDGET_MAX = 12000;
-    private static final int MEMORY_TOP_K_MIN = 0;
-    private static final int MEMORY_TOP_K_MAX = 30;
-    private static final int MEMORY_DECAY_DAYS_MIN = 1;
-    private static final int MEMORY_DECAY_DAYS_MAX = 3650;
-    private static final int MEMORY_RETRIEVAL_LOOKBACK_DAYS_MIN = 1;
-    private static final int MEMORY_RETRIEVAL_LOOKBACK_DAYS_MAX = 90;
-    private static final Set<String> VALID_MEMORY_DISCLOSURE_MODES = Set.of(
-            "index",
-            "summary",
-            "selective_detail",
-            "full_pack");
-    private static final Set<String> VALID_MEMORY_PROMPT_STYLES = Set.of("compact", "balanced", "rich");
-    private static final Set<String> VALID_MEMORY_RERANKING_PROFILES = Set.of("balanced", "aggressive");
-    private static final Set<String> VALID_MEMORY_DIAGNOSTICS_VERBOSITY = Set.of("off", "basic", "detailed");
-    private static final int TURN_PROGRESS_BATCH_SIZE_MIN = 1;
-    private static final int TURN_PROGRESS_BATCH_SIZE_MAX = 50;
-    private static final int TURN_PROGRESS_MAX_SILENCE_SECONDS_MIN = 1;
-    private static final int TURN_PROGRESS_MAX_SILENCE_SECONDS_MAX = 300;
-    private static final int TURN_PROGRESS_SUMMARY_TIMEOUT_MS_MIN = 1000;
-    private static final int TURN_PROGRESS_SUMMARY_TIMEOUT_MS_MAX = 60000;
-    private static final Pattern SHELL_ENV_VAR_NAME_PATTERN = Pattern.compile("[A-Za-z_][A-Za-z0-9_]*");
-    private static final Set<String> RESERVED_SHELL_ENV_VAR_NAMES = Set.of("HOME", "PWD");
-    private static final int SHELL_ENV_VAR_NAME_MAX_LENGTH = 128;
-    private static final int SHELL_ENV_VAR_VALUE_MAX_LENGTH = 8192;
 
     private final UserPreferencesService preferencesService;
     private final ModelSelectionService modelSelectionService;
-    private final RuntimeConfigService runtimeConfigService;
-    private final MemoryPresetService memoryPresetService;
-    private final SttProviderRegistry sttProviderRegistry;
-    private final TtsProviderRegistry ttsProviderRegistry;
+    private final RuntimeSettingsFacade runtimeSettingsFacade;
 
     public SettingsController(UserPreferencesService preferencesService,
             ModelSelectionService modelSelectionService,
-            RuntimeConfigService runtimeConfigService,
-            MemoryPresetService memoryPresetService,
-            SttProviderRegistry sttProviderRegistry,
-            TtsProviderRegistry ttsProviderRegistry) {
+            RuntimeSettingsFacade runtimeSettingsFacade) {
         this.preferencesService = preferencesService;
         this.modelSelectionService = modelSelectionService;
-        this.runtimeConfigService = runtimeConfigService;
-        this.memoryPresetService = memoryPresetService;
-        this.sttProviderRegistry = sttProviderRegistry;
-        this.ttsProviderRegistry = ttsProviderRegistry;
+        this.runtimeSettingsFacade = runtimeSettingsFacade;
     }
 
     @GetMapping
@@ -178,1110 +119,197 @@ public class SettingsController {
         return getSettings();
     }
 
-    // ==================== Runtime Config ====================
-
     @GetMapping("/runtime")
     public Mono<ResponseEntity<RuntimeConfig>> getRuntimeConfig() {
-        return Mono.just(ResponseEntity.ok(runtimeConfigService.getRuntimeConfigForApi()));
+        return Mono.just(ResponseEntity.ok(runtimeSettingsFacade.getRuntimeConfigForApi()));
     }
 
     @PutMapping("/runtime")
     public Mono<ResponseEntity<RuntimeConfig>> updateRuntimeConfig(@RequestBody RuntimeConfig config) {
-        RuntimeConfig current = runtimeConfigService.getRuntimeConfig();
-        rejectManagedHiveMutation(current, config != null ? config.getHive() : null);
-        RuntimeConfig merged = mergeRuntimeConfigSections(current, config);
-        if (merged.getTelegram() == null) {
-            merged.setTelegram(new RuntimeConfig.TelegramConfig());
-        }
-        normalizeAndValidateTelegramConfig(merged.getTelegram());
-        mergeRuntimeSecrets(current, merged);
-        normalizeAndValidateShellEnvironmentVariables(merged.getTools());
-        validateLlmConfig(merged.getLlm(), merged.getModelRouter());
-        validateModelRouterConfig(merged.getModelRouter(), merged.getLlm());
-        if (merged.getAutoMode() != null) {
-            validateAndNormalizeAutoModeConfig(merged.getAutoMode());
-        }
-        if (merged.getTracing() != null) {
-            validateAndNormalizeTracingConfig(merged.getTracing());
-        }
-        if (merged.getMemory() != null) {
-            validateMemoryConfig(merged.getMemory());
-        }
-        validateCompactionConfig(merged.getCompaction());
-        validateVoiceConfig(merged.getVoice());
-        validateAndNormalizeModelRegistryConfig(merged.getModelRegistry());
-        validateHiveConfig(merged.getHive());
-        runtimeConfigService.updateRuntimeConfig(merged);
-        return Mono.just(ResponseEntity.ok(runtimeConfigService.getRuntimeConfigForApi()));
+        return runtimeConfigResponse(() -> runtimeSettingsFacade.updateRuntimeConfig(config));
     }
 
     @PutMapping("/runtime/models")
     public Mono<ResponseEntity<RuntimeConfig>> updateModelRouterConfig(
             @RequestBody RuntimeConfig.ModelRouterConfig modelRouterConfig) {
-        RuntimeConfig config = runtimeConfigService.getRuntimeConfig();
-        validateModelRouterConfig(modelRouterConfig, config.getLlm());
-        config.setModelRouter(modelRouterConfig);
-        runtimeConfigService.updateRuntimeConfig(config);
-        return Mono.just(ResponseEntity.ok(runtimeConfigService.getRuntimeConfigForApi()));
+        return runtimeConfigResponse(() -> runtimeSettingsFacade.updateModelRouterConfig(modelRouterConfig));
     }
 
     @PutMapping("/runtime/llm")
-    public Mono<ResponseEntity<RuntimeConfig>> updateLlmConfig(
-            @RequestBody RuntimeConfig.LlmConfig llmConfig) {
-        log.info("[Settings] Updating LLM config with {} providers: {}",
-                llmConfig.getProviders() != null ? llmConfig.getProviders().size() : 0,
-                llmConfig.getProviders() != null ? llmConfig.getProviders().keySet() : "null");
-        RuntimeConfig config = runtimeConfigService.getRuntimeConfig();
-        mergeLlmSecrets(config.getLlm(), llmConfig);
-        validateLlmConfig(llmConfig, config.getModelRouter());
-        validateModelRouterConfig(config.getModelRouter(), llmConfig);
-        config.setLlm(llmConfig);
-        runtimeConfigService.updateRuntimeConfig(config);
-        log.info("[Settings] LLM config updated successfully");
-        return Mono.just(ResponseEntity.ok(runtimeConfigService.getRuntimeConfigForApi()));
+    public Mono<ResponseEntity<RuntimeConfig>> updateLlmConfig(@RequestBody RuntimeConfig.LlmConfig llmConfig) {
+        return runtimeConfigResponse(() -> runtimeSettingsFacade.updateLlmConfig(llmConfig));
     }
 
     @PostMapping("/runtime/llm/providers/{name}")
     public Mono<ResponseEntity<RuntimeConfig>> addLlmProvider(
             @PathVariable String name,
             @RequestBody RuntimeConfig.LlmProviderConfig providerConfig) {
-        String normalizedName = name.toLowerCase(Locale.ROOT);
-        if (!normalizedName.matches("[a-z0-9][a-z0-9_-]*")) {
-            throw new IllegalArgumentException("Provider name must match [a-z0-9][a-z0-9_-]*");
-        }
-        RuntimeConfig config = runtimeConfigService.getRuntimeConfig();
-        if (config.getLlm().getProviders().containsKey(normalizedName)) {
-            throw new IllegalArgumentException("Provider '" + normalizedName + "' already exists");
-        }
-        validateProviderConfig(normalizedName, providerConfig);
-        runtimeConfigService.addLlmProvider(normalizedName, providerConfig);
-        return Mono.just(ResponseEntity.ok(runtimeConfigService.getRuntimeConfigForApi()));
+        return runtimeConfigResponse(() -> runtimeSettingsFacade.addLlmProvider(name, providerConfig));
     }
 
     @PutMapping("/runtime/llm/providers/{name}")
     public Mono<ResponseEntity<RuntimeConfig>> updateLlmProvider(
             @PathVariable String name,
             @RequestBody RuntimeConfig.LlmProviderConfig providerConfig) {
-        String normalizedName = name.toLowerCase(Locale.ROOT);
-        RuntimeConfig config = runtimeConfigService.getRuntimeConfig();
-        if (!config.getLlm().getProviders().containsKey(normalizedName)) {
-            throw new IllegalArgumentException("Provider '" + normalizedName + "' does not exist");
-        }
-        validateProviderConfig(normalizedName, providerConfig);
-        runtimeConfigService.updateLlmProvider(normalizedName, providerConfig);
-        return Mono.just(ResponseEntity.ok(runtimeConfigService.getRuntimeConfigForApi()));
+        return runtimeConfigResponse(() -> runtimeSettingsFacade.updateLlmProvider(name, providerConfig));
     }
 
     @DeleteMapping("/runtime/llm/providers/{name}")
     public Mono<ResponseEntity<Void>> removeLlmProvider(@PathVariable String name) {
-        String normalizedName = name.toLowerCase(Locale.ROOT);
-        RuntimeConfig config = runtimeConfigService.getRuntimeConfig();
-        Set<String> usedProviders = getProvidersUsedByModelRouter(config.getModelRouter());
-        if (usedProviders.contains(normalizedName)) {
-            throw new IllegalArgumentException(
-                    "Cannot remove provider '" + normalizedName + "' because it is used by model router tiers");
-        }
-        boolean removed = runtimeConfigService.removeLlmProvider(normalizedName);
-        if (!removed) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND,
-                    "Provider '" + normalizedName + "' not found");
-        }
-        return Mono.just(ResponseEntity.ok().build());
-    }
-
-    private void validateProviderConfig(String name, RuntimeConfig.LlmProviderConfig config) {
-        if (config == null) {
-            throw new IllegalArgumentException("Provider config is required");
-        }
-        Integer timeout = config.getRequestTimeoutSeconds();
-        if (timeout != null && (timeout < 1 || timeout > 3600)) {
-            throw new IllegalArgumentException(
-                    "llm.providers." + name + ".requestTimeoutSeconds must be between 1 and 3600");
-        }
-        String baseUrl = config.getBaseUrl();
-        if (baseUrl != null && !baseUrl.isBlank() && !isValidHttpUrl(baseUrl)) {
-            throw new IllegalArgumentException(
-                    "llm.providers." + name + ".baseUrl must be a valid http(s) URL");
-        }
-        String apiType = config.getApiType();
-        if (apiType != null && !apiType.isBlank() && !VALID_API_TYPES.contains(apiType.toLowerCase(Locale.ROOT))) {
-            throw new IllegalArgumentException(
-                    "llm.providers." + name + ".apiType must be one of " + VALID_API_TYPES);
-        }
+        return runtimeVoidResponse(() -> runtimeSettingsFacade.removeLlmProvider(name));
     }
 
     @PutMapping("/runtime/tools")
-    public Mono<ResponseEntity<RuntimeConfig>> updateToolsConfig(
-            @RequestBody RuntimeConfig.ToolsConfig toolsConfig) {
-        RuntimeConfig config = runtimeConfigService.getRuntimeConfig();
-        normalizeAndValidateShellEnvironmentVariables(toolsConfig);
-        config.setTools(toolsConfig);
-        runtimeConfigService.updateRuntimeConfig(config);
-        return Mono.just(ResponseEntity.ok(runtimeConfigService.getRuntimeConfigForApi()));
+    public Mono<ResponseEntity<RuntimeConfig>> updateToolsConfig(@RequestBody RuntimeConfig.ToolsConfig toolsConfig) {
+        return runtimeConfigResponse(() -> runtimeSettingsFacade.updateToolsConfig(toolsConfig));
     }
 
     @GetMapping("/runtime/tools/shell/env")
     public Mono<ResponseEntity<List<RuntimeConfig.ShellEnvironmentVariable>>> getShellEnvironmentVariables() {
-        RuntimeConfig.ToolsConfig toolsConfig = runtimeConfigService.getRuntimeConfigForApi().getTools();
-        List<RuntimeConfig.ShellEnvironmentVariable> variables = toolsConfig != null
-                && toolsConfig.getShellEnvironmentVariables() != null
-                        ? toolsConfig.getShellEnvironmentVariables()
-                        : List.of();
-        return Mono.just(ResponseEntity.ok(variables));
+        return runtimeListResponse(runtimeSettingsFacade::getShellEnvironmentVariables);
     }
 
     @PostMapping("/runtime/tools/shell/env")
     public Mono<ResponseEntity<RuntimeConfig>> createShellEnvironmentVariable(
             @RequestBody RuntimeConfig.ShellEnvironmentVariable variable) {
-        RuntimeConfig config = runtimeConfigService.getRuntimeConfig();
-        RuntimeConfig.ToolsConfig toolsConfig = ensureToolsConfig(config);
-        List<RuntimeConfig.ShellEnvironmentVariable> variables = ensureShellEnvironmentVariables(toolsConfig);
-
-        RuntimeConfig.ShellEnvironmentVariable normalized = normalizeAndValidateShellEnvironmentVariable(variable);
-        if (containsShellEnvironmentVariableName(variables, normalized.getName())) {
-            throw new IllegalArgumentException(
-                    "tools.shellEnvironmentVariables contains duplicate name: " + normalized.getName());
-        }
-        variables.add(normalized);
-        runtimeConfigService.updateRuntimeConfig(config);
-        return Mono.just(ResponseEntity.ok(runtimeConfigService.getRuntimeConfigForApi()));
+        return runtimeConfigResponse(() -> runtimeSettingsFacade.createShellEnvironmentVariable(variable));
     }
 
     @PutMapping("/runtime/tools/shell/env/{name}")
     public Mono<ResponseEntity<RuntimeConfig>> updateShellEnvironmentVariable(
             @PathVariable String name,
             @RequestBody RuntimeConfig.ShellEnvironmentVariable variable) {
-        RuntimeConfig config = runtimeConfigService.getRuntimeConfig();
-        RuntimeConfig.ToolsConfig toolsConfig = ensureToolsConfig(config);
-        List<RuntimeConfig.ShellEnvironmentVariable> variables = ensureShellEnvironmentVariables(toolsConfig);
-        String normalizedCurrentName = normalizeAndValidateShellEnvironmentVariableName(name);
-
-        int index = findShellEnvironmentVariableIndex(variables, normalizedCurrentName);
-        if (index < 0) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND,
-                    "Shell environment variable '" + normalizedCurrentName + "' not found");
-        }
-
-        RuntimeConfig.ShellEnvironmentVariable source = variable != null ? variable
-                : RuntimeConfig.ShellEnvironmentVariable.builder().build();
-        String updatedName = source.getName() == null || source.getName().isBlank()
-                ? normalizedCurrentName
-                : source.getName();
-        RuntimeConfig.ShellEnvironmentVariable normalizedUpdated = normalizeAndValidateShellEnvironmentVariable(
-                RuntimeConfig.ShellEnvironmentVariable.builder()
-                        .name(updatedName)
-                        .value(source.getValue())
-                        .build());
-
-        if (!normalizedCurrentName.equals(normalizedUpdated.getName())
-                && containsShellEnvironmentVariableName(variables, normalizedUpdated.getName())) {
-            throw new IllegalArgumentException(
-                    "tools.shellEnvironmentVariables contains duplicate name: " + normalizedUpdated.getName());
-        }
-
-        variables.set(index, normalizedUpdated);
-        runtimeConfigService.updateRuntimeConfig(config);
-        return Mono.just(ResponseEntity.ok(runtimeConfigService.getRuntimeConfigForApi()));
+        return runtimeConfigResponse(() -> runtimeSettingsFacade.updateShellEnvironmentVariable(name, variable));
     }
 
     @DeleteMapping("/runtime/tools/shell/env/{name}")
     public Mono<ResponseEntity<RuntimeConfig>> deleteShellEnvironmentVariable(@PathVariable String name) {
-        RuntimeConfig config = runtimeConfigService.getRuntimeConfig();
-        RuntimeConfig.ToolsConfig toolsConfig = ensureToolsConfig(config);
-        List<RuntimeConfig.ShellEnvironmentVariable> variables = ensureShellEnvironmentVariables(toolsConfig);
-        String normalizedName = normalizeAndValidateShellEnvironmentVariableName(name);
-
-        int index = findShellEnvironmentVariableIndex(variables, normalizedName);
-        if (index < 0) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND,
-                    "Shell environment variable '" + normalizedName + "' not found");
-        }
-
-        variables.remove(index);
-        runtimeConfigService.updateRuntimeConfig(config);
-        return Mono.just(ResponseEntity.ok(runtimeConfigService.getRuntimeConfigForApi()));
+        return runtimeConfigResponse(() -> runtimeSettingsFacade.deleteShellEnvironmentVariable(name));
     }
 
     @PutMapping("/runtime/voice")
-    public Mono<ResponseEntity<RuntimeConfig>> updateVoiceConfig(
-            @RequestBody RuntimeConfig.VoiceConfig voiceConfig) {
-        RuntimeConfig config = runtimeConfigService.getRuntimeConfig();
-        voiceConfig.setApiKey(mergeSecret(config.getVoice().getApiKey(), voiceConfig.getApiKey()));
-        voiceConfig.setWhisperSttApiKey(
-                mergeSecret(config.getVoice().getWhisperSttApiKey(), voiceConfig.getWhisperSttApiKey()));
-        validateVoiceConfig(voiceConfig);
-        config.setVoice(voiceConfig);
-        runtimeConfigService.updateRuntimeConfig(config);
-        return Mono.just(ResponseEntity.ok(runtimeConfigService.getRuntimeConfigForApi()));
+    public Mono<ResponseEntity<RuntimeConfig>> updateVoiceConfig(@RequestBody RuntimeConfig.VoiceConfig voiceConfig) {
+        return runtimeConfigResponse(() -> runtimeSettingsFacade.updateVoiceConfig(voiceConfig));
     }
 
     @PutMapping("/runtime/turn")
-    public Mono<ResponseEntity<RuntimeConfig>> updateTurnConfig(
-            @RequestBody RuntimeConfig.TurnConfig turnConfig) {
-        validateTurnConfig(turnConfig);
-        RuntimeConfig config = runtimeConfigService.getRuntimeConfig();
-        config.setTurn(turnConfig);
-        runtimeConfigService.updateRuntimeConfig(config);
-        return Mono.just(ResponseEntity.ok(runtimeConfigService.getRuntimeConfigForApi()));
+    public Mono<ResponseEntity<RuntimeConfig>> updateTurnConfig(@RequestBody RuntimeConfig.TurnConfig turnConfig) {
+        return runtimeConfigResponse(() -> runtimeSettingsFacade.updateTurnConfig(turnConfig));
     }
 
     @PutMapping("/runtime/memory")
     public Mono<ResponseEntity<RuntimeConfig>> updateMemoryConfig(
             @RequestBody RuntimeConfig.MemoryConfig memoryConfig) {
-        validateMemoryConfig(memoryConfig);
-        RuntimeConfig config = runtimeConfigService.getRuntimeConfig();
-        config.setMemory(memoryConfig);
-        runtimeConfigService.updateRuntimeConfig(config);
-        return Mono.just(ResponseEntity.ok(runtimeConfigService.getRuntimeConfigForApi()));
+        return runtimeConfigResponse(() -> runtimeSettingsFacade.updateMemoryConfig(memoryConfig));
     }
 
     @GetMapping("/runtime/memory/presets")
     public Mono<ResponseEntity<List<MemoryPreset>>> getMemoryPresets() {
-        return Mono.just(ResponseEntity.ok(memoryPresetService.getPresets()));
+        return runtimeListResponse(runtimeSettingsFacade::getMemoryPresets);
     }
 
     @PutMapping("/runtime/skills")
     public Mono<ResponseEntity<RuntimeConfig>> updateSkillsConfig(
             @RequestBody RuntimeConfig.SkillsConfig skillsConfig) {
-        RuntimeConfig config = runtimeConfigService.getRuntimeConfig();
-        config.setSkills(skillsConfig);
-        runtimeConfigService.updateRuntimeConfig(config);
-        return Mono.just(ResponseEntity.ok(runtimeConfigService.getRuntimeConfigForApi()));
+        return runtimeConfigResponse(() -> runtimeSettingsFacade.updateSkillsConfig(skillsConfig));
     }
 
     @PutMapping("/runtime/usage")
-    public Mono<ResponseEntity<RuntimeConfig>> updateUsageConfig(
-            @RequestBody RuntimeConfig.UsageConfig usageConfig) {
-        RuntimeConfig config = runtimeConfigService.getRuntimeConfig();
-        config.setUsage(usageConfig);
-        runtimeConfigService.updateRuntimeConfig(config);
-        return Mono.just(ResponseEntity.ok(runtimeConfigService.getRuntimeConfigForApi()));
+    public Mono<ResponseEntity<RuntimeConfig>> updateUsageConfig(@RequestBody RuntimeConfig.UsageConfig usageConfig) {
+        return runtimeConfigResponse(() -> runtimeSettingsFacade.updateUsageConfig(usageConfig));
     }
 
     @PutMapping("/runtime/telemetry")
     public Mono<ResponseEntity<RuntimeConfig>> updateTelemetryConfig(
             @RequestBody RuntimeConfig.TelemetryConfig telemetryConfig) {
-        RuntimeConfig config = runtimeConfigService.getRuntimeConfig();
-        config.setTelemetry(telemetryConfig);
-        runtimeConfigService.updateRuntimeConfig(config);
-        return Mono.just(ResponseEntity.ok(runtimeConfigService.getRuntimeConfigForApi()));
+        return runtimeConfigResponse(() -> runtimeSettingsFacade.updateTelemetryConfig(telemetryConfig));
     }
 
     @PutMapping("/runtime/mcp")
-    public Mono<ResponseEntity<RuntimeConfig>> updateMcpConfig(
-            @RequestBody RuntimeConfig.McpConfig mcpConfig) {
-        RuntimeConfig config = runtimeConfigService.getRuntimeConfig();
-        // Preserve existing catalog when updating global MCP settings
-        RuntimeConfig.McpConfig existing = config.getMcp();
-        if (existing != null && mcpConfig.getCatalog() == null) {
-            mcpConfig.setCatalog(existing.getCatalog());
-        }
-        config.setMcp(mcpConfig);
-        runtimeConfigService.updateRuntimeConfig(config);
-        return Mono.just(ResponseEntity.ok(runtimeConfigService.getRuntimeConfigForApi()));
+    public Mono<ResponseEntity<RuntimeConfig>> updateMcpConfig(@RequestBody RuntimeConfig.McpConfig mcpConfig) {
+        return runtimeConfigResponse(() -> runtimeSettingsFacade.updateMcpConfig(mcpConfig));
     }
-
-    // ==================== MCP Catalog CRUD ====================
 
     @GetMapping("/runtime/mcp/catalog")
     public Mono<ResponseEntity<List<RuntimeConfig.McpCatalogEntry>>> getMcpCatalog() {
-        return Mono.just(ResponseEntity.ok(runtimeConfigService.getMcpCatalog()));
+        return runtimeListResponse(runtimeSettingsFacade::getMcpCatalog);
     }
 
     @PostMapping("/runtime/mcp/catalog")
-    public Mono<ResponseEntity<RuntimeConfig>> addMcpCatalogEntry(
-            @RequestBody RuntimeConfig.McpCatalogEntry entry) {
-        validateMcpCatalogEntry(entry);
-        String normalizedName = entry.getName().toLowerCase(Locale.ROOT).trim();
-        entry.setName(normalizedName);
-        List<RuntimeConfig.McpCatalogEntry> catalog = runtimeConfigService.getMcpCatalog();
-        boolean exists = catalog.stream().anyMatch(e -> normalizedName.equals(e.getName()));
-        if (exists) {
-            throw new IllegalArgumentException("MCP catalog entry '" + normalizedName + "' already exists");
-        }
-        runtimeConfigService.addMcpCatalogEntry(entry);
-        return Mono.just(ResponseEntity.ok(runtimeConfigService.getRuntimeConfigForApi()));
+    public Mono<ResponseEntity<RuntimeConfig>> addMcpCatalogEntry(@RequestBody RuntimeConfig.McpCatalogEntry entry) {
+        return runtimeConfigResponse(() -> runtimeSettingsFacade.addMcpCatalogEntry(entry));
     }
 
     @PutMapping("/runtime/mcp/catalog/{name}")
     public Mono<ResponseEntity<RuntimeConfig>> updateMcpCatalogEntry(
             @PathVariable String name,
             @RequestBody RuntimeConfig.McpCatalogEntry entry) {
-        String normalizedName = name.toLowerCase(Locale.ROOT).trim();
-        validateMcpCatalogEntry(entry);
-        boolean updated = runtimeConfigService.updateMcpCatalogEntry(normalizedName, entry);
-        if (!updated) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND,
-                    "MCP catalog entry '" + normalizedName + "' not found");
-        }
-        return Mono.just(ResponseEntity.ok(runtimeConfigService.getRuntimeConfigForApi()));
+        return runtimeConfigResponse(() -> runtimeSettingsFacade.updateMcpCatalogEntry(name, entry));
     }
 
     @DeleteMapping("/runtime/mcp/catalog/{name}")
     public Mono<ResponseEntity<Void>> removeMcpCatalogEntry(@PathVariable String name) {
-        String normalizedName = name.toLowerCase(Locale.ROOT).trim();
-        boolean removed = runtimeConfigService.removeMcpCatalogEntry(normalizedName);
-        if (!removed) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND,
-                    "MCP catalog entry '" + normalizedName + "' not found");
-        }
-        return Mono.just(ResponseEntity.ok().build());
-    }
-
-    private void validateMcpCatalogEntry(RuntimeConfig.McpCatalogEntry entry) {
-        if (entry == null) {
-            throw new IllegalArgumentException("MCP catalog entry is required");
-        }
-        if (entry.getName() == null || entry.getName().isBlank()) {
-            throw new IllegalArgumentException("MCP catalog entry name is required");
-        }
-        String name = entry.getName().toLowerCase(Locale.ROOT).trim();
-        if (!name.matches("[a-z0-9][a-z0-9_-]*")) {
-            throw new IllegalArgumentException("MCP catalog entry name must match [a-z0-9][a-z0-9_-]*");
-        }
-        if (entry.getCommand() == null || entry.getCommand().isBlank()) {
-            throw new IllegalArgumentException("MCP catalog entry command is required");
-        }
-        Integer startupTimeout = entry.getStartupTimeoutSeconds();
-        if (startupTimeout != null && (startupTimeout < 1 || startupTimeout > 300)) {
-            throw new IllegalArgumentException("startupTimeoutSeconds must be between 1 and 300");
-        }
-        Integer idleTimeout = entry.getIdleTimeoutMinutes();
-        if (idleTimeout != null && (idleTimeout < 1 || idleTimeout > 120)) {
-            throw new IllegalArgumentException("idleTimeoutMinutes must be between 1 and 120");
-        }
+        return runtimeVoidResponse(() -> runtimeSettingsFacade.removeMcpCatalogEntry(name));
     }
 
     @PutMapping("/runtime/hive")
-    public Mono<ResponseEntity<RuntimeConfig>> updateHiveConfig(
-            @RequestBody RuntimeConfig.HiveConfig hiveConfig) {
-        RuntimeConfig config = runtimeConfigService.getRuntimeConfig();
-        rejectManagedHiveMutation(config, hiveConfig);
-        validateHiveConfig(hiveConfig);
-        config.setHive(hiveConfig);
-        runtimeConfigService.updateRuntimeConfig(config);
-        return Mono.just(ResponseEntity.ok(runtimeConfigService.getRuntimeConfigForApi()));
+    public Mono<ResponseEntity<RuntimeConfig>> updateHiveConfig(@RequestBody RuntimeConfig.HiveConfig hiveConfig) {
+        return runtimeConfigResponse(() -> runtimeSettingsFacade.updateHiveConfig(hiveConfig));
     }
 
     @PutMapping("/runtime/plan")
-    public Mono<ResponseEntity<RuntimeConfig>> updatePlanConfig(
-            @RequestBody RuntimeConfig.PlanConfig planConfig) {
-        validatePlanConfig(planConfig);
-        RuntimeConfig config = runtimeConfigService.getRuntimeConfig();
-        config.setPlan(planConfig);
-        runtimeConfigService.updateRuntimeConfig(config);
-        return Mono.just(ResponseEntity.ok(runtimeConfigService.getRuntimeConfigForApi()));
+    public Mono<ResponseEntity<RuntimeConfig>> updatePlanConfig(@RequestBody RuntimeConfig.PlanConfig planConfig) {
+        return runtimeConfigResponse(() -> runtimeSettingsFacade.updatePlanConfig(planConfig));
     }
 
     @PutMapping("/runtime/webhooks")
-    public Mono<ResponseEntity<Void>> updateWebhooksConfig(
-            @RequestBody UserPreferences.WebhookConfig webhookConfig) {
-        UserPreferences prefs = preferencesService.getPreferences();
-        mergeWebhookSecrets(prefs.getWebhooks(), webhookConfig);
-        validateWebhookConfig(webhookConfig);
-        prefs.setWebhooks(webhookConfig);
-        preferencesService.savePreferences(prefs);
-        return Mono.just(ResponseEntity.ok().build());
+    public Mono<ResponseEntity<Void>> updateWebhooksConfig(@RequestBody UserPreferences.WebhookConfig webhookConfig) {
+        return runtimeVoidResponse(() -> runtimeSettingsFacade.updateWebhooksConfig(webhookConfig));
     }
 
     @PutMapping("/runtime/auto")
-    public Mono<ResponseEntity<RuntimeConfig>> updateAutoConfig(
-            @RequestBody RuntimeConfig.AutoModeConfig autoConfig) {
-        RuntimeConfig config = runtimeConfigService.getRuntimeConfig();
-        validateAndNormalizeAutoModeConfig(autoConfig);
-        config.setAutoMode(autoConfig);
-        runtimeConfigService.updateRuntimeConfig(config);
-        return Mono.just(ResponseEntity.ok(runtimeConfigService.getRuntimeConfigForApi()));
+    public Mono<ResponseEntity<RuntimeConfig>> updateAutoConfig(@RequestBody RuntimeConfig.AutoModeConfig autoConfig) {
+        return runtimeConfigResponse(() -> runtimeSettingsFacade.updateAutoConfig(autoConfig));
     }
 
     @PutMapping("/runtime/tracing")
     public Mono<ResponseEntity<RuntimeConfig>> updateTracingConfig(
             @RequestBody RuntimeConfig.TracingConfig tracingConfig) {
-        RuntimeConfig config = runtimeConfigService.getRuntimeConfig();
-        validateAndNormalizeTracingConfig(tracingConfig);
-        config.setTracing(tracingConfig);
-        runtimeConfigService.updateRuntimeConfig(config);
-        return Mono.just(ResponseEntity.ok(runtimeConfigService.getRuntimeConfigForApi()));
+        return runtimeConfigResponse(() -> runtimeSettingsFacade.updateTracingConfig(tracingConfig));
     }
 
     @PutMapping("/runtime/advanced")
-    public Mono<ResponseEntity<RuntimeConfig>> updateAdvancedConfig(
-            @RequestBody AdvancedConfigRequest request) {
-        RuntimeConfig config = runtimeConfigService.getRuntimeConfig();
-        if (request.rateLimit() != null) {
-            config.setRateLimit(request.rateLimit());
-        }
-        if (request.security() != null) {
-            config.setSecurity(request.security());
-        }
-        if (request.compaction() != null) {
-            validateCompactionConfig(request.compaction());
-            config.setCompaction(request.compaction());
-        }
-        runtimeConfigService.updateRuntimeConfig(config);
-        return Mono.just(ResponseEntity.ok(runtimeConfigService.getRuntimeConfig()));
+    public Mono<ResponseEntity<RuntimeConfig>> updateAdvancedConfig(@RequestBody AdvancedConfigRequest request) {
+        return runtimeConfigResponse(() -> runtimeSettingsFacade.updateAdvancedConfig(
+                request.rateLimit(),
+                request.security(),
+                request.compaction()));
     }
 
-    // ==================== DTOs ====================
-
-    private record ModelDto(String id, String displayName, boolean hasReasoning,
-            List<String> reasoningLevels, boolean supportsVision) {
+    private Mono<ResponseEntity<RuntimeConfig>> runtimeConfigResponse(Supplier<RuntimeConfig> supplier) {
+        return Mono.just(ResponseEntity.ok(invokeRuntime(supplier)));
     }
 
-    private record AdvancedConfigRequest(
-            RuntimeConfig.RateLimitConfig rateLimit,
-            RuntimeConfig.SecurityConfig security,
-            RuntimeConfig.CompactionConfig compaction) {
+    private <T> Mono<ResponseEntity<List<T>>> runtimeListResponse(Supplier<List<T>> supplier) {
+        return Mono.just(ResponseEntity.ok(invokeRuntime(supplier)));
     }
 
-    private void normalizeAndValidateTelegramConfig(RuntimeConfig.TelegramConfig telegramConfig) {
-        telegramConfig.setAuthMode(TELEGRAM_AUTH_MODE_INVITE_ONLY);
-
-        List<String> allowedUsers = telegramConfig.getAllowedUsers();
-        if (allowedUsers == null) {
-            telegramConfig.setAllowedUsers(new ArrayList<>());
-            return;
-        }
-
-        for (String userId : allowedUsers) {
-            if (userId == null || !userId.matches("\\d+")) {
-                throw new IllegalArgumentException("telegram.allowedUsers must contain numeric IDs only");
-            }
-        }
-
-        if (allowedUsers.size() > 1) {
-            throw new IllegalArgumentException("telegram.allowedUsers supports only one invited user");
-        }
-    }
-
-    private void validateLlmConfig(RuntimeConfig.LlmConfig llmConfig,
-            RuntimeConfig.ModelRouterConfig modelRouterConfig) {
-        if (llmConfig == null) {
-            throw new IllegalArgumentException("llm config is required");
-        }
-
-        Map<String, RuntimeConfig.LlmProviderConfig> providers = llmConfig.getProviders();
-        if (providers == null) {
-            llmConfig.setProviders(new LinkedHashMap<>());
-            return;
-        }
-
-        Set<String> normalizedNames = new LinkedHashSet<>();
-        for (Map.Entry<String, RuntimeConfig.LlmProviderConfig> entry : providers.entrySet()) {
-            String providerName = entry.getKey();
-            RuntimeConfig.LlmProviderConfig providerConfig = entry.getValue();
-
-            if (providerName == null || providerName.isBlank()) {
-                throw new IllegalArgumentException("llm.providers keys must be non-empty");
-            }
-            if (!providerName.equals(providerName.trim())) {
-                throw new IllegalArgumentException("llm.providers keys must not have leading/trailing spaces");
-            }
-            if (!providerName.equals(providerName.toLowerCase(Locale.ROOT))) {
-                throw new IllegalArgumentException("llm.providers keys must be lowercase");
-            }
-            if (!providerName.matches("[a-z0-9][a-z0-9_-]*")) {
-                throw new IllegalArgumentException(
-                        "llm.providers keys must match [a-z0-9][a-z0-9_-]*");
-            }
-            if (!normalizedNames.add(providerName)) {
-                throw new IllegalArgumentException("llm.providers contains duplicate provider key: " + providerName);
-            }
-            if (providerConfig == null) {
-                throw new IllegalArgumentException("llm.providers." + providerName + " config is required");
-            }
-
-            Integer requestTimeoutSeconds = providerConfig.getRequestTimeoutSeconds();
-            if (requestTimeoutSeconds != null && (requestTimeoutSeconds < 1 || requestTimeoutSeconds > 3600)) {
-                throw new IllegalArgumentException(
-                        "llm.providers." + providerName + ".requestTimeoutSeconds must be between 1 and 3600");
-            }
-
-            String baseUrl = providerConfig.getBaseUrl();
-            if (baseUrl != null && !baseUrl.isBlank()) {
-                if (!isValidHttpUrl(baseUrl)) {
-                    throw new IllegalArgumentException(
-                            "llm.providers." + providerName + ".baseUrl must be a valid http(s) URL");
-                }
-            }
-
-            String apiType = providerConfig.getApiType();
-            if (apiType != null && !apiType.isBlank()
-                    && !VALID_API_TYPES.contains(apiType.toLowerCase(Locale.ROOT))) {
-                throw new IllegalArgumentException(
-                        "llm.providers." + providerName + ".apiType must be one of " + VALID_API_TYPES);
-            }
-        }
-
-        Set<String> providersUsedByModelRouter = getProvidersUsedByModelRouter(modelRouterConfig);
-        for (String usedProvider : providersUsedByModelRouter) {
-            if (!providers.containsKey(usedProvider)) {
-                throw new IllegalArgumentException(
-                        "Cannot remove provider '" + usedProvider + "' because it is used by model router tiers");
-            }
-        }
-    }
-
-    private void validateModelRouterConfig(RuntimeConfig.ModelRouterConfig modelRouterConfig,
-            RuntimeConfig.LlmConfig llmConfig) {
-        if (modelRouterConfig == null) {
-            return;
-        }
-        List<String> configuredProviders = llmConfig != null && llmConfig.getProviders() != null
-                ? new ArrayList<>(llmConfig.getProviders().keySet())
-                : List.of();
-        validateModelRouterBinding(modelRouterConfig.getRouting(), "routing", configuredProviders);
-        if (modelRouterConfig.getTiers() == null) {
-            return;
-        }
-        for (Map.Entry<String, RuntimeConfig.TierBinding> entry : modelRouterConfig.getTiers().entrySet()) {
-            validateModelRouterBinding(entry.getValue(), entry.getKey(), configuredProviders);
-        }
-    }
-
-    private void validateModelRouterBinding(RuntimeConfig.TierBinding binding, String tier,
-            List<String> configuredProviders) {
-        if (binding == null || binding.getModel() == null || binding.getModel().isBlank()) {
-            return;
-        }
-        ModelSelectionService.ValidationResult validation = modelSelectionService.validateModel(
-                binding.getModel(),
-                configuredProviders);
-        if (validation.valid()) {
-            return;
-        }
-        throw switch (validation.error()) {
-        case "model.not.found" -> new IllegalArgumentException(
-                "Model router tier '" + tier + "' points to unknown model '" + binding.getModel() + "'");
-        case "provider.not.configured" -> new IllegalArgumentException(
-                "Model router tier '" + tier + "' points to model '" + binding.getModel()
-                        + "' whose provider is not configured");
-        default -> new IllegalArgumentException(
-                "Model router tier '" + tier + "' is invalid: " + validation.error());
-        };
-    }
-
-    private void validateTurnConfig(RuntimeConfig.TurnConfig turnConfig) {
-        if (turnConfig == null) {
-            throw new IllegalArgumentException("turn config is required");
-        }
-        if (turnConfig.getMaxLlmCalls() != null && turnConfig.getMaxLlmCalls() < 1) {
-            throw new IllegalArgumentException("turn.maxLlmCalls must be >= 1");
-        }
-        if (turnConfig.getMaxToolExecutions() != null && turnConfig.getMaxToolExecutions() < 1) {
-            throw new IllegalArgumentException("turn.maxToolExecutions must be >= 1");
-        }
-        if (turnConfig.getDeadline() != null && !turnConfig.getDeadline().isBlank()) {
-            try {
-                java.time.Duration deadline = java.time.Duration.parse(turnConfig.getDeadline().trim());
-                if (deadline.isZero() || deadline.isNegative()) {
-                    throw new IllegalArgumentException("turn.deadline must be a positive ISO-8601 duration");
-                }
-            } catch (java.time.format.DateTimeParseException e) {
-                throw new IllegalArgumentException("turn.deadline must be a valid ISO-8601 duration");
-            }
-        }
-        validateRange(turnConfig.getProgressBatchSize(), TURN_PROGRESS_BATCH_SIZE_MIN, TURN_PROGRESS_BATCH_SIZE_MAX,
-                "turn.progressBatchSize");
-        validateRange(turnConfig.getProgressMaxSilenceSeconds(),
-                TURN_PROGRESS_MAX_SILENCE_SECONDS_MIN,
-                TURN_PROGRESS_MAX_SILENCE_SECONDS_MAX,
-                "turn.progressMaxSilenceSeconds");
-        validateRange(turnConfig.getProgressSummaryTimeoutMs(),
-                TURN_PROGRESS_SUMMARY_TIMEOUT_MS_MIN,
-                TURN_PROGRESS_SUMMARY_TIMEOUT_MS_MAX,
-                "turn.progressSummaryTimeoutMs");
-    }
-
-    private void validateRange(Integer value, int min, int max, String fieldName) {
-        if (value == null) {
-            return;
-        }
-        if (value < min || value > max) {
-            throw new IllegalArgumentException(fieldName + " must be between " + min + " and " + max);
-        }
-    }
-
-    private void validateMemoryConfig(RuntimeConfig.MemoryConfig memoryConfig) {
-        if (memoryConfig == null) {
-            throw new IllegalArgumentException("memory config is required");
-        }
-        if (memoryConfig.getDisclosure() == null) {
-            memoryConfig.setDisclosure(RuntimeConfig.MemoryDisclosureConfig.builder().build());
-        }
-        if (memoryConfig.getReranking() == null) {
-            memoryConfig.setReranking(RuntimeConfig.MemoryRerankingConfig.builder().build());
-        }
-        if (memoryConfig.getDiagnostics() == null) {
-            memoryConfig.setDiagnostics(RuntimeConfig.MemoryDiagnosticsConfig.builder().build());
-        }
-
-        validateNullableInteger(memoryConfig.getSoftPromptBudgetTokens(), MEMORY_SOFT_BUDGET_MIN,
-                MEMORY_SOFT_BUDGET_MAX,
-                "memory.softPromptBudgetTokens");
-        validateNullableInteger(memoryConfig.getMaxPromptBudgetTokens(), MEMORY_MAX_BUDGET_MIN, MEMORY_MAX_BUDGET_MAX,
-                "memory.maxPromptBudgetTokens");
-        validateNullableInteger(memoryConfig.getWorkingTopK(), MEMORY_TOP_K_MIN, MEMORY_TOP_K_MAX,
-                "memory.workingTopK");
-        validateNullableInteger(memoryConfig.getEpisodicTopK(), MEMORY_TOP_K_MIN, MEMORY_TOP_K_MAX,
-                "memory.episodicTopK");
-        validateNullableInteger(memoryConfig.getSemanticTopK(), MEMORY_TOP_K_MIN, MEMORY_TOP_K_MAX,
-                "memory.semanticTopK");
-        validateNullableInteger(memoryConfig.getProceduralTopK(), MEMORY_TOP_K_MIN, MEMORY_TOP_K_MAX,
-                "memory.proceduralTopK");
-        validateNullableDouble(memoryConfig.getPromotionMinConfidence(), 0.0, 1.0, "memory.promotionMinConfidence");
-        validateNullableInteger(memoryConfig.getDecayDays(), MEMORY_DECAY_DAYS_MIN, MEMORY_DECAY_DAYS_MAX,
-                "memory.decayDays");
-        validateNullableInteger(memoryConfig.getRetrievalLookbackDays(), MEMORY_RETRIEVAL_LOOKBACK_DAYS_MIN,
-                MEMORY_RETRIEVAL_LOOKBACK_DAYS_MAX, "memory.retrievalLookbackDays");
-
-        Integer softBudget = memoryConfig.getSoftPromptBudgetTokens();
-        Integer maxBudget = memoryConfig.getMaxPromptBudgetTokens();
-        if (softBudget != null && maxBudget != null && maxBudget < softBudget) {
-            throw new IllegalArgumentException(
-                    "memory.maxPromptBudgetTokens must be greater than or equal to memory.softPromptBudgetTokens");
-        }
-
-        normalizeAndValidateMemoryDisclosureConfig(memoryConfig.getDisclosure());
-        normalizeAndValidateMemoryRerankingConfig(memoryConfig.getReranking());
-        normalizeAndValidateMemoryDiagnosticsConfig(memoryConfig.getDiagnostics());
-    }
-
-    private void normalizeAndValidateMemoryDisclosureConfig(
-            RuntimeConfig.MemoryDisclosureConfig disclosureConfig) {
-        if (disclosureConfig == null) {
-            return;
-        }
-        disclosureConfig.setMode(normalizeAndValidateMemoryOption(
-                disclosureConfig.getMode(),
-                "summary",
-                VALID_MEMORY_DISCLOSURE_MODES,
-                "memory.disclosure.mode"));
-        disclosureConfig.setPromptStyle(normalizeAndValidateMemoryOption(
-                disclosureConfig.getPromptStyle(),
-                "balanced",
-                VALID_MEMORY_PROMPT_STYLES,
-                "memory.disclosure.promptStyle"));
-        validateNullableDouble(disclosureConfig.getDetailMinScore(), 0.0, 1.0, "memory.disclosure.detailMinScore");
-        if (disclosureConfig.getToolExpansionEnabled() == null) {
-            disclosureConfig.setToolExpansionEnabled(true);
-        }
-        if (disclosureConfig.getDisclosureHintsEnabled() == null) {
-            disclosureConfig.setDisclosureHintsEnabled(true);
-        }
-    }
-
-    private void normalizeAndValidateMemoryDiagnosticsConfig(
-            RuntimeConfig.MemoryDiagnosticsConfig diagnosticsConfig) {
-        if (diagnosticsConfig == null) {
-            return;
-        }
-        diagnosticsConfig.setVerbosity(normalizeAndValidateMemoryOption(
-                diagnosticsConfig.getVerbosity(),
-                "basic",
-                VALID_MEMORY_DIAGNOSTICS_VERBOSITY,
-                "memory.diagnostics.verbosity"));
-    }
-
-    private void normalizeAndValidateMemoryRerankingConfig(
-            RuntimeConfig.MemoryRerankingConfig rerankingConfig) {
-        if (rerankingConfig == null) {
-            return;
-        }
-        rerankingConfig.setProfile(normalizeAndValidateMemoryOption(
-                rerankingConfig.getProfile(),
-                "balanced",
-                VALID_MEMORY_RERANKING_PROFILES,
-                "memory.reranking.profile"));
-        if (rerankingConfig.getEnabled() == null) {
-            rerankingConfig.setEnabled(true);
-        }
-    }
-
-    private void validateCompactionConfig(RuntimeConfig.CompactionConfig compactionConfig) {
-        if (compactionConfig == null) {
-            return;
-        }
-
-        String triggerMode = compactionConfig.getTriggerMode();
-        if (triggerMode == null || triggerMode.isBlank()) {
-            compactionConfig.setTriggerMode(DEFAULT_COMPACTION_TRIGGER_MODE);
-        } else {
-            String normalized = triggerMode.trim().toLowerCase(Locale.ROOT);
-            if (!VALID_COMPACTION_TRIGGER_MODES.contains(normalized)) {
-                throw new IllegalArgumentException(
-                        "compaction.triggerMode must be one of " + VALID_COMPACTION_TRIGGER_MODES);
-            }
-            compactionConfig.setTriggerMode(normalized);
-        }
-
-        Double modelThresholdRatio = compactionConfig.getModelThresholdRatio();
-        if (modelThresholdRatio == null) {
-            compactionConfig.setModelThresholdRatio(DEFAULT_COMPACTION_MODEL_THRESHOLD_RATIO);
-        } else if (modelThresholdRatio <= 0.0d || modelThresholdRatio > 1.0d) {
-            throw new IllegalArgumentException("compaction.modelThresholdRatio must be between 0 and 1");
-        }
-
-        Integer maxContextTokens = compactionConfig.getMaxContextTokens();
-        if (maxContextTokens != null && maxContextTokens < 1) {
-            throw new IllegalArgumentException("compaction.maxContextTokens must be greater than 0");
-        }
-
-        Integer keepLastMessages = compactionConfig.getKeepLastMessages();
-        if (keepLastMessages != null && keepLastMessages < 1) {
-            throw new IllegalArgumentException("compaction.keepLastMessages must be greater than 0");
-        }
-    }
-
-    private void validateNullableInteger(Integer value, int min, int max, String fieldName) {
-        if (value == null) {
-            return;
-        }
-        if (value < min || value > max) {
-            throw new IllegalArgumentException(fieldName + " must be between " + min + " and " + max);
-        }
-    }
-
-    private void validateNullableDouble(Double value, double min, double max, String fieldName) {
-        if (value == null) {
-            return;
-        }
-        if (value < min || value > max) {
-            throw new IllegalArgumentException(fieldName + " must be between " + min + " and " + max);
-        }
-    }
-
-    private String normalizeAndValidateMemoryOption(
-            String value,
-            String defaultValue,
-            Set<String> allowedValues,
-            String fieldName) {
-        String normalized = value == null || value.isBlank()
-                ? defaultValue
-                : value.trim().toLowerCase(Locale.ROOT);
-        if (!allowedValues.contains(normalized)) {
-            throw new IllegalArgumentException(fieldName + " must be one of " + allowedValues);
-        }
-        return normalized;
-    }
-
-    private void validateVoiceConfig(RuntimeConfig.VoiceConfig voiceConfig) {
-        if (voiceConfig == null) {
-            return;
-        }
-        boolean voiceEnabled = Boolean.TRUE.equals(voiceConfig.getEnabled());
-
-        String normalizedSttProvider = normalizeProvider(voiceConfig.getSttProvider());
-        if (normalizedSttProvider == null) {
-            normalizedSttProvider = firstLoadedSttProvider();
-        }
-        if (normalizedSttProvider == null && voiceEnabled) {
-            throw new IllegalArgumentException("voice.sttProvider must resolve to a loaded STT provider");
-        }
-        if (normalizedSttProvider != null && !isKnownSttProvider(normalizedSttProvider)) {
-            throw new IllegalArgumentException("voice.sttProvider must resolve to a loaded STT provider");
-        }
-        voiceConfig.setSttProvider(normalizedSttProvider);
-
-        String normalizedTtsProvider = normalizeProvider(voiceConfig.getTtsProvider());
-        if (normalizedTtsProvider == null) {
-            normalizedTtsProvider = firstLoadedTtsProvider();
-        }
-        if (normalizedTtsProvider == null && voiceEnabled) {
-            throw new IllegalArgumentException("voice.ttsProvider must resolve to a loaded TTS provider");
-        }
-        if (normalizedTtsProvider != null && !isKnownTtsProvider(normalizedTtsProvider)) {
-            throw new IllegalArgumentException("voice.ttsProvider must resolve to a loaded TTS provider");
-        }
-        voiceConfig.setTtsProvider(normalizedTtsProvider);
-
-        String whisperSttUrl = voiceConfig.getWhisperSttUrl();
-        if (whisperSttUrl != null && whisperSttUrl.isBlank()) {
-            voiceConfig.setWhisperSttUrl(null);
-        }
-    }
-
-    private void validatePlanConfig(RuntimeConfig.PlanConfig planConfig) {
-        if (planConfig == null) {
-            throw new IllegalArgumentException("plan config is required");
-        }
-        validateNullableInteger(planConfig.getMaxPlans(), 1, 100, "plan.maxPlans");
-        validateNullableInteger(planConfig.getMaxStepsPerPlan(), 1, 1000, "plan.maxStepsPerPlan");
-    }
-
-    private void validateAndNormalizeAutoModeConfig(RuntimeConfig.AutoModeConfig autoConfig) {
-        if (autoConfig == null) {
-            throw new IllegalArgumentException("autoMode config is required");
-        }
-        autoConfig.setModelTier(normalizeOptionalSelectableTier(autoConfig.getModelTier(), "autoMode.modelTier"));
-        autoConfig.setReflectionModelTier(normalizeOptionalSelectableTier(autoConfig.getReflectionModelTier(),
-                "autoMode.reflectionModelTier"));
-    }
-
-    private void validateAndNormalizeTracingConfig(RuntimeConfig.TracingConfig tracingConfig) {
-        if (tracingConfig == null) {
-            throw new IllegalArgumentException("tracing config is required");
-        }
-        validateNullableInteger(tracingConfig.getSessionTraceBudgetMb(), 1, 1024, "tracing.sessionTraceBudgetMb");
-        validateNullableInteger(tracingConfig.getMaxSnapshotSizeKb(), 1, 10240, "tracing.maxSnapshotSizeKb");
-        validateNullableInteger(tracingConfig.getMaxSnapshotsPerSpan(), 1, 1000, "tracing.maxSnapshotsPerSpan");
-        validateNullableInteger(tracingConfig.getMaxTracesPerSession(), 1, 10000, "tracing.maxTracesPerSession");
-    }
-
-    private void validateHiveConfig(RuntimeConfig.HiveConfig hiveConfig) {
-        if (hiveConfig == null) {
-            throw new IllegalArgumentException("hive config is required");
-        }
-        String serverUrl = hiveConfig.getServerUrl();
-        if (serverUrl != null && !serverUrl.isBlank() && !isValidHttpUrl(serverUrl)) {
-            throw new IllegalArgumentException("hive.serverUrl must be a valid http(s) URL");
-        }
-    }
-
-    private void validateAndNormalizeModelRegistryConfig(RuntimeConfig.ModelRegistryConfig modelRegistryConfig) {
-        if (modelRegistryConfig == null) {
-            return;
-        }
-        String repositoryUrl = modelRegistryConfig.getRepositoryUrl();
-        if (repositoryUrl != null) {
-            repositoryUrl = repositoryUrl.trim();
-        }
-        if (repositoryUrl == null || repositoryUrl.isBlank()) {
-            modelRegistryConfig.setRepositoryUrl(null);
-        } else {
-            if (!isValidHttpUrl(repositoryUrl)) {
-                throw new IllegalArgumentException("modelRegistry.repositoryUrl must be a valid http(s) URL");
-            }
-            modelRegistryConfig.setRepositoryUrl(repositoryUrl);
-        }
-
-        String branch = modelRegistryConfig.getBranch();
-        if (branch == null || branch.isBlank()) {
-            modelRegistryConfig.setBranch("main");
-        } else {
-            modelRegistryConfig.setBranch(branch.trim());
-        }
-    }
-
-    private void validateWebhookConfig(UserPreferences.WebhookConfig webhookConfig) {
-        if (webhookConfig == null || webhookConfig.getMappings() == null) {
-            return;
-        }
-        for (UserPreferences.HookMapping mapping : webhookConfig.getMappings()) {
-            if (mapping == null) {
-                continue;
-            }
-            mapping.setModel(normalizeOptionalSelectableTier(mapping.getModel(), "webhooks.mapping.model"));
-        }
-    }
-
-    private RuntimeConfig.ToolsConfig ensureToolsConfig(RuntimeConfig config) {
-        RuntimeConfig.ToolsConfig toolsConfig = config.getTools();
-        if (toolsConfig == null) {
-            toolsConfig = RuntimeConfig.ToolsConfig.builder().build();
-            config.setTools(toolsConfig);
-        }
-        return toolsConfig;
-    }
-
-    private RuntimeConfig mergeRuntimeConfigSections(RuntimeConfig current, RuntimeConfig incoming) {
-        RuntimeConfig baseline = current != null ? current : RuntimeConfig.builder().build();
-        RuntimeConfig patch = incoming != null ? incoming : RuntimeConfig.builder().build();
-        return RuntimeConfig.builder()
-                .telegram(mergeSection(patch.getTelegram(), baseline.getTelegram(), RuntimeConfig.TelegramConfig::new))
-                .modelRouter(mergeSection(patch.getModelRouter(), baseline.getModelRouter(),
-                        RuntimeConfig.ModelRouterConfig::new))
-                .llm(mergeSection(patch.getLlm(), baseline.getLlm(), RuntimeConfig.LlmConfig::new))
-                .tools(mergeSection(patch.getTools(), baseline.getTools(), RuntimeConfig.ToolsConfig::new))
-                .voice(mergeSection(patch.getVoice(), baseline.getVoice(), RuntimeConfig.VoiceConfig::new))
-                .autoMode(mergeSection(patch.getAutoMode(), baseline.getAutoMode(), RuntimeConfig.AutoModeConfig::new))
-                .tracing(mergeSection(patch.getTracing(), baseline.getTracing(), RuntimeConfig.TracingConfig::new))
-                .rateLimit(mergeSection(patch.getRateLimit(), baseline.getRateLimit(),
-                        RuntimeConfig.RateLimitConfig::new))
-                .security(mergeSection(patch.getSecurity(), baseline.getSecurity(), RuntimeConfig.SecurityConfig::new))
-                .compaction(mergeSection(patch.getCompaction(), baseline.getCompaction(),
-                        RuntimeConfig.CompactionConfig::new))
-                .turn(mergeSection(patch.getTurn(), baseline.getTurn(), RuntimeConfig.TurnConfig::new))
-                .memory(mergeSection(patch.getMemory(), baseline.getMemory(), RuntimeConfig.MemoryConfig::new))
-                .skills(mergeSection(patch.getSkills(), baseline.getSkills(), RuntimeConfig.SkillsConfig::new))
-                .modelRegistry(mergeSection(patch.getModelRegistry(), baseline.getModelRegistry(),
-                        RuntimeConfig.ModelRegistryConfig::new))
-                .usage(mergeSection(patch.getUsage(), baseline.getUsage(), RuntimeConfig.UsageConfig::new))
-                .telemetry(mergeSection(patch.getTelemetry(), baseline.getTelemetry(),
-                        RuntimeConfig.TelemetryConfig::new))
-                .mcp(mergeSection(patch.getMcp(), baseline.getMcp(), RuntimeConfig.McpConfig::new))
-                .plan(mergeSection(patch.getPlan(), baseline.getPlan(), RuntimeConfig.PlanConfig::new))
-                .delayedActions(mergeSection(patch.getDelayedActions(), baseline.getDelayedActions(),
-                        RuntimeConfig.DelayedActionsConfig::new))
-                .hive(mergeSection(patch.getHive(), baseline.getHive(), RuntimeConfig.HiveConfig::new))
-                .selfEvolving(mergeSelfEvolvingSection(patch.getSelfEvolving(), baseline.getSelfEvolving()))
-                .build();
-    }
-
-    private RuntimeConfig.SelfEvolvingConfig mergeSelfEvolvingSection(
-            RuntimeConfig.SelfEvolvingConfig patch,
-            RuntimeConfig.SelfEvolvingConfig baseline) {
-        if (patch == null) {
-            return baseline;
-        }
-        preserveSelfEvolvingEmbeddingsApiKey(patch, baseline);
-        return patch;
-    }
-
-    private void preserveSelfEvolvingEmbeddingsApiKey(
-            RuntimeConfig.SelfEvolvingConfig patch,
-            RuntimeConfig.SelfEvolvingConfig baseline) {
-        RuntimeConfig.SelfEvolvingTacticEmbeddingsConfig patchEmbeddings = extractEmbeddings(patch);
-        if (patchEmbeddings == null) {
-            return;
-        }
-        RuntimeConfig.SelfEvolvingTacticEmbeddingsConfig baselineEmbeddings = extractEmbeddings(baseline);
-        Secret baselineKey = baselineEmbeddings != null ? baselineEmbeddings.getApiKey() : null;
-        patchEmbeddings.setApiKey(mergeSecret(baselineKey, patchEmbeddings.getApiKey()));
-    }
-
-    private RuntimeConfig.SelfEvolvingTacticEmbeddingsConfig extractEmbeddings(
-            RuntimeConfig.SelfEvolvingConfig config) {
-        if (config == null || config.getTactics() == null || config.getTactics().getSearch() == null) {
+    private Mono<ResponseEntity<Void>> runtimeVoidResponse(Runnable runnable) {
+        invokeRuntime(() -> {
+            runnable.run();
             return null;
-        }
-        return config.getTactics().getSearch().getEmbeddings();
+        });
+        return Mono.just(ResponseEntity.ok().build());
     }
 
-    private <T> T mergeSection(T incoming, T current, Supplier<T> emptySupplier) {
-        if (incoming == null) {
-            return current;
+    private <T> T invokeRuntime(Supplier<T> supplier) {
+        try {
+            return supplier.get();
+        } catch (NoSuchElementException ex) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, ex.getMessage());
+        } catch (IllegalStateException ex) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, ex.getMessage());
         }
-        if (current == null) {
-            return incoming;
-        }
-        return incoming.equals(emptySupplier.get()) ? current : incoming;
-    }
-
-    private List<RuntimeConfig.ShellEnvironmentVariable> ensureShellEnvironmentVariables(
-            RuntimeConfig.ToolsConfig toolsConfig) {
-        List<RuntimeConfig.ShellEnvironmentVariable> variables = toolsConfig.getShellEnvironmentVariables();
-        if (variables == null) {
-            variables = new ArrayList<>();
-            toolsConfig.setShellEnvironmentVariables(variables);
-        }
-        return variables;
-    }
-
-    private void normalizeAndValidateShellEnvironmentVariables(RuntimeConfig.ToolsConfig toolsConfig) {
-        if (toolsConfig == null) {
-            return;
-        }
-        List<RuntimeConfig.ShellEnvironmentVariable> variables = toolsConfig.getShellEnvironmentVariables();
-        if (variables == null || variables.isEmpty()) {
-            toolsConfig.setShellEnvironmentVariables(new ArrayList<>());
-            return;
-        }
-
-        List<RuntimeConfig.ShellEnvironmentVariable> normalized = new ArrayList<>(variables.size());
-        Set<String> names = new LinkedHashSet<>();
-        for (RuntimeConfig.ShellEnvironmentVariable variable : variables) {
-            RuntimeConfig.ShellEnvironmentVariable normalizedVariable = normalizeAndValidateShellEnvironmentVariable(
-                    variable);
-            if (!names.add(normalizedVariable.getName())) {
-                throw new IllegalArgumentException(
-                        "tools.shellEnvironmentVariables contains duplicate name: " + normalizedVariable.getName());
-            }
-            normalized.add(normalizedVariable);
-        }
-        toolsConfig.setShellEnvironmentVariables(normalized);
-    }
-
-    private RuntimeConfig.ShellEnvironmentVariable normalizeAndValidateShellEnvironmentVariable(
-            RuntimeConfig.ShellEnvironmentVariable variable) {
-        if (variable == null) {
-            throw new IllegalArgumentException("tools.shellEnvironmentVariables item is required");
-        }
-        String normalizedName = normalizeAndValidateShellEnvironmentVariableName(variable.getName());
-        String normalizedValue = normalizeAndValidateShellEnvironmentVariableValue(variable.getValue(), normalizedName);
-        return RuntimeConfig.ShellEnvironmentVariable.builder()
-                .name(normalizedName)
-                .value(normalizedValue)
-                .build();
-    }
-
-    private String normalizeAndValidateShellEnvironmentVariableName(String value) {
-        if (value == null || value.isBlank()) {
-            throw new IllegalArgumentException("tools.shellEnvironmentVariables.name is required");
-        }
-        String normalized = value.trim();
-        if (normalized.length() > SHELL_ENV_VAR_NAME_MAX_LENGTH) {
-            throw new IllegalArgumentException("tools.shellEnvironmentVariables.name must be at most "
-                    + SHELL_ENV_VAR_NAME_MAX_LENGTH + " characters");
-        }
-        if (!SHELL_ENV_VAR_NAME_PATTERN.matcher(normalized).matches()) {
-            throw new IllegalArgumentException(
-                    "tools.shellEnvironmentVariables.name must match [A-Za-z_][A-Za-z0-9_]*");
-        }
-        if (RESERVED_SHELL_ENV_VAR_NAMES.contains(normalized)) {
-            throw new IllegalArgumentException(
-                    "tools.shellEnvironmentVariables.name must not redefine reserved variable: " + normalized);
-        }
-        return normalized;
-    }
-
-    private String normalizeAndValidateShellEnvironmentVariableValue(String value, String normalizedName) {
-        String normalizedValue = value != null ? value : "";
-        if (normalizedValue.length() > SHELL_ENV_VAR_VALUE_MAX_LENGTH) {
-            throw new IllegalArgumentException("tools.shellEnvironmentVariables." + normalizedName
-                    + ".value must be at most " + SHELL_ENV_VAR_VALUE_MAX_LENGTH + " characters");
-        }
-        return normalizedValue;
-    }
-
-    private boolean containsShellEnvironmentVariableName(List<RuntimeConfig.ShellEnvironmentVariable> variables,
-            String name) {
-        return findShellEnvironmentVariableIndex(variables, name) >= 0;
-    }
-
-    private int findShellEnvironmentVariableIndex(List<RuntimeConfig.ShellEnvironmentVariable> variables, String name) {
-        for (int index = 0; index < variables.size(); index++) {
-            RuntimeConfig.ShellEnvironmentVariable variable = variables.get(index);
-            if (variable != null && name.equals(variable.getName())) {
-                return index;
-            }
-        }
-        return -1;
-    }
-
-    private Set<String> getProvidersUsedByModelRouter(RuntimeConfig.ModelRouterConfig modelRouterConfig) {
-        Set<String> usedProviders = new LinkedHashSet<>();
-        if (modelRouterConfig == null) {
-            return usedProviders;
-        }
-        RuntimeConfig.TierBinding routingBinding = modelRouterConfig.getRouting();
-        if (routingBinding != null) {
-            addProviderFromModel(usedProviders, routingBinding.getModel());
-        }
-        if (modelRouterConfig.getTiers() != null) {
-            for (RuntimeConfig.TierBinding tierBinding : modelRouterConfig.getTiers().values()) {
-                if (tierBinding != null) {
-                    addProviderFromModel(usedProviders, tierBinding.getModel());
-                }
-            }
-        }
-        return usedProviders;
-    }
-
-    private void addProviderFromModel(Set<String> usedProviders, String model) {
-        if (model == null || model.isBlank()) {
-            return;
-        }
-        String resolvedProvider = modelSelectionService.resolveProviderForModel(model);
-        if (resolvedProvider != null) {
-            usedProviders.add(resolvedProvider);
-            return;
-        }
-        int delimiterIndex = model.indexOf('/');
-        if (delimiterIndex <= 0) {
-            return;
-        }
-        usedProviders.add(model.substring(0, delimiterIndex));
     }
 
     private String normalizeOptionalSelectableTier(String tier, String fieldName) {
@@ -1303,143 +331,13 @@ public class SettingsController {
         return normalizedTier;
     }
 
-    private void mergeRuntimeSecrets(RuntimeConfig current, RuntimeConfig incoming) {
-        if (current == null || incoming == null) {
-            return;
-        }
-        if (incoming.getTelegram() != null && current.getTelegram() != null) {
-            incoming.getTelegram()
-                    .setToken(mergeSecret(current.getTelegram().getToken(), incoming.getTelegram().getToken()));
-        }
-        if (incoming.getVoice() != null && current.getVoice() != null) {
-            incoming.getVoice().setApiKey(mergeSecret(current.getVoice().getApiKey(), incoming.getVoice().getApiKey()));
-            incoming.getVoice().setWhisperSttApiKey(
-                    mergeSecret(current.getVoice().getWhisperSttApiKey(), incoming.getVoice().getWhisperSttApiKey()));
-        }
-        mergeLlmSecrets(current.getLlm(), incoming.getLlm());
+    private record ModelDto(String id, String displayName, boolean hasReasoning,
+            List<String> reasoningLevels, boolean supportsVision) {
     }
 
-    private void rejectManagedHiveMutation(RuntimeConfig current, RuntimeConfig.HiveConfig incomingHiveConfig) {
-        if (current == null || !runtimeConfigService.isHiveManagedByProperties()) {
-            return;
-        }
-        if (incomingHiveConfig == null) {
-            return;
-        }
-        RuntimeConfig.HiveConfig currentHiveConfig = current.getHive();
-        RuntimeConfig.HiveConfig normalizedCurrentHiveConfig = currentHiveConfig != null
-                ? currentHiveConfig
-                : RuntimeConfig.HiveConfig.builder().build();
-        if (!incomingHiveConfig.equals(normalizedCurrentHiveConfig)) {
-            throw new ResponseStatusException(HttpStatus.CONFLICT,
-                    "Hive settings are managed by bot.hive.* and are read-only");
-        }
+    private record AdvancedConfigRequest(
+            RuntimeConfig.RateLimitConfig rateLimit,
+            RuntimeConfig.SecurityConfig security,
+            RuntimeConfig.CompactionConfig compaction) {
     }
-
-    private void mergeLlmSecrets(RuntimeConfig.LlmConfig current, RuntimeConfig.LlmConfig incoming) {
-        if (current == null || incoming == null || incoming.getProviders() == null) {
-            return;
-        }
-        Map<String, RuntimeConfig.LlmProviderConfig> currentProviders = current.getProviders();
-        for (Map.Entry<String, RuntimeConfig.LlmProviderConfig> entry : incoming.getProviders().entrySet()) {
-            RuntimeConfig.LlmProviderConfig incomingProvider = entry.getValue();
-            RuntimeConfig.LlmProviderConfig currentProvider = currentProviders != null
-                    ? currentProviders.get(entry.getKey())
-                    : null;
-            if (incomingProvider != null && currentProvider != null) {
-                incomingProvider.setApiKey(mergeSecret(currentProvider.getApiKey(), incomingProvider.getApiKey()));
-            }
-        }
-    }
-
-    private void mergeWebhookSecrets(UserPreferences.WebhookConfig current, UserPreferences.WebhookConfig incoming) {
-        if (incoming == null) {
-            return;
-        }
-        if (current != null) {
-            incoming.setToken(mergeSecret(current.getToken(), incoming.getToken()));
-        }
-        if (incoming.getMappings() == null || incoming.getMappings().isEmpty() || current == null
-                || current.getMappings() == null) {
-            return;
-        }
-
-        Map<String, UserPreferences.HookMapping> currentByName = new LinkedHashMap<>();
-        for (UserPreferences.HookMapping mapping : current.getMappings()) {
-            if (mapping != null && mapping.getName() != null) {
-                currentByName.put(mapping.getName(), mapping);
-            }
-        }
-
-        for (UserPreferences.HookMapping mapping : incoming.getMappings()) {
-            if (mapping == null || mapping.getName() == null) {
-                continue;
-            }
-            UserPreferences.HookMapping existing = currentByName.get(mapping.getName());
-            if (existing != null) {
-                mapping.setHmacSecret(mergeSecret(existing.getHmacSecret(), mapping.getHmacSecret()));
-            }
-        }
-    }
-
-    private Secret mergeSecret(Secret current, Secret incoming) {
-        if (incoming == null) {
-            return current;
-        }
-        if (!Secret.hasValue(incoming)) {
-            Secret retained = current != null ? current : Secret.builder().build();
-            if (incoming.getEncrypted() != null) {
-                retained.setEncrypted(incoming.getEncrypted());
-            }
-            retained.setPresent(Secret.hasValue(retained));
-            return retained;
-        }
-        return Secret.builder()
-                .value(incoming.getValue())
-                .encrypted(Boolean.TRUE.equals(incoming.getEncrypted()))
-                .present(true)
-                .build();
-    }
-
-    private String normalizeProvider(String value) {
-        if (value == null || value.isBlank()) {
-            return null;
-        }
-        String normalized = value.trim().toLowerCase(Locale.ROOT);
-        if (LEGACY_STT_PROVIDER_ELEVENLABS.equals(normalized)) {
-            return STT_PROVIDER_ELEVENLABS;
-        }
-        if (LEGACY_STT_PROVIDER_WHISPER.equals(normalized)) {
-            return STT_PROVIDER_WHISPER;
-        }
-        return normalized;
-    }
-
-    private boolean isKnownSttProvider(String providerId) {
-        return providerId != null && sttProviderRegistry.find(providerId).isPresent();
-    }
-
-    private boolean isKnownTtsProvider(String providerId) {
-        return providerId != null && ttsProviderRegistry.find(providerId).isPresent();
-    }
-
-    private String firstLoadedSttProvider() {
-        return sttProviderRegistry.listProviderIds().keySet().stream().findFirst().orElse(null);
-    }
-
-    private String firstLoadedTtsProvider() {
-        return ttsProviderRegistry.listProviderIds().keySet().stream().findFirst().orElse(null);
-    }
-
-    private boolean isValidHttpUrl(String value) {
-        try {
-            java.net.URI uri = new java.net.URI(value);
-            String scheme = uri.getScheme();
-            String host = uri.getHost();
-            return host != null && ("http".equalsIgnoreCase(scheme) || "https".equalsIgnoreCase(scheme));
-        } catch (java.net.URISyntaxException ignored) {
-            return false;
-        }
-    }
-
 }

--- a/src/main/java/me/golemcore/bot/application/settings/RuntimeSettingsFacade.java
+++ b/src/main/java/me/golemcore/bot/application/settings/RuntimeSettingsFacade.java
@@ -241,7 +241,7 @@ public class RuntimeSettingsFacade {
         }
         RuntimeConfig config = runtimeConfigService.getRuntimeConfig();
         RuntimeConfig.McpConfig existing = config.getMcp();
-        if (existing != null && mcpConfig.getCatalog() == null) {
+        if (existing != null && (mcpConfig.getCatalog() == null || mcpConfig.getCatalog().isEmpty())) {
             mcpConfig.setCatalog(existing.getCatalog());
         }
         config.setMcp(mcpConfig);

--- a/src/main/java/me/golemcore/bot/application/settings/RuntimeSettingsFacade.java
+++ b/src/main/java/me/golemcore/bot/application/settings/RuntimeSettingsFacade.java
@@ -1,0 +1,359 @@
+package me.golemcore.bot.application.settings;
+
+import me.golemcore.bot.domain.model.MemoryPreset;
+import me.golemcore.bot.domain.model.RuntimeConfig;
+import me.golemcore.bot.domain.model.UserPreferences;
+import me.golemcore.bot.domain.service.MemoryPresetService;
+import me.golemcore.bot.domain.service.RuntimeConfigService;
+import me.golemcore.bot.domain.service.UserPreferencesService;
+import org.springframework.stereotype.Service;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+@Service
+public class RuntimeSettingsFacade {
+
+    private final RuntimeConfigService runtimeConfigService;
+    private final UserPreferencesService preferencesService;
+    private final MemoryPresetService memoryPresetService;
+    private final RuntimeSettingsValidator validator;
+    private final RuntimeSettingsMergeService mergeService;
+
+    public RuntimeSettingsFacade(RuntimeConfigService runtimeConfigService,
+            UserPreferencesService preferencesService,
+            MemoryPresetService memoryPresetService,
+            RuntimeSettingsValidator validator,
+            RuntimeSettingsMergeService mergeService) {
+        this.runtimeConfigService = runtimeConfigService;
+        this.preferencesService = preferencesService;
+        this.memoryPresetService = memoryPresetService;
+        this.validator = validator;
+        this.mergeService = mergeService;
+    }
+
+    public RuntimeConfig getRuntimeConfigForApi() {
+        return runtimeConfigService.getRuntimeConfigForApi();
+    }
+
+    public RuntimeConfig updateRuntimeConfig(RuntimeConfig config) {
+        RuntimeConfig current = runtimeConfigService.getRuntimeConfig();
+        RuntimeConfig merged = mergeService.mergeRuntimeConfigSections(current, config);
+        mergeService.mergeRuntimeSecrets(current, merged);
+        validator.validateRuntimeConfigUpdate(current, merged, runtimeConfigService.isHiveManagedByProperties());
+        runtimeConfigService.updateRuntimeConfig(merged);
+        return runtimeConfigService.getRuntimeConfigForApi();
+    }
+
+    public RuntimeConfig updateModelRouterConfig(RuntimeConfig.ModelRouterConfig modelRouterConfig) {
+        RuntimeConfig config = runtimeConfigService.getRuntimeConfig();
+        validator.validateModelRouterConfig(modelRouterConfig, config.getLlm());
+        config.setModelRouter(modelRouterConfig);
+        runtimeConfigService.updateRuntimeConfig(config);
+        return runtimeConfigService.getRuntimeConfigForApi();
+    }
+
+    public RuntimeConfig updateLlmConfig(RuntimeConfig.LlmConfig llmConfig) {
+        RuntimeConfig config = runtimeConfigService.getRuntimeConfig();
+        mergeService.mergeLlmSecrets(config.getLlm(), llmConfig);
+        validator.validateLlmConfig(llmConfig, config.getModelRouter());
+        validator.validateModelRouterConfig(config.getModelRouter(), llmConfig);
+        config.setLlm(llmConfig);
+        runtimeConfigService.updateRuntimeConfig(config);
+        return runtimeConfigService.getRuntimeConfigForApi();
+    }
+
+    public RuntimeConfig addLlmProvider(String name, RuntimeConfig.LlmProviderConfig providerConfig) {
+        String normalizedName = validator.normalizeProviderName(name);
+        RuntimeConfig config = runtimeConfigService.getRuntimeConfig();
+        RuntimeConfig.LlmConfig llmConfig = ensureLlmConfig(config);
+        if (llmConfig.getProviders().containsKey(normalizedName)) {
+            throw new IllegalArgumentException("Provider '" + normalizedName + "' already exists");
+        }
+        validator.validateProviderConfig(normalizedName, providerConfig);
+        runtimeConfigService.addLlmProvider(normalizedName, providerConfig);
+        return runtimeConfigService.getRuntimeConfigForApi();
+    }
+
+    public RuntimeConfig updateLlmProvider(String name, RuntimeConfig.LlmProviderConfig providerConfig) {
+        String normalizedName = validator.normalizeProviderName(name);
+        RuntimeConfig config = runtimeConfigService.getRuntimeConfig();
+        RuntimeConfig.LlmConfig llmConfig = ensureLlmConfig(config);
+        if (!llmConfig.getProviders().containsKey(normalizedName)) {
+            throw new IllegalArgumentException("Provider '" + normalizedName + "' does not exist");
+        }
+        validator.validateProviderConfig(normalizedName, providerConfig);
+        runtimeConfigService.updateLlmProvider(normalizedName, providerConfig);
+        return runtimeConfigService.getRuntimeConfigForApi();
+    }
+
+    public void removeLlmProvider(String name) {
+        String normalizedName = validator.normalizeProviderName(name);
+        RuntimeConfig config = runtimeConfigService.getRuntimeConfig();
+        validator.validateProviderRemoval(config.getModelRouter(), normalizedName);
+        boolean removed = runtimeConfigService.removeLlmProvider(normalizedName);
+        if (!removed) {
+            throw new NoSuchElementException("Provider '" + normalizedName + "' not found");
+        }
+    }
+
+    public RuntimeConfig updateToolsConfig(RuntimeConfig.ToolsConfig toolsConfig) {
+        RuntimeConfig config = runtimeConfigService.getRuntimeConfig();
+        validator.normalizeAndValidateShellEnvironmentVariables(toolsConfig);
+        config.setTools(toolsConfig);
+        runtimeConfigService.updateRuntimeConfig(config);
+        return runtimeConfigService.getRuntimeConfigForApi();
+    }
+
+    public List<RuntimeConfig.ShellEnvironmentVariable> getShellEnvironmentVariables() {
+        RuntimeConfig.ToolsConfig toolsConfig = runtimeConfigService.getRuntimeConfigForApi().getTools();
+        return toolsConfig != null && toolsConfig.getShellEnvironmentVariables() != null
+                ? toolsConfig.getShellEnvironmentVariables()
+                : List.of();
+    }
+
+    public RuntimeConfig createShellEnvironmentVariable(RuntimeConfig.ShellEnvironmentVariable variable) {
+        RuntimeConfig config = runtimeConfigService.getRuntimeConfig();
+        RuntimeConfig.ToolsConfig toolsConfig = validator.ensureToolsConfig(config);
+        List<RuntimeConfig.ShellEnvironmentVariable> variables = validator.ensureShellEnvironmentVariables(toolsConfig);
+
+        RuntimeConfig.ShellEnvironmentVariable normalized = validator.normalizeAndValidateShellEnvironmentVariable(
+                variable);
+        if (validator.containsShellEnvironmentVariableName(variables, normalized.getName())) {
+            throw new IllegalArgumentException(
+                    "tools.shellEnvironmentVariables contains duplicate name: " + normalized.getName());
+        }
+        variables.add(normalized);
+        runtimeConfigService.updateRuntimeConfig(config);
+        return runtimeConfigService.getRuntimeConfigForApi();
+    }
+
+    public RuntimeConfig updateShellEnvironmentVariable(String name, RuntimeConfig.ShellEnvironmentVariable variable) {
+        RuntimeConfig config = runtimeConfigService.getRuntimeConfig();
+        RuntimeConfig.ToolsConfig toolsConfig = validator.ensureToolsConfig(config);
+        List<RuntimeConfig.ShellEnvironmentVariable> variables = validator.ensureShellEnvironmentVariables(toolsConfig);
+        String normalizedCurrentName = validator.normalizeAndValidateShellEnvironmentVariableName(name);
+
+        int index = validator.findShellEnvironmentVariableIndex(variables, normalizedCurrentName);
+        if (index < 0) {
+            throw new NoSuchElementException(
+                    "Shell environment variable '" + normalizedCurrentName + "' not found");
+        }
+
+        RuntimeConfig.ShellEnvironmentVariable source = variable != null ? variable
+                : RuntimeConfig.ShellEnvironmentVariable.builder().build();
+        String updatedName = source.getName() == null || source.getName().isBlank()
+                ? normalizedCurrentName
+                : source.getName();
+        RuntimeConfig.ShellEnvironmentVariable normalizedUpdated = validator
+                .normalizeAndValidateShellEnvironmentVariable(
+                        RuntimeConfig.ShellEnvironmentVariable.builder()
+                                .name(updatedName)
+                                .value(source.getValue())
+                                .build());
+
+        if (!normalizedCurrentName.equals(normalizedUpdated.getName())
+                && validator.containsShellEnvironmentVariableName(variables, normalizedUpdated.getName())) {
+            throw new IllegalArgumentException(
+                    "tools.shellEnvironmentVariables contains duplicate name: " + normalizedUpdated.getName());
+        }
+
+        variables.set(index, normalizedUpdated);
+        runtimeConfigService.updateRuntimeConfig(config);
+        return runtimeConfigService.getRuntimeConfigForApi();
+    }
+
+    public RuntimeConfig deleteShellEnvironmentVariable(String name) {
+        RuntimeConfig config = runtimeConfigService.getRuntimeConfig();
+        RuntimeConfig.ToolsConfig toolsConfig = validator.ensureToolsConfig(config);
+        List<RuntimeConfig.ShellEnvironmentVariable> variables = validator.ensureShellEnvironmentVariables(toolsConfig);
+        String normalizedName = validator.normalizeAndValidateShellEnvironmentVariableName(name);
+
+        int index = validator.findShellEnvironmentVariableIndex(variables, normalizedName);
+        if (index < 0) {
+            throw new NoSuchElementException("Shell environment variable '" + normalizedName + "' not found");
+        }
+
+        variables.remove(index);
+        runtimeConfigService.updateRuntimeConfig(config);
+        return runtimeConfigService.getRuntimeConfigForApi();
+    }
+
+    public RuntimeConfig updateVoiceConfig(RuntimeConfig.VoiceConfig voiceConfig) {
+        RuntimeConfig config = runtimeConfigService.getRuntimeConfig();
+        RuntimeConfig.VoiceConfig currentVoiceConfig = config.getVoice() != null
+                ? config.getVoice()
+                : RuntimeConfig.VoiceConfig.builder().build();
+        voiceConfig.setApiKey(mergeService.mergeSecret(currentVoiceConfig.getApiKey(), voiceConfig.getApiKey()));
+        voiceConfig.setWhisperSttApiKey(
+                mergeService.mergeSecret(currentVoiceConfig.getWhisperSttApiKey(), voiceConfig.getWhisperSttApiKey()));
+        validator.validateVoiceConfig(voiceConfig);
+        config.setVoice(voiceConfig);
+        runtimeConfigService.updateRuntimeConfig(config);
+        return runtimeConfigService.getRuntimeConfigForApi();
+    }
+
+    public RuntimeConfig updateTurnConfig(RuntimeConfig.TurnConfig turnConfig) {
+        validator.validateTurnConfig(turnConfig);
+        RuntimeConfig config = runtimeConfigService.getRuntimeConfig();
+        config.setTurn(turnConfig);
+        runtimeConfigService.updateRuntimeConfig(config);
+        return runtimeConfigService.getRuntimeConfigForApi();
+    }
+
+    public RuntimeConfig updateMemoryConfig(RuntimeConfig.MemoryConfig memoryConfig) {
+        validator.validateMemoryConfig(memoryConfig);
+        RuntimeConfig config = runtimeConfigService.getRuntimeConfig();
+        config.setMemory(memoryConfig);
+        runtimeConfigService.updateRuntimeConfig(config);
+        return runtimeConfigService.getRuntimeConfigForApi();
+    }
+
+    public List<MemoryPreset> getMemoryPresets() {
+        return memoryPresetService.getPresets();
+    }
+
+    public RuntimeConfig updateSkillsConfig(RuntimeConfig.SkillsConfig skillsConfig) {
+        RuntimeConfig config = runtimeConfigService.getRuntimeConfig();
+        config.setSkills(skillsConfig);
+        runtimeConfigService.updateRuntimeConfig(config);
+        return runtimeConfigService.getRuntimeConfigForApi();
+    }
+
+    public RuntimeConfig updateUsageConfig(RuntimeConfig.UsageConfig usageConfig) {
+        RuntimeConfig config = runtimeConfigService.getRuntimeConfig();
+        config.setUsage(usageConfig);
+        runtimeConfigService.updateRuntimeConfig(config);
+        return runtimeConfigService.getRuntimeConfigForApi();
+    }
+
+    public RuntimeConfig updateTelemetryConfig(RuntimeConfig.TelemetryConfig telemetryConfig) {
+        RuntimeConfig config = runtimeConfigService.getRuntimeConfig();
+        config.setTelemetry(telemetryConfig);
+        runtimeConfigService.updateRuntimeConfig(config);
+        return runtimeConfigService.getRuntimeConfigForApi();
+    }
+
+    public RuntimeConfig updateMcpConfig(RuntimeConfig.McpConfig mcpConfig) {
+        if (mcpConfig == null) {
+            throw new IllegalArgumentException("mcp config is required");
+        }
+        RuntimeConfig config = runtimeConfigService.getRuntimeConfig();
+        RuntimeConfig.McpConfig existing = config.getMcp();
+        if (existing != null && mcpConfig.getCatalog() == null) {
+            mcpConfig.setCatalog(existing.getCatalog());
+        }
+        config.setMcp(mcpConfig);
+        runtimeConfigService.updateRuntimeConfig(config);
+        return runtimeConfigService.getRuntimeConfigForApi();
+    }
+
+    public List<RuntimeConfig.McpCatalogEntry> getMcpCatalog() {
+        return runtimeConfigService.getMcpCatalog();
+    }
+
+    public RuntimeConfig addMcpCatalogEntry(RuntimeConfig.McpCatalogEntry entry) {
+        validator.validateMcpCatalogEntry(entry);
+        String normalizedName = validator.normalizeCatalogEntryName(entry.getName());
+        entry.setName(normalizedName);
+        List<RuntimeConfig.McpCatalogEntry> catalog = runtimeConfigService.getMcpCatalog();
+        boolean exists = catalog.stream().anyMatch(existingEntry -> normalizedName.equals(existingEntry.getName()));
+        if (exists) {
+            throw new IllegalArgumentException("MCP catalog entry '" + normalizedName + "' already exists");
+        }
+        runtimeConfigService.addMcpCatalogEntry(entry);
+        return runtimeConfigService.getRuntimeConfigForApi();
+    }
+
+    public RuntimeConfig updateMcpCatalogEntry(String name, RuntimeConfig.McpCatalogEntry entry) {
+        String normalizedName = validator.normalizeCatalogEntryName(name);
+        validator.validateMcpCatalogEntry(entry);
+        boolean updated = runtimeConfigService.updateMcpCatalogEntry(normalizedName, entry);
+        if (!updated) {
+            throw new NoSuchElementException("MCP catalog entry '" + normalizedName + "' not found");
+        }
+        return runtimeConfigService.getRuntimeConfigForApi();
+    }
+
+    public void removeMcpCatalogEntry(String name) {
+        String normalizedName = validator.normalizeCatalogEntryName(name);
+        boolean removed = runtimeConfigService.removeMcpCatalogEntry(normalizedName);
+        if (!removed) {
+            throw new NoSuchElementException("MCP catalog entry '" + normalizedName + "' not found");
+        }
+    }
+
+    public RuntimeConfig updateHiveConfig(RuntimeConfig.HiveConfig hiveConfig) {
+        RuntimeConfig config = runtimeConfigService.getRuntimeConfig();
+        validator.rejectManagedHiveMutation(config, hiveConfig, runtimeConfigService.isHiveManagedByProperties());
+        validator.validateHiveConfig(hiveConfig);
+        config.setHive(hiveConfig);
+        runtimeConfigService.updateRuntimeConfig(config);
+        return runtimeConfigService.getRuntimeConfigForApi();
+    }
+
+    public RuntimeConfig updatePlanConfig(RuntimeConfig.PlanConfig planConfig) {
+        validator.validatePlanConfig(planConfig);
+        RuntimeConfig config = runtimeConfigService.getRuntimeConfig();
+        config.setPlan(planConfig);
+        runtimeConfigService.updateRuntimeConfig(config);
+        return runtimeConfigService.getRuntimeConfigForApi();
+    }
+
+    public void updateWebhooksConfig(UserPreferences.WebhookConfig webhookConfig) {
+        UserPreferences prefs = preferencesService.getPreferences();
+        mergeService.mergeWebhookSecrets(prefs.getWebhooks(), webhookConfig);
+        validator.validateWebhookConfig(webhookConfig);
+        prefs.setWebhooks(webhookConfig);
+        preferencesService.savePreferences(prefs);
+    }
+
+    public RuntimeConfig updateAutoConfig(RuntimeConfig.AutoModeConfig autoConfig) {
+        RuntimeConfig config = runtimeConfigService.getRuntimeConfig();
+        validator.validateAndNormalizeAutoModeConfig(autoConfig);
+        config.setAutoMode(autoConfig);
+        runtimeConfigService.updateRuntimeConfig(config);
+        return runtimeConfigService.getRuntimeConfigForApi();
+    }
+
+    public RuntimeConfig updateTracingConfig(RuntimeConfig.TracingConfig tracingConfig) {
+        RuntimeConfig config = runtimeConfigService.getRuntimeConfig();
+        validator.validateAndNormalizeTracingConfig(tracingConfig);
+        config.setTracing(tracingConfig);
+        runtimeConfigService.updateRuntimeConfig(config);
+        return runtimeConfigService.getRuntimeConfigForApi();
+    }
+
+    public RuntimeConfig updateAdvancedConfig(RuntimeConfig.RateLimitConfig rateLimitConfig,
+            RuntimeConfig.SecurityConfig securityConfig,
+            RuntimeConfig.CompactionConfig compactionConfig) {
+        RuntimeConfig config = runtimeConfigService.getRuntimeConfig();
+        if (rateLimitConfig != null) {
+            config.setRateLimit(rateLimitConfig);
+        }
+        if (securityConfig != null) {
+            config.setSecurity(securityConfig);
+        }
+        if (compactionConfig != null) {
+            validator.validateCompactionConfig(compactionConfig);
+            config.setCompaction(compactionConfig);
+        }
+        runtimeConfigService.updateRuntimeConfig(config);
+        return runtimeConfigService.getRuntimeConfig();
+    }
+
+    private RuntimeConfig.LlmConfig ensureLlmConfig(RuntimeConfig config) {
+        RuntimeConfig.LlmConfig llmConfig = config.getLlm();
+        if (llmConfig == null) {
+            llmConfig = RuntimeConfig.LlmConfig.builder()
+                    .providers(new LinkedHashMap<>())
+                    .build();
+            config.setLlm(llmConfig);
+        }
+        if (llmConfig.getProviders() == null) {
+            llmConfig.setProviders(new LinkedHashMap<>());
+        }
+        return llmConfig;
+    }
+}

--- a/src/main/java/me/golemcore/bot/application/settings/RuntimeSettingsMergeService.java
+++ b/src/main/java/me/golemcore/bot/application/settings/RuntimeSettingsMergeService.java
@@ -1,0 +1,169 @@
+package me.golemcore.bot.application.settings;
+
+import me.golemcore.bot.domain.model.RuntimeConfig;
+import me.golemcore.bot.domain.model.Secret;
+import me.golemcore.bot.domain.model.UserPreferences;
+import org.springframework.stereotype.Component;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+@Component
+public class RuntimeSettingsMergeService {
+
+    public RuntimeConfig mergeRuntimeConfigSections(RuntimeConfig current, RuntimeConfig incoming) {
+        RuntimeConfig baseline = current != null ? current : RuntimeConfig.builder().build();
+        RuntimeConfig patch = incoming != null ? incoming : RuntimeConfig.builder().build();
+        return RuntimeConfig.builder()
+                .telegram(mergeSection(patch.getTelegram(), baseline.getTelegram(), RuntimeConfig.TelegramConfig::new))
+                .modelRouter(mergeSection(patch.getModelRouter(), baseline.getModelRouter(),
+                        RuntimeConfig.ModelRouterConfig::new))
+                .llm(mergeSection(patch.getLlm(), baseline.getLlm(), RuntimeConfig.LlmConfig::new))
+                .tools(mergeSection(patch.getTools(), baseline.getTools(), RuntimeConfig.ToolsConfig::new))
+                .voice(mergeSection(patch.getVoice(), baseline.getVoice(), RuntimeConfig.VoiceConfig::new))
+                .autoMode(mergeSection(patch.getAutoMode(), baseline.getAutoMode(), RuntimeConfig.AutoModeConfig::new))
+                .tracing(mergeSection(patch.getTracing(), baseline.getTracing(), RuntimeConfig.TracingConfig::new))
+                .rateLimit(mergeSection(patch.getRateLimit(), baseline.getRateLimit(),
+                        RuntimeConfig.RateLimitConfig::new))
+                .security(mergeSection(patch.getSecurity(), baseline.getSecurity(), RuntimeConfig.SecurityConfig::new))
+                .compaction(mergeSection(patch.getCompaction(), baseline.getCompaction(),
+                        RuntimeConfig.CompactionConfig::new))
+                .turn(mergeSection(patch.getTurn(), baseline.getTurn(), RuntimeConfig.TurnConfig::new))
+                .memory(mergeSection(patch.getMemory(), baseline.getMemory(), RuntimeConfig.MemoryConfig::new))
+                .skills(mergeSection(patch.getSkills(), baseline.getSkills(), RuntimeConfig.SkillsConfig::new))
+                .modelRegistry(mergeSection(patch.getModelRegistry(), baseline.getModelRegistry(),
+                        RuntimeConfig.ModelRegistryConfig::new))
+                .usage(mergeSection(patch.getUsage(), baseline.getUsage(), RuntimeConfig.UsageConfig::new))
+                .telemetry(mergeSection(patch.getTelemetry(), baseline.getTelemetry(),
+                        RuntimeConfig.TelemetryConfig::new))
+                .mcp(mergeSection(patch.getMcp(), baseline.getMcp(), RuntimeConfig.McpConfig::new))
+                .plan(mergeSection(patch.getPlan(), baseline.getPlan(), RuntimeConfig.PlanConfig::new))
+                .delayedActions(mergeSection(patch.getDelayedActions(), baseline.getDelayedActions(),
+                        RuntimeConfig.DelayedActionsConfig::new))
+                .hive(mergeSection(patch.getHive(), baseline.getHive(), RuntimeConfig.HiveConfig::new))
+                .selfEvolving(mergeSelfEvolvingSection(patch.getSelfEvolving(), baseline.getSelfEvolving()))
+                .build();
+    }
+
+    public void mergeRuntimeSecrets(RuntimeConfig current, RuntimeConfig incoming) {
+        if (current == null || incoming == null) {
+            return;
+        }
+        if (incoming.getTelegram() != null && current.getTelegram() != null) {
+            incoming.getTelegram()
+                    .setToken(mergeSecret(current.getTelegram().getToken(), incoming.getTelegram().getToken()));
+        }
+        if (incoming.getVoice() != null && current.getVoice() != null) {
+            incoming.getVoice().setApiKey(mergeSecret(current.getVoice().getApiKey(), incoming.getVoice().getApiKey()));
+            incoming.getVoice().setWhisperSttApiKey(
+                    mergeSecret(current.getVoice().getWhisperSttApiKey(), incoming.getVoice().getWhisperSttApiKey()));
+        }
+        mergeLlmSecrets(current.getLlm(), incoming.getLlm());
+    }
+
+    public void mergeLlmSecrets(RuntimeConfig.LlmConfig current, RuntimeConfig.LlmConfig incoming) {
+        if (current == null || incoming == null || incoming.getProviders() == null) {
+            return;
+        }
+        Map<String, RuntimeConfig.LlmProviderConfig> currentProviders = current.getProviders();
+        for (Map.Entry<String, RuntimeConfig.LlmProviderConfig> entry : incoming.getProviders().entrySet()) {
+            RuntimeConfig.LlmProviderConfig incomingProvider = entry.getValue();
+            RuntimeConfig.LlmProviderConfig currentProvider = currentProviders != null
+                    ? currentProviders.get(entry.getKey())
+                    : null;
+            if (incomingProvider != null && currentProvider != null) {
+                incomingProvider.setApiKey(mergeSecret(currentProvider.getApiKey(), incomingProvider.getApiKey()));
+            }
+        }
+    }
+
+    public void mergeWebhookSecrets(UserPreferences.WebhookConfig current, UserPreferences.WebhookConfig incoming) {
+        if (incoming == null) {
+            return;
+        }
+        if (current != null) {
+            incoming.setToken(mergeSecret(current.getToken(), incoming.getToken()));
+        }
+        if (incoming.getMappings() == null || incoming.getMappings().isEmpty() || current == null
+                || current.getMappings() == null) {
+            return;
+        }
+
+        Map<String, UserPreferences.HookMapping> currentByName = new LinkedHashMap<>();
+        for (UserPreferences.HookMapping mapping : current.getMappings()) {
+            if (mapping != null && mapping.getName() != null) {
+                currentByName.put(mapping.getName(), mapping);
+            }
+        }
+
+        for (UserPreferences.HookMapping mapping : incoming.getMappings()) {
+            if (mapping == null || mapping.getName() == null) {
+                continue;
+            }
+            UserPreferences.HookMapping existing = currentByName.get(mapping.getName());
+            if (existing != null) {
+                mapping.setHmacSecret(mergeSecret(existing.getHmacSecret(), mapping.getHmacSecret()));
+            }
+        }
+    }
+
+    public Secret mergeSecret(Secret current, Secret incoming) {
+        if (incoming == null) {
+            return current;
+        }
+        if (!Secret.hasValue(incoming)) {
+            Secret retained = current != null ? current : Secret.builder().build();
+            if (incoming.getEncrypted() != null) {
+                retained.setEncrypted(incoming.getEncrypted());
+            }
+            retained.setPresent(Secret.hasValue(retained));
+            return retained;
+        }
+        return Secret.builder()
+                .value(incoming.getValue())
+                .encrypted(Boolean.TRUE.equals(incoming.getEncrypted()))
+                .present(true)
+                .build();
+    }
+
+    private RuntimeConfig.SelfEvolvingConfig mergeSelfEvolvingSection(
+            RuntimeConfig.SelfEvolvingConfig patch,
+            RuntimeConfig.SelfEvolvingConfig baseline) {
+        if (patch == null) {
+            return baseline;
+        }
+        preserveSelfEvolvingEmbeddingsApiKey(patch, baseline);
+        return patch;
+    }
+
+    private void preserveSelfEvolvingEmbeddingsApiKey(
+            RuntimeConfig.SelfEvolvingConfig patch,
+            RuntimeConfig.SelfEvolvingConfig baseline) {
+        RuntimeConfig.SelfEvolvingTacticEmbeddingsConfig patchEmbeddings = extractEmbeddings(patch);
+        if (patchEmbeddings == null) {
+            return;
+        }
+        RuntimeConfig.SelfEvolvingTacticEmbeddingsConfig baselineEmbeddings = extractEmbeddings(baseline);
+        Secret baselineKey = baselineEmbeddings != null ? baselineEmbeddings.getApiKey() : null;
+        patchEmbeddings.setApiKey(mergeSecret(baselineKey, patchEmbeddings.getApiKey()));
+    }
+
+    private RuntimeConfig.SelfEvolvingTacticEmbeddingsConfig extractEmbeddings(
+            RuntimeConfig.SelfEvolvingConfig config) {
+        if (config == null || config.getTactics() == null || config.getTactics().getSearch() == null) {
+            return null;
+        }
+        return config.getTactics().getSearch().getEmbeddings();
+    }
+
+    private <T> T mergeSection(T incoming, T current, Supplier<T> emptySupplier) {
+        if (incoming == null) {
+            return current;
+        }
+        if (current == null) {
+            return incoming;
+        }
+        return incoming.equals(emptySupplier.get()) ? current : incoming;
+    }
+}

--- a/src/main/java/me/golemcore/bot/application/settings/RuntimeSettingsValidator.java
+++ b/src/main/java/me/golemcore/bot/application/settings/RuntimeSettingsValidator.java
@@ -1,0 +1,794 @@
+package me.golemcore.bot.application.settings;
+
+import me.golemcore.bot.domain.model.MemoryPreset;
+import me.golemcore.bot.domain.model.ModelTierCatalog;
+import me.golemcore.bot.domain.model.RuntimeConfig;
+import me.golemcore.bot.domain.model.UserPreferences;
+import me.golemcore.bot.domain.service.ModelSelectionService;
+import me.golemcore.bot.plugin.runtime.SttProviderRegistry;
+import me.golemcore.bot.plugin.runtime.TtsProviderRegistry;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.time.Duration;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.regex.Pattern;
+
+@Component
+public class RuntimeSettingsValidator {
+
+    private static final String TELEGRAM_AUTH_MODE_INVITE_ONLY = "invite_only";
+    private static final String STT_PROVIDER_ELEVENLABS = "golemcore/elevenlabs";
+    private static final String STT_PROVIDER_WHISPER = "golemcore/whisper";
+    private static final String LEGACY_STT_PROVIDER_ELEVENLABS = "elevenlabs";
+    private static final String LEGACY_STT_PROVIDER_WHISPER = "whisper";
+    private static final Set<String> VALID_API_TYPES = Set.of("openai", "anthropic", "gemini");
+    private static final String DEFAULT_COMPACTION_TRIGGER_MODE = "model_ratio";
+    private static final String COMPACTION_TRIGGER_MODE_TOKEN_THRESHOLD = "token_threshold";
+    private static final Set<String> VALID_COMPACTION_TRIGGER_MODES = Set.of(
+            DEFAULT_COMPACTION_TRIGGER_MODE,
+            COMPACTION_TRIGGER_MODE_TOKEN_THRESHOLD);
+    private static final double DEFAULT_COMPACTION_MODEL_THRESHOLD_RATIO = 0.95d;
+    private static final int MEMORY_SOFT_BUDGET_MIN = 200;
+    private static final int MEMORY_SOFT_BUDGET_MAX = 10000;
+    private static final int MEMORY_MAX_BUDGET_MIN = 200;
+    private static final int MEMORY_MAX_BUDGET_MAX = 12000;
+    private static final int MEMORY_TOP_K_MIN = 0;
+    private static final int MEMORY_TOP_K_MAX = 30;
+    private static final int MEMORY_DECAY_DAYS_MIN = 1;
+    private static final int MEMORY_DECAY_DAYS_MAX = 3650;
+    private static final int MEMORY_RETRIEVAL_LOOKBACK_DAYS_MIN = 1;
+    private static final int MEMORY_RETRIEVAL_LOOKBACK_DAYS_MAX = 90;
+    private static final Set<String> VALID_MEMORY_DISCLOSURE_MODES = Set.of(
+            "index",
+            "summary",
+            "selective_detail",
+            "full_pack");
+    private static final Set<String> VALID_MEMORY_PROMPT_STYLES = Set.of("compact", "balanced", "rich");
+    private static final Set<String> VALID_MEMORY_RERANKING_PROFILES = Set.of("balanced", "aggressive");
+    private static final Set<String> VALID_MEMORY_DIAGNOSTICS_VERBOSITY = Set.of("off", "basic", "detailed");
+    private static final int TURN_PROGRESS_BATCH_SIZE_MIN = 1;
+    private static final int TURN_PROGRESS_BATCH_SIZE_MAX = 50;
+    private static final int TURN_PROGRESS_MAX_SILENCE_SECONDS_MIN = 1;
+    private static final int TURN_PROGRESS_MAX_SILENCE_SECONDS_MAX = 300;
+    private static final int TURN_PROGRESS_SUMMARY_TIMEOUT_MS_MIN = 1000;
+    private static final int TURN_PROGRESS_SUMMARY_TIMEOUT_MS_MAX = 60000;
+    private static final Pattern SHELL_ENV_VAR_NAME_PATTERN = Pattern.compile("[A-Za-z_][A-Za-z0-9_]*");
+    private static final Set<String> RESERVED_SHELL_ENV_VAR_NAMES = Set.of("HOME", "PWD");
+    private static final int SHELL_ENV_VAR_NAME_MAX_LENGTH = 128;
+    private static final int SHELL_ENV_VAR_VALUE_MAX_LENGTH = 8192;
+
+    private final ModelSelectionService modelSelectionService;
+    private final SttProviderRegistry sttProviderRegistry;
+    private final TtsProviderRegistry ttsProviderRegistry;
+
+    public RuntimeSettingsValidator(ModelSelectionService modelSelectionService,
+            SttProviderRegistry sttProviderRegistry,
+            TtsProviderRegistry ttsProviderRegistry) {
+        this.modelSelectionService = modelSelectionService;
+        this.sttProviderRegistry = sttProviderRegistry;
+        this.ttsProviderRegistry = ttsProviderRegistry;
+    }
+
+    public void validateRuntimeConfigUpdate(RuntimeConfig current, RuntimeConfig merged,
+            boolean hiveManagedByProperties) {
+        if (merged == null) {
+            throw new IllegalArgumentException("runtime config is required");
+        }
+        rejectManagedHiveMutation(current, merged.getHive(), hiveManagedByProperties);
+        if (merged.getTelegram() == null) {
+            merged.setTelegram(new RuntimeConfig.TelegramConfig());
+        }
+        normalizeAndValidateTelegramConfig(merged.getTelegram());
+        normalizeAndValidateShellEnvironmentVariables(merged.getTools());
+        validateLlmConfig(merged.getLlm(), merged.getModelRouter());
+        validateModelRouterConfig(merged.getModelRouter(), merged.getLlm());
+        if (merged.getAutoMode() != null) {
+            validateAndNormalizeAutoModeConfig(merged.getAutoMode());
+        }
+        if (merged.getTracing() != null) {
+            validateAndNormalizeTracingConfig(merged.getTracing());
+        }
+        if (merged.getMemory() != null) {
+            validateMemoryConfig(merged.getMemory());
+        }
+        validateCompactionConfig(merged.getCompaction());
+        validateVoiceConfig(merged.getVoice());
+        validateAndNormalizeModelRegistryConfig(merged.getModelRegistry());
+        validateHiveConfig(merged.getHive());
+    }
+
+    public void validateModelRouterConfig(RuntimeConfig.ModelRouterConfig modelRouterConfig,
+            RuntimeConfig.LlmConfig llmConfig) {
+        if (modelRouterConfig == null) {
+            return;
+        }
+        List<String> configuredProviders = llmConfig != null && llmConfig.getProviders() != null
+                ? new ArrayList<>(llmConfig.getProviders().keySet())
+                : List.of();
+        validateModelRouterBinding(modelRouterConfig.getRouting(), "routing", configuredProviders);
+        if (modelRouterConfig.getTiers() == null) {
+            return;
+        }
+        for (Map.Entry<String, RuntimeConfig.TierBinding> entry : modelRouterConfig.getTiers().entrySet()) {
+            validateModelRouterBinding(entry.getValue(), entry.getKey(), configuredProviders);
+        }
+    }
+
+    public void validateLlmConfig(RuntimeConfig.LlmConfig llmConfig,
+            RuntimeConfig.ModelRouterConfig modelRouterConfig) {
+        if (llmConfig == null) {
+            throw new IllegalArgumentException("llm config is required");
+        }
+
+        Map<String, RuntimeConfig.LlmProviderConfig> providers = llmConfig.getProviders();
+        if (providers == null) {
+            llmConfig.setProviders(new LinkedHashMap<>());
+            return;
+        }
+
+        Set<String> normalizedNames = new LinkedHashSet<>();
+        for (Map.Entry<String, RuntimeConfig.LlmProviderConfig> entry : providers.entrySet()) {
+            String providerName = entry.getKey();
+            RuntimeConfig.LlmProviderConfig providerConfig = entry.getValue();
+
+            if (providerName == null || providerName.isBlank()) {
+                throw new IllegalArgumentException("llm.providers keys must be non-empty");
+            }
+            if (!providerName.equals(providerName.trim())) {
+                throw new IllegalArgumentException("llm.providers keys must not have leading/trailing spaces");
+            }
+            if (!providerName.equals(providerName.toLowerCase(Locale.ROOT))) {
+                throw new IllegalArgumentException("llm.providers keys must be lowercase");
+            }
+            if (!providerName.matches("[a-z0-9][a-z0-9_-]*")) {
+                throw new IllegalArgumentException("llm.providers keys must match [a-z0-9][a-z0-9_-]*");
+            }
+            if (!normalizedNames.add(providerName)) {
+                throw new IllegalArgumentException("llm.providers contains duplicate provider key: " + providerName);
+            }
+            validateProviderConfig(providerName, providerConfig);
+        }
+
+        Set<String> providersUsedByModelRouter = getProvidersUsedByModelRouter(modelRouterConfig);
+        for (String usedProvider : providersUsedByModelRouter) {
+            if (!providers.containsKey(usedProvider)) {
+                throw new IllegalArgumentException(
+                        "Cannot remove provider '" + usedProvider + "' because it is used by model router tiers");
+            }
+        }
+    }
+
+    public void validateProviderConfig(String name, RuntimeConfig.LlmProviderConfig config) {
+        if (config == null) {
+            throw new IllegalArgumentException("Provider config is required");
+        }
+        Integer timeout = config.getRequestTimeoutSeconds();
+        if (timeout != null && (timeout < 1 || timeout > 3600)) {
+            throw new IllegalArgumentException(
+                    "llm.providers." + name + ".requestTimeoutSeconds must be between 1 and 3600");
+        }
+        String baseUrl = config.getBaseUrl();
+        if (baseUrl != null && !baseUrl.isBlank() && !isValidHttpUrl(baseUrl)) {
+            throw new IllegalArgumentException(
+                    "llm.providers." + name + ".baseUrl must be a valid http(s) URL");
+        }
+        String apiType = config.getApiType();
+        if (apiType != null && !apiType.isBlank() && !VALID_API_TYPES.contains(apiType.toLowerCase(Locale.ROOT))) {
+            throw new IllegalArgumentException(
+                    "llm.providers." + name + ".apiType must be one of " + VALID_API_TYPES);
+        }
+    }
+
+    public String normalizeProviderName(String name) {
+        String normalizedName = name.toLowerCase(Locale.ROOT);
+        if (!normalizedName.matches("[a-z0-9][a-z0-9_-]*")) {
+            throw new IllegalArgumentException("Provider name must match [a-z0-9][a-z0-9_-]*");
+        }
+        return normalizedName;
+    }
+
+    public void validateProviderRemoval(RuntimeConfig.ModelRouterConfig modelRouterConfig,
+            String normalizedProviderName) {
+        Set<String> usedProviders = getProvidersUsedByModelRouter(modelRouterConfig);
+        if (usedProviders.contains(normalizedProviderName)) {
+            throw new IllegalArgumentException(
+                    "Cannot remove provider '" + normalizedProviderName + "' because it is used by model router tiers");
+        }
+    }
+
+    public void validateTurnConfig(RuntimeConfig.TurnConfig turnConfig) {
+        if (turnConfig == null) {
+            throw new IllegalArgumentException("turn config is required");
+        }
+        if (turnConfig.getMaxLlmCalls() != null && turnConfig.getMaxLlmCalls() < 1) {
+            throw new IllegalArgumentException("turn.maxLlmCalls must be >= 1");
+        }
+        if (turnConfig.getMaxToolExecutions() != null && turnConfig.getMaxToolExecutions() < 1) {
+            throw new IllegalArgumentException("turn.maxToolExecutions must be >= 1");
+        }
+        if (turnConfig.getDeadline() != null && !turnConfig.getDeadline().isBlank()) {
+            try {
+                Duration deadline = Duration.parse(turnConfig.getDeadline().trim());
+                if (deadline.isZero() || deadline.isNegative()) {
+                    throw new IllegalArgumentException("turn.deadline must be a positive ISO-8601 duration");
+                }
+            } catch (DateTimeParseException e) {
+                throw new IllegalArgumentException("turn.deadline must be a valid ISO-8601 duration");
+            }
+        }
+        validateRange(turnConfig.getProgressBatchSize(), TURN_PROGRESS_BATCH_SIZE_MIN, TURN_PROGRESS_BATCH_SIZE_MAX,
+                "turn.progressBatchSize");
+        validateRange(turnConfig.getProgressMaxSilenceSeconds(),
+                TURN_PROGRESS_MAX_SILENCE_SECONDS_MIN,
+                TURN_PROGRESS_MAX_SILENCE_SECONDS_MAX,
+                "turn.progressMaxSilenceSeconds");
+        validateRange(turnConfig.getProgressSummaryTimeoutMs(),
+                TURN_PROGRESS_SUMMARY_TIMEOUT_MS_MIN,
+                TURN_PROGRESS_SUMMARY_TIMEOUT_MS_MAX,
+                "turn.progressSummaryTimeoutMs");
+    }
+
+    public void validateMemoryConfig(RuntimeConfig.MemoryConfig memoryConfig) {
+        if (memoryConfig == null) {
+            throw new IllegalArgumentException("memory config is required");
+        }
+        if (memoryConfig.getDisclosure() == null) {
+            memoryConfig.setDisclosure(RuntimeConfig.MemoryDisclosureConfig.builder().build());
+        }
+        if (memoryConfig.getReranking() == null) {
+            memoryConfig.setReranking(RuntimeConfig.MemoryRerankingConfig.builder().build());
+        }
+        if (memoryConfig.getDiagnostics() == null) {
+            memoryConfig.setDiagnostics(RuntimeConfig.MemoryDiagnosticsConfig.builder().build());
+        }
+
+        validateNullableInteger(memoryConfig.getSoftPromptBudgetTokens(), MEMORY_SOFT_BUDGET_MIN,
+                MEMORY_SOFT_BUDGET_MAX, "memory.softPromptBudgetTokens");
+        validateNullableInteger(memoryConfig.getMaxPromptBudgetTokens(), MEMORY_MAX_BUDGET_MIN,
+                MEMORY_MAX_BUDGET_MAX, "memory.maxPromptBudgetTokens");
+        validateNullableInteger(memoryConfig.getWorkingTopK(), MEMORY_TOP_K_MIN, MEMORY_TOP_K_MAX,
+                "memory.workingTopK");
+        validateNullableInteger(memoryConfig.getEpisodicTopK(), MEMORY_TOP_K_MIN, MEMORY_TOP_K_MAX,
+                "memory.episodicTopK");
+        validateNullableInteger(memoryConfig.getSemanticTopK(), MEMORY_TOP_K_MIN, MEMORY_TOP_K_MAX,
+                "memory.semanticTopK");
+        validateNullableInteger(memoryConfig.getProceduralTopK(), MEMORY_TOP_K_MIN, MEMORY_TOP_K_MAX,
+                "memory.proceduralTopK");
+        validateNullableDouble(memoryConfig.getPromotionMinConfidence(), 0.0, 1.0, "memory.promotionMinConfidence");
+        validateNullableInteger(memoryConfig.getDecayDays(), MEMORY_DECAY_DAYS_MIN, MEMORY_DECAY_DAYS_MAX,
+                "memory.decayDays");
+        validateNullableInteger(memoryConfig.getRetrievalLookbackDays(), MEMORY_RETRIEVAL_LOOKBACK_DAYS_MIN,
+                MEMORY_RETRIEVAL_LOOKBACK_DAYS_MAX, "memory.retrievalLookbackDays");
+
+        Integer softBudget = memoryConfig.getSoftPromptBudgetTokens();
+        Integer maxBudget = memoryConfig.getMaxPromptBudgetTokens();
+        if (softBudget != null && maxBudget != null && maxBudget < softBudget) {
+            throw new IllegalArgumentException(
+                    "memory.maxPromptBudgetTokens must be greater than or equal to memory.softPromptBudgetTokens");
+        }
+
+        normalizeAndValidateMemoryDisclosureConfig(memoryConfig.getDisclosure());
+        normalizeAndValidateMemoryRerankingConfig(memoryConfig.getReranking());
+        normalizeAndValidateMemoryDiagnosticsConfig(memoryConfig.getDiagnostics());
+    }
+
+    public void validateCompactionConfig(RuntimeConfig.CompactionConfig compactionConfig) {
+        if (compactionConfig == null) {
+            return;
+        }
+        String triggerMode = compactionConfig.getTriggerMode();
+        if (triggerMode == null || triggerMode.isBlank()) {
+            compactionConfig.setTriggerMode(DEFAULT_COMPACTION_TRIGGER_MODE);
+        } else {
+            String normalized = triggerMode.trim().toLowerCase(Locale.ROOT);
+            if (!VALID_COMPACTION_TRIGGER_MODES.contains(normalized)) {
+                throw new IllegalArgumentException(
+                        "compaction.triggerMode must be one of " + VALID_COMPACTION_TRIGGER_MODES);
+            }
+            compactionConfig.setTriggerMode(normalized);
+        }
+
+        Double modelThresholdRatio = compactionConfig.getModelThresholdRatio();
+        if (modelThresholdRatio == null) {
+            compactionConfig.setModelThresholdRatio(DEFAULT_COMPACTION_MODEL_THRESHOLD_RATIO);
+        } else if (modelThresholdRatio <= 0.0d || modelThresholdRatio > 1.0d) {
+            throw new IllegalArgumentException("compaction.modelThresholdRatio must be between 0 and 1");
+        }
+
+        Integer maxContextTokens = compactionConfig.getMaxContextTokens();
+        if (maxContextTokens != null && maxContextTokens < 1) {
+            throw new IllegalArgumentException("compaction.maxContextTokens must be greater than 0");
+        }
+        Integer keepLastMessages = compactionConfig.getKeepLastMessages();
+        if (keepLastMessages != null && keepLastMessages < 1) {
+            throw new IllegalArgumentException("compaction.keepLastMessages must be greater than 0");
+        }
+    }
+
+    public void validateVoiceConfig(RuntimeConfig.VoiceConfig voiceConfig) {
+        if (voiceConfig == null) {
+            return;
+        }
+        boolean voiceEnabled = Boolean.TRUE.equals(voiceConfig.getEnabled());
+
+        String normalizedSttProvider = normalizeProvider(voiceConfig.getSttProvider());
+        if (normalizedSttProvider == null) {
+            normalizedSttProvider = firstLoadedSttProvider();
+        }
+        if (normalizedSttProvider == null && voiceEnabled) {
+            throw new IllegalArgumentException("voice.sttProvider must resolve to a loaded STT provider");
+        }
+        if (normalizedSttProvider != null && !isKnownSttProvider(normalizedSttProvider)) {
+            throw new IllegalArgumentException("voice.sttProvider must resolve to a loaded STT provider");
+        }
+        voiceConfig.setSttProvider(normalizedSttProvider);
+
+        String normalizedTtsProvider = normalizeProvider(voiceConfig.getTtsProvider());
+        if (normalizedTtsProvider == null) {
+            normalizedTtsProvider = firstLoadedTtsProvider();
+        }
+        if (normalizedTtsProvider == null && voiceEnabled) {
+            throw new IllegalArgumentException("voice.ttsProvider must resolve to a loaded TTS provider");
+        }
+        if (normalizedTtsProvider != null && !isKnownTtsProvider(normalizedTtsProvider)) {
+            throw new IllegalArgumentException("voice.ttsProvider must resolve to a loaded TTS provider");
+        }
+        voiceConfig.setTtsProvider(normalizedTtsProvider);
+
+        String whisperSttUrl = voiceConfig.getWhisperSttUrl();
+        if (whisperSttUrl != null && whisperSttUrl.isBlank()) {
+            voiceConfig.setWhisperSttUrl(null);
+        }
+    }
+
+    public void validatePlanConfig(RuntimeConfig.PlanConfig planConfig) {
+        if (planConfig == null) {
+            throw new IllegalArgumentException("plan config is required");
+        }
+        validateNullableInteger(planConfig.getMaxPlans(), 1, 100, "plan.maxPlans");
+        validateNullableInteger(planConfig.getMaxStepsPerPlan(), 1, 1000, "plan.maxStepsPerPlan");
+    }
+
+    public void validateAndNormalizeAutoModeConfig(RuntimeConfig.AutoModeConfig autoConfig) {
+        if (autoConfig == null) {
+            throw new IllegalArgumentException("autoMode config is required");
+        }
+        autoConfig.setModelTier(normalizeOptionalSelectableTier(autoConfig.getModelTier(), "autoMode.modelTier"));
+        autoConfig.setReflectionModelTier(normalizeOptionalSelectableTier(autoConfig.getReflectionModelTier(),
+                "autoMode.reflectionModelTier"));
+    }
+
+    public void validateAndNormalizeTracingConfig(RuntimeConfig.TracingConfig tracingConfig) {
+        if (tracingConfig == null) {
+            throw new IllegalArgumentException("tracing config is required");
+        }
+        validateNullableInteger(tracingConfig.getSessionTraceBudgetMb(), 1, 1024, "tracing.sessionTraceBudgetMb");
+        validateNullableInteger(tracingConfig.getMaxSnapshotSizeKb(), 1, 10240, "tracing.maxSnapshotSizeKb");
+        validateNullableInteger(tracingConfig.getMaxSnapshotsPerSpan(), 1, 1000, "tracing.maxSnapshotsPerSpan");
+        validateNullableInteger(tracingConfig.getMaxTracesPerSession(), 1, 10000, "tracing.maxTracesPerSession");
+    }
+
+    public void validateHiveConfig(RuntimeConfig.HiveConfig hiveConfig) {
+        if (hiveConfig == null) {
+            throw new IllegalArgumentException("hive config is required");
+        }
+        String serverUrl = hiveConfig.getServerUrl();
+        if (serverUrl != null && !serverUrl.isBlank() && !isValidHttpUrl(serverUrl)) {
+            throw new IllegalArgumentException("hive.serverUrl must be a valid http(s) URL");
+        }
+    }
+
+    public void validateAndNormalizeModelRegistryConfig(RuntimeConfig.ModelRegistryConfig modelRegistryConfig) {
+        if (modelRegistryConfig == null) {
+            return;
+        }
+        String repositoryUrl = modelRegistryConfig.getRepositoryUrl();
+        if (repositoryUrl != null) {
+            repositoryUrl = repositoryUrl.trim();
+        }
+        if (repositoryUrl == null || repositoryUrl.isBlank()) {
+            modelRegistryConfig.setRepositoryUrl(null);
+        } else {
+            if (!isValidHttpUrl(repositoryUrl)) {
+                throw new IllegalArgumentException("modelRegistry.repositoryUrl must be a valid http(s) URL");
+            }
+            modelRegistryConfig.setRepositoryUrl(repositoryUrl);
+        }
+
+        String branch = modelRegistryConfig.getBranch();
+        if (branch == null || branch.isBlank()) {
+            modelRegistryConfig.setBranch("main");
+        } else {
+            modelRegistryConfig.setBranch(branch.trim());
+        }
+    }
+
+    public void validateWebhookConfig(UserPreferences.WebhookConfig webhookConfig) {
+        if (webhookConfig == null || webhookConfig.getMappings() == null) {
+            return;
+        }
+        for (UserPreferences.HookMapping mapping : webhookConfig.getMappings()) {
+            if (mapping == null) {
+                continue;
+            }
+            mapping.setModel(normalizeOptionalSelectableTier(mapping.getModel(), "webhooks.mapping.model"));
+        }
+    }
+
+    public RuntimeConfig.ToolsConfig ensureToolsConfig(RuntimeConfig config) {
+        RuntimeConfig.ToolsConfig toolsConfig = config.getTools();
+        if (toolsConfig == null) {
+            toolsConfig = RuntimeConfig.ToolsConfig.builder().build();
+            config.setTools(toolsConfig);
+        }
+        return toolsConfig;
+    }
+
+    public List<RuntimeConfig.ShellEnvironmentVariable> ensureShellEnvironmentVariables(
+            RuntimeConfig.ToolsConfig toolsConfig) {
+        List<RuntimeConfig.ShellEnvironmentVariable> variables = toolsConfig.getShellEnvironmentVariables();
+        if (variables == null) {
+            variables = new ArrayList<>();
+            toolsConfig.setShellEnvironmentVariables(variables);
+        }
+        return variables;
+    }
+
+    public void normalizeAndValidateShellEnvironmentVariables(RuntimeConfig.ToolsConfig toolsConfig) {
+        if (toolsConfig == null) {
+            return;
+        }
+        List<RuntimeConfig.ShellEnvironmentVariable> variables = toolsConfig.getShellEnvironmentVariables();
+        if (variables == null || variables.isEmpty()) {
+            toolsConfig.setShellEnvironmentVariables(new ArrayList<>());
+            return;
+        }
+
+        List<RuntimeConfig.ShellEnvironmentVariable> normalized = new ArrayList<>(variables.size());
+        Set<String> names = new LinkedHashSet<>();
+        for (RuntimeConfig.ShellEnvironmentVariable variable : variables) {
+            RuntimeConfig.ShellEnvironmentVariable normalizedVariable = normalizeAndValidateShellEnvironmentVariable(
+                    variable);
+            if (!names.add(normalizedVariable.getName())) {
+                throw new IllegalArgumentException(
+                        "tools.shellEnvironmentVariables contains duplicate name: " + normalizedVariable.getName());
+            }
+            normalized.add(normalizedVariable);
+        }
+        toolsConfig.setShellEnvironmentVariables(normalized);
+    }
+
+    public RuntimeConfig.ShellEnvironmentVariable normalizeAndValidateShellEnvironmentVariable(
+            RuntimeConfig.ShellEnvironmentVariable variable) {
+        if (variable == null) {
+            throw new IllegalArgumentException("tools.shellEnvironmentVariables item is required");
+        }
+        String normalizedName = normalizeAndValidateShellEnvironmentVariableName(variable.getName());
+        String normalizedValue = normalizeAndValidateShellEnvironmentVariableValue(variable.getValue(), normalizedName);
+        return RuntimeConfig.ShellEnvironmentVariable.builder()
+                .name(normalizedName)
+                .value(normalizedValue)
+                .build();
+    }
+
+    public String normalizeAndValidateShellEnvironmentVariableName(String value) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException("tools.shellEnvironmentVariables.name is required");
+        }
+        String normalized = value.trim();
+        if (normalized.length() > SHELL_ENV_VAR_NAME_MAX_LENGTH) {
+            throw new IllegalArgumentException("tools.shellEnvironmentVariables.name must be at most "
+                    + SHELL_ENV_VAR_NAME_MAX_LENGTH + " characters");
+        }
+        if (!SHELL_ENV_VAR_NAME_PATTERN.matcher(normalized).matches()) {
+            throw new IllegalArgumentException(
+                    "tools.shellEnvironmentVariables.name must match [A-Za-z_][A-Za-z0-9_]*");
+        }
+        if (RESERVED_SHELL_ENV_VAR_NAMES.contains(normalized)) {
+            throw new IllegalArgumentException(
+                    "tools.shellEnvironmentVariables.name must not redefine reserved variable: " + normalized);
+        }
+        return normalized;
+    }
+
+    public boolean containsShellEnvironmentVariableName(List<RuntimeConfig.ShellEnvironmentVariable> variables,
+            String name) {
+        return findShellEnvironmentVariableIndex(variables, name) >= 0;
+    }
+
+    public int findShellEnvironmentVariableIndex(List<RuntimeConfig.ShellEnvironmentVariable> variables, String name) {
+        for (int index = 0; index < variables.size(); index++) {
+            RuntimeConfig.ShellEnvironmentVariable variable = variables.get(index);
+            if (variable != null && name.equals(variable.getName())) {
+                return index;
+            }
+        }
+        return -1;
+    }
+
+    public void validateMcpCatalogEntry(RuntimeConfig.McpCatalogEntry entry) {
+        if (entry == null) {
+            throw new IllegalArgumentException("MCP catalog entry is required");
+        }
+        if (entry.getName() == null || entry.getName().isBlank()) {
+            throw new IllegalArgumentException("MCP catalog entry name is required");
+        }
+        String name = entry.getName().toLowerCase(Locale.ROOT).trim();
+        if (!name.matches("[a-z0-9][a-z0-9_-]*")) {
+            throw new IllegalArgumentException("MCP catalog entry name must match [a-z0-9][a-z0-9_-]*");
+        }
+        if (entry.getCommand() == null || entry.getCommand().isBlank()) {
+            throw new IllegalArgumentException("MCP catalog entry command is required");
+        }
+        Integer startupTimeout = entry.getStartupTimeoutSeconds();
+        if (startupTimeout != null && (startupTimeout < 1 || startupTimeout > 300)) {
+            throw new IllegalArgumentException("startupTimeoutSeconds must be between 1 and 300");
+        }
+        Integer idleTimeout = entry.getIdleTimeoutMinutes();
+        if (idleTimeout != null && (idleTimeout < 1 || idleTimeout > 120)) {
+            throw new IllegalArgumentException("idleTimeoutMinutes must be between 1 and 120");
+        }
+    }
+
+    public String normalizeCatalogEntryName(String value) {
+        return value.toLowerCase(Locale.ROOT).trim();
+    }
+
+    public void rejectManagedHiveMutation(RuntimeConfig current, RuntimeConfig.HiveConfig incomingHiveConfig,
+            boolean hiveManagedByProperties) {
+        if (current == null || !hiveManagedByProperties || incomingHiveConfig == null) {
+            return;
+        }
+        RuntimeConfig.HiveConfig currentHiveConfig = current.getHive();
+        RuntimeConfig.HiveConfig normalizedCurrentHiveConfig = currentHiveConfig != null
+                ? currentHiveConfig
+                : RuntimeConfig.HiveConfig.builder().build();
+        if (!incomingHiveConfig.equals(normalizedCurrentHiveConfig)) {
+            throw new IllegalStateException("Hive settings are managed by bot.hive.* and are read-only");
+        }
+    }
+
+    public String normalizeOptionalSelectableTier(String tier, String fieldName) {
+        String normalizedTier = ModelTierCatalog.normalizeTierId(tier);
+        if (normalizedTier == null) {
+            return null;
+        }
+        if ("default".equals(normalizedTier)) {
+            return null;
+        }
+        return normalizeRequiredSelectableTier(normalizedTier, fieldName);
+    }
+
+    public String normalizeRequiredSelectableTier(String tier, String fieldName) {
+        String normalizedTier = ModelTierCatalog.normalizeTierId(tier);
+        if (!ModelTierCatalog.isExplicitSelectableTier(normalizedTier)) {
+            throw new IllegalArgumentException(fieldName + " must be a known tier id");
+        }
+        return normalizedTier;
+    }
+
+    private void normalizeAndValidateTelegramConfig(RuntimeConfig.TelegramConfig telegramConfig) {
+        telegramConfig.setAuthMode(TELEGRAM_AUTH_MODE_INVITE_ONLY);
+
+        List<String> allowedUsers = telegramConfig.getAllowedUsers();
+        if (allowedUsers == null) {
+            telegramConfig.setAllowedUsers(new ArrayList<>());
+            return;
+        }
+
+        for (String userId : allowedUsers) {
+            if (userId == null || !userId.matches("\\d+")) {
+                throw new IllegalArgumentException("telegram.allowedUsers must contain numeric IDs only");
+            }
+        }
+        if (allowedUsers.size() > 1) {
+            throw new IllegalArgumentException("telegram.allowedUsers supports only one invited user");
+        }
+    }
+
+    private void validateModelRouterBinding(RuntimeConfig.TierBinding binding, String tier,
+            List<String> configuredProviders) {
+        if (binding == null || binding.getModel() == null || binding.getModel().isBlank()) {
+            return;
+        }
+        ModelSelectionService.ValidationResult validation = modelSelectionService.validateModel(
+                binding.getModel(),
+                configuredProviders);
+        if (validation.valid()) {
+            return;
+        }
+        throw switch (validation.error()) {
+        case "model.not.found" -> new IllegalArgumentException(
+                "Model router tier '" + tier + "' points to unknown model '" + binding.getModel() + "'");
+        case "provider.not.configured" -> new IllegalArgumentException(
+                "Model router tier '" + tier + "' points to model '" + binding.getModel()
+                        + "' whose provider is not configured");
+        default -> new IllegalArgumentException(
+                "Model router tier '" + tier + "' is invalid: " + validation.error());
+        };
+    }
+
+    private void validateRange(Integer value, int min, int max, String fieldName) {
+        if (value == null) {
+            return;
+        }
+        if (value < min || value > max) {
+            throw new IllegalArgumentException(fieldName + " must be between " + min + " and " + max);
+        }
+    }
+
+    private void normalizeAndValidateMemoryDisclosureConfig(RuntimeConfig.MemoryDisclosureConfig disclosureConfig) {
+        if (disclosureConfig == null) {
+            return;
+        }
+        disclosureConfig.setMode(normalizeAndValidateMemoryOption(
+                disclosureConfig.getMode(),
+                "summary",
+                VALID_MEMORY_DISCLOSURE_MODES,
+                "memory.disclosure.mode"));
+        disclosureConfig.setPromptStyle(normalizeAndValidateMemoryOption(
+                disclosureConfig.getPromptStyle(),
+                "balanced",
+                VALID_MEMORY_PROMPT_STYLES,
+                "memory.disclosure.promptStyle"));
+        validateNullableDouble(disclosureConfig.getDetailMinScore(), 0.0, 1.0, "memory.disclosure.detailMinScore");
+        if (disclosureConfig.getToolExpansionEnabled() == null) {
+            disclosureConfig.setToolExpansionEnabled(true);
+        }
+        if (disclosureConfig.getDisclosureHintsEnabled() == null) {
+            disclosureConfig.setDisclosureHintsEnabled(true);
+        }
+    }
+
+    private void normalizeAndValidateMemoryDiagnosticsConfig(RuntimeConfig.MemoryDiagnosticsConfig diagnosticsConfig) {
+        if (diagnosticsConfig == null) {
+            return;
+        }
+        diagnosticsConfig.setVerbosity(normalizeAndValidateMemoryOption(
+                diagnosticsConfig.getVerbosity(),
+                "basic",
+                VALID_MEMORY_DIAGNOSTICS_VERBOSITY,
+                "memory.diagnostics.verbosity"));
+    }
+
+    private void normalizeAndValidateMemoryRerankingConfig(RuntimeConfig.MemoryRerankingConfig rerankingConfig) {
+        if (rerankingConfig == null) {
+            return;
+        }
+        rerankingConfig.setProfile(normalizeAndValidateMemoryOption(
+                rerankingConfig.getProfile(),
+                "balanced",
+                VALID_MEMORY_RERANKING_PROFILES,
+                "memory.reranking.profile"));
+        if (rerankingConfig.getEnabled() == null) {
+            rerankingConfig.setEnabled(true);
+        }
+    }
+
+    private void validateNullableInteger(Integer value, int min, int max, String fieldName) {
+        if (value == null) {
+            return;
+        }
+        if (value < min || value > max) {
+            throw new IllegalArgumentException(fieldName + " must be between " + min + " and " + max);
+        }
+    }
+
+    private void validateNullableDouble(Double value, double min, double max, String fieldName) {
+        if (value == null) {
+            return;
+        }
+        if (value < min || value > max) {
+            throw new IllegalArgumentException(fieldName + " must be between " + min + " and " + max);
+        }
+    }
+
+    private String normalizeAndValidateMemoryOption(
+            String value,
+            String defaultValue,
+            Set<String> allowedValues,
+            String fieldName) {
+        String normalized = value == null || value.isBlank()
+                ? defaultValue
+                : value.trim().toLowerCase(Locale.ROOT);
+        if (!allowedValues.contains(normalized)) {
+            throw new IllegalArgumentException(fieldName + " must be one of " + allowedValues);
+        }
+        return normalized;
+    }
+
+    private String normalizeAndValidateShellEnvironmentVariableValue(String value, String normalizedName) {
+        String normalizedValue = value != null ? value : "";
+        if (normalizedValue.length() > SHELL_ENV_VAR_VALUE_MAX_LENGTH) {
+            throw new IllegalArgumentException("tools.shellEnvironmentVariables." + normalizedName
+                    + ".value must be at most " + SHELL_ENV_VAR_VALUE_MAX_LENGTH + " characters");
+        }
+        return normalizedValue;
+    }
+
+    private Set<String> getProvidersUsedByModelRouter(RuntimeConfig.ModelRouterConfig modelRouterConfig) {
+        Set<String> usedProviders = new LinkedHashSet<>();
+        if (modelRouterConfig == null) {
+            return usedProviders;
+        }
+        RuntimeConfig.TierBinding routingBinding = modelRouterConfig.getRouting();
+        if (routingBinding != null) {
+            addProviderFromModel(usedProviders, routingBinding.getModel());
+        }
+        if (modelRouterConfig.getTiers() != null) {
+            for (RuntimeConfig.TierBinding tierBinding : modelRouterConfig.getTiers().values()) {
+                if (tierBinding != null) {
+                    addProviderFromModel(usedProviders, tierBinding.getModel());
+                }
+            }
+        }
+        return usedProviders;
+    }
+
+    private void addProviderFromModel(Set<String> usedProviders, String model) {
+        if (model == null || model.isBlank()) {
+            return;
+        }
+        String resolvedProvider = modelSelectionService.resolveProviderForModel(model);
+        if (resolvedProvider != null) {
+            usedProviders.add(resolvedProvider);
+            return;
+        }
+        int delimiterIndex = model.indexOf('/');
+        if (delimiterIndex <= 0) {
+            return;
+        }
+        usedProviders.add(model.substring(0, delimiterIndex));
+    }
+
+    private String normalizeProvider(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        String normalized = value.trim().toLowerCase(Locale.ROOT);
+        if (LEGACY_STT_PROVIDER_ELEVENLABS.equals(normalized)) {
+            return STT_PROVIDER_ELEVENLABS;
+        }
+        if (LEGACY_STT_PROVIDER_WHISPER.equals(normalized)) {
+            return STT_PROVIDER_WHISPER;
+        }
+        return normalized;
+    }
+
+    private boolean isKnownSttProvider(String providerId) {
+        return providerId != null && sttProviderRegistry.find(providerId).isPresent();
+    }
+
+    private boolean isKnownTtsProvider(String providerId) {
+        return providerId != null && ttsProviderRegistry.find(providerId).isPresent();
+    }
+
+    private String firstLoadedSttProvider() {
+        return sttProviderRegistry.listProviderIds().keySet().stream().findFirst().orElse(null);
+    }
+
+    private String firstLoadedTtsProvider() {
+        return ttsProviderRegistry.listProviderIds().keySet().stream().findFirst().orElse(null);
+    }
+
+    private boolean isValidHttpUrl(String value) {
+        try {
+            URI uri = new URI(value);
+            String scheme = uri.getScheme();
+            String host = uri.getHost();
+            return host != null && ("http".equalsIgnoreCase(scheme) || "https".equalsIgnoreCase(scheme));
+        } catch (URISyntaxException ignored) {
+            return false;
+        }
+    }
+}

--- a/src/test/java/me/golemcore/bot/adapter/inbound/web/controller/SettingsControllerTest.java
+++ b/src/test/java/me/golemcore/bot/adapter/inbound/web/controller/SettingsControllerTest.java
@@ -22,9 +22,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -44,6 +46,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 class SettingsControllerTest {
@@ -2356,6 +2359,88 @@ class SettingsControllerTest {
         assertNotNull(incomingMcp.getCatalog());
         assertEquals(1, incomingMcp.getCatalog().size());
         assertEquals("github", incomingMcp.getCatalog().get(0).getName());
+    }
+
+    @Test
+    void shouldGetRuntimeConfigFromFacade() {
+        RuntimeConfig apiView = RuntimeConfig.builder().build();
+        when(runtimeConfigService.getRuntimeConfigForApi()).thenReturn(apiView);
+
+        StepVerifier.create(controller.getRuntimeConfig())
+                .assertNext(response -> {
+                    assertEquals(HttpStatus.OK, response.getStatusCode());
+                    assertEquals(apiView, response.getBody());
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void shouldDelegateRuntimeEndpointUpdates() {
+        RuntimeConfig current = RuntimeConfig.builder()
+                .llm(RuntimeConfig.LlmConfig.builder()
+                        .providers(new LinkedHashMap<>(Map.of("openai",
+                                RuntimeConfig.LlmProviderConfig.builder().build())))
+                        .build())
+                .build();
+        RuntimeConfig apiView = RuntimeConfig.builder().build();
+        when(runtimeConfigService.getRuntimeConfig()).thenReturn(current);
+        when(runtimeConfigService.getRuntimeConfigForApi()).thenReturn(apiView);
+        when(runtimeConfigService.removeLlmProvider("openai")).thenReturn(true);
+        when(preferencesService.getPreferences()).thenReturn(new UserPreferences());
+
+        StepVerifier.create(controller.updateModelRouterConfig(RuntimeConfig.ModelRouterConfig.builder().build()))
+                .assertNext(response -> assertEquals(HttpStatus.OK, response.getStatusCode()))
+                .verifyComplete();
+        StepVerifier.create(controller.updateLlmProvider("openai", RuntimeConfig.LlmProviderConfig.builder()
+                .requestTimeoutSeconds(30)
+                .build()))
+                .assertNext(response -> assertEquals(HttpStatus.OK, response.getStatusCode()))
+                .verifyComplete();
+        StepVerifier.create(controller.removeLlmProvider("openai"))
+                .assertNext(response -> assertEquals(HttpStatus.OK, response.getStatusCode()))
+                .verifyComplete();
+        StepVerifier.create(controller.updateToolsConfig(RuntimeConfig.ToolsConfig.builder().build()))
+                .assertNext(response -> assertEquals(HttpStatus.OK, response.getStatusCode()))
+                .verifyComplete();
+        StepVerifier.create(controller.updateSkillsConfig(RuntimeConfig.SkillsConfig.builder().build()))
+                .assertNext(response -> assertEquals(HttpStatus.OK, response.getStatusCode()))
+                .verifyComplete();
+        StepVerifier.create(controller.updateUsageConfig(RuntimeConfig.UsageConfig.builder().build()))
+                .assertNext(response -> assertEquals(HttpStatus.OK, response.getStatusCode()))
+                .verifyComplete();
+        StepVerifier.create(controller.updateTelemetryConfig(RuntimeConfig.TelemetryConfig.builder().build()))
+                .assertNext(response -> assertEquals(HttpStatus.OK, response.getStatusCode()))
+                .verifyComplete();
+        StepVerifier.create(controller.updateWebhooksConfig(UserPreferences.WebhookConfig.builder().build()))
+                .assertNext(response -> assertEquals(HttpStatus.OK, response.getStatusCode()))
+                .verifyComplete();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldDelegateAdvancedConfigUpdate() throws Exception {
+        RuntimeConfig current = RuntimeConfig.builder().build();
+        RuntimeConfig apiView = RuntimeConfig.builder().build();
+        when(runtimeConfigService.getRuntimeConfig()).thenReturn(current);
+        when(runtimeConfigService.getRuntimeConfigForApi()).thenReturn(apiView);
+        Class<?> requestType = Class.forName(SettingsController.class.getName() + "$AdvancedConfigRequest");
+        var constructor = requestType.getDeclaredConstructor(
+                RuntimeConfig.RateLimitConfig.class,
+                RuntimeConfig.SecurityConfig.class,
+                RuntimeConfig.CompactionConfig.class);
+        constructor.setAccessible(true);
+        Object request = constructor.newInstance(
+                RuntimeConfig.RateLimitConfig.builder().build(),
+                RuntimeConfig.SecurityConfig.builder().build(),
+                RuntimeConfig.CompactionConfig.builder().build());
+        Method method = SettingsController.class.getMethod("updateAdvancedConfig", requestType);
+
+        Mono<ResponseEntity<RuntimeConfig>> response = (Mono<ResponseEntity<RuntimeConfig>>) method.invoke(controller,
+                request);
+
+        StepVerifier.create(response)
+                .assertNext(result -> assertEquals(HttpStatus.OK, result.getStatusCode()))
+                .verifyComplete();
     }
 
     @Test

--- a/src/test/java/me/golemcore/bot/adapter/inbound/web/controller/SettingsControllerTest.java
+++ b/src/test/java/me/golemcore/bot/adapter/inbound/web/controller/SettingsControllerTest.java
@@ -2,6 +2,9 @@ package me.golemcore.bot.adapter.inbound.web.controller;
 
 import me.golemcore.bot.adapter.inbound.web.dto.PreferencesUpdateRequest;
 import me.golemcore.bot.adapter.inbound.web.dto.SettingsResponse;
+import me.golemcore.bot.application.settings.RuntimeSettingsFacade;
+import me.golemcore.bot.application.settings.RuntimeSettingsMergeService;
+import me.golemcore.bot.application.settings.RuntimeSettingsValidator;
 import me.golemcore.bot.domain.model.MemoryPreset;
 import me.golemcore.bot.domain.model.RuntimeConfig;
 import me.golemcore.bot.domain.model.Secret;
@@ -65,8 +68,7 @@ class SettingsControllerTest {
         registerSttProvider("golemcore/whisper", "whisper");
         registerTtsProvider("golemcore/elevenlabs", "elevenlabs");
         registerTtsProvider("golemcore/whisper", "whisper");
-        controller = new SettingsController(preferencesService, modelSelectionService, runtimeConfigService,
-                memoryPresetService, sttProviderRegistry, ttsProviderRegistry);
+        controller = createController(sttProviderRegistry, ttsProviderRegistry);
         when(runtimeConfigService.getRuntimeConfigForApi()).thenReturn(RuntimeConfig.builder().build());
         when(runtimeConfigService.isHiveManagedByProperties()).thenReturn(false);
         when(modelSelectionService.validateModel(anyString(), anyList()))
@@ -79,6 +81,16 @@ class SettingsControllerTest {
             int delimiterIndex = model.indexOf('/');
             return delimiterIndex > 0 ? model.substring(0, delimiterIndex) : null;
         });
+    }
+
+    private SettingsController createController(SttProviderRegistry sttRegistry, TtsProviderRegistry ttsRegistry) {
+        RuntimeSettingsFacade runtimeSettingsFacade = new RuntimeSettingsFacade(
+                runtimeConfigService,
+                preferencesService,
+                memoryPresetService,
+                new RuntimeSettingsValidator(modelSelectionService, sttRegistry, ttsRegistry),
+                new RuntimeSettingsMergeService());
+        return new SettingsController(preferencesService, modelSelectionService, runtimeSettingsFacade);
     }
 
     @Test
@@ -1645,13 +1657,7 @@ class SettingsControllerTest {
 
     @Test
     void shouldRejectUnloadedVoiceProvidersEvenWhenCanonicalIdsAreUsed() {
-        SettingsController unloadedController = new SettingsController(
-                preferencesService,
-                modelSelectionService,
-                runtimeConfigService,
-                memoryPresetService,
-                new SttProviderRegistry(),
-                new TtsProviderRegistry());
+        SettingsController unloadedController = createController(new SttProviderRegistry(), new TtsProviderRegistry());
         RuntimeConfig runtimeConfig = RuntimeConfig.builder()
                 .voice(RuntimeConfig.VoiceConfig.builder().build())
                 .build();
@@ -1789,13 +1795,7 @@ class SettingsControllerTest {
 
     @Test
     void shouldAllowDisabledVoiceConfigWhenNoVoiceProvidersAreLoaded() {
-        SettingsController unloadedController = new SettingsController(
-                preferencesService,
-                modelSelectionService,
-                runtimeConfigService,
-                memoryPresetService,
-                new SttProviderRegistry(),
-                new TtsProviderRegistry());
+        SettingsController unloadedController = createController(new SttProviderRegistry(), new TtsProviderRegistry());
         RuntimeConfig runtimeConfig = RuntimeConfig.builder()
                 .voice(RuntimeConfig.VoiceConfig.builder()
                         .enabled(false)

--- a/src/test/java/me/golemcore/bot/application/settings/RuntimeSettingsFacadeTest.java
+++ b/src/test/java/me/golemcore/bot/application/settings/RuntimeSettingsFacadeTest.java
@@ -3,6 +3,7 @@ package me.golemcore.bot.application.settings;
 import me.golemcore.bot.domain.model.Secret;
 import me.golemcore.bot.domain.model.UserPreferences;
 import me.golemcore.bot.domain.model.RuntimeConfig;
+import me.golemcore.bot.domain.model.MemoryPreset;
 import me.golemcore.bot.domain.service.MemoryPresetService;
 import me.golemcore.bot.domain.service.ModelSelectionService;
 import me.golemcore.bot.domain.service.RuntimeConfigService;
@@ -18,6 +19,7 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -107,6 +109,63 @@ class RuntimeSettingsFacadeTest {
     }
 
     @Test
+    void shouldUpdateModelRouterConfigAndReturnApiView() {
+        RuntimeConfig current = RuntimeConfig.builder()
+                .llm(RuntimeConfig.LlmConfig.builder()
+                        .providers(new java.util.LinkedHashMap<>(Map.of("openai",
+                                RuntimeConfig.LlmProviderConfig.builder().build())))
+                        .build())
+                .build();
+        RuntimeConfig apiView = RuntimeConfig.builder().build();
+        RuntimeConfig.ModelRouterConfig update = RuntimeConfig.ModelRouterConfig.builder().build();
+        when(runtimeConfigService.getRuntimeConfig()).thenReturn(current);
+        when(runtimeConfigService.getRuntimeConfigForApi()).thenReturn(apiView);
+
+        RuntimeConfig response = facade.updateModelRouterConfig(update);
+
+        assertEquals(apiView, response);
+        assertEquals(update, current.getModelRouter());
+        verify(runtimeConfigService).updateRuntimeConfig(current);
+    }
+
+    @Test
+    void shouldRejectAddingDuplicateProvider() {
+        RuntimeConfig current = RuntimeConfig.builder()
+                .llm(RuntimeConfig.LlmConfig.builder()
+                        .providers(new java.util.LinkedHashMap<>(Map.of("openai",
+                                RuntimeConfig.LlmProviderConfig.builder().build())))
+                        .build())
+                .build();
+        when(runtimeConfigService.getRuntimeConfig()).thenReturn(current);
+
+        IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
+                () -> facade.addLlmProvider("openai", RuntimeConfig.LlmProviderConfig.builder().build()));
+
+        assertTrue(error.getMessage().contains("already exists"));
+    }
+
+    @Test
+    void shouldUpdateExistingProviderAndReturnApiView() {
+        RuntimeConfig current = RuntimeConfig.builder()
+                .llm(RuntimeConfig.LlmConfig.builder()
+                        .providers(new java.util.LinkedHashMap<>(Map.of("openai",
+                                RuntimeConfig.LlmProviderConfig.builder().build())))
+                        .build())
+                .build();
+        RuntimeConfig apiView = RuntimeConfig.builder().build();
+        RuntimeConfig.LlmProviderConfig update = RuntimeConfig.LlmProviderConfig.builder()
+                .requestTimeoutSeconds(30)
+                .build();
+        when(runtimeConfigService.getRuntimeConfig()).thenReturn(current);
+        when(runtimeConfigService.getRuntimeConfigForApi()).thenReturn(apiView);
+
+        RuntimeConfig response = facade.updateLlmProvider("openai", update);
+
+        assertEquals(apiView, response);
+        verify(runtimeConfigService).updateLlmProvider("openai", update);
+    }
+
+    @Test
     void shouldThrowWhenRemovingUnknownProvider() {
         RuntimeConfig current = RuntimeConfig.builder()
                 .modelRouter(RuntimeConfig.ModelRouterConfig.builder().build())
@@ -122,6 +181,21 @@ class RuntimeSettingsFacadeTest {
         when(runtimeConfigService.getRuntimeConfigForApi()).thenReturn(RuntimeConfig.builder().build());
 
         assertEquals(List.of(), facade.getShellEnvironmentVariables());
+    }
+
+    @Test
+    void shouldUpdateToolsConfigAndReturnApiView() {
+        RuntimeConfig current = RuntimeConfig.builder().build();
+        RuntimeConfig apiView = RuntimeConfig.builder().build();
+        RuntimeConfig.ToolsConfig update = RuntimeConfig.ToolsConfig.builder().build();
+        when(runtimeConfigService.getRuntimeConfig()).thenReturn(current);
+        when(runtimeConfigService.getRuntimeConfigForApi()).thenReturn(apiView);
+
+        RuntimeConfig response = facade.updateToolsConfig(update);
+
+        assertEquals(apiView, response);
+        assertEquals(update, current.getTools());
+        verify(runtimeConfigService).updateRuntimeConfig(current);
     }
 
     @Test
@@ -209,5 +283,26 @@ class RuntimeSettingsFacadeTest {
         assertEquals(security, current.getSecurity());
         assertEquals(compaction, current.getCompaction());
         verify(runtimeConfigService).updateRuntimeConfig(current);
+    }
+
+    @Test
+    void shouldReturnMemoryPresetsAndUpdatePassiveRuntimeSections() {
+        RuntimeConfig current = RuntimeConfig.builder().build();
+        RuntimeConfig apiView = RuntimeConfig.builder().build();
+        RuntimeConfig.SkillsConfig skills = RuntimeConfig.SkillsConfig.builder().build();
+        RuntimeConfig.UsageConfig usage = RuntimeConfig.UsageConfig.builder().build();
+        RuntimeConfig.TelemetryConfig telemetry = RuntimeConfig.TelemetryConfig.builder().build();
+        List<MemoryPreset> presets = List.of(MemoryPreset.builder().id("default").label("Default").build());
+        when(memoryPresetService.getPresets()).thenReturn(presets);
+        when(runtimeConfigService.getRuntimeConfig()).thenReturn(current);
+        when(runtimeConfigService.getRuntimeConfigForApi()).thenReturn(apiView);
+
+        assertEquals(presets, facade.getMemoryPresets());
+        assertEquals(apiView, facade.updateSkillsConfig(skills));
+        assertEquals(apiView, facade.updateUsageConfig(usage));
+        assertEquals(apiView, facade.updateTelemetryConfig(telemetry));
+        assertEquals(skills, current.getSkills());
+        assertEquals(usage, current.getUsage());
+        assertEquals(telemetry, current.getTelemetry());
     }
 }

--- a/src/test/java/me/golemcore/bot/application/settings/RuntimeSettingsFacadeTest.java
+++ b/src/test/java/me/golemcore/bot/application/settings/RuntimeSettingsFacadeTest.java
@@ -1,5 +1,7 @@
 package me.golemcore.bot.application.settings;
 
+import me.golemcore.bot.domain.model.Secret;
+import me.golemcore.bot.domain.model.UserPreferences;
 import me.golemcore.bot.domain.model.RuntimeConfig;
 import me.golemcore.bot.domain.service.MemoryPresetService;
 import me.golemcore.bot.domain.service.ModelSelectionService;
@@ -10,6 +12,11 @@ import me.golemcore.bot.plugin.runtime.TtsProviderRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
@@ -20,13 +27,15 @@ import static org.mockito.Mockito.when;
 class RuntimeSettingsFacadeTest {
 
     private RuntimeConfigService runtimeConfigService;
+    private UserPreferencesService preferencesService;
+    private MemoryPresetService memoryPresetService;
     private RuntimeSettingsFacade facade;
 
     @BeforeEach
     void setUp() {
         runtimeConfigService = mock(RuntimeConfigService.class);
-        UserPreferencesService preferencesService = mock(UserPreferencesService.class);
-        MemoryPresetService memoryPresetService = mock(MemoryPresetService.class);
+        preferencesService = mock(UserPreferencesService.class);
+        memoryPresetService = mock(MemoryPresetService.class);
         ModelSelectionService modelSelectionService = mock(ModelSelectionService.class);
         RuntimeSettingsValidator validator = new RuntimeSettingsValidator(
                 modelSelectionService,
@@ -59,5 +68,146 @@ class RuntimeSettingsFacadeTest {
         assertThrows(IllegalStateException.class, () -> facade.updateRuntimeConfig(incoming));
 
         verify(runtimeConfigService, never()).updateRuntimeConfig(any());
+    }
+
+    @Test
+    void shouldDelegateGetRuntimeConfigForApi() {
+        RuntimeConfig config = RuntimeConfig.builder().build();
+        when(runtimeConfigService.getRuntimeConfigForApi()).thenReturn(config);
+
+        assertEquals(config, facade.getRuntimeConfigForApi());
+    }
+
+    @Test
+    void shouldInitializeMissingLlmConfigWhenAddingProvider() {
+        RuntimeConfig current = RuntimeConfig.builder().build();
+        RuntimeConfig apiView = RuntimeConfig.builder().build();
+        RuntimeConfig.LlmProviderConfig providerConfig = RuntimeConfig.LlmProviderConfig.builder().build();
+        when(runtimeConfigService.getRuntimeConfig()).thenReturn(current);
+        when(runtimeConfigService.getRuntimeConfigForApi()).thenReturn(apiView);
+
+        RuntimeConfig response = facade.addLlmProvider("openai", providerConfig);
+
+        assertEquals(apiView, response);
+        assertEquals(Map.of(), current.getLlm().getProviders());
+        verify(runtimeConfigService).addLlmProvider("openai", providerConfig);
+    }
+
+    @Test
+    void shouldRejectUpdatingUnknownProvider() {
+        RuntimeConfig current = RuntimeConfig.builder()
+                .llm(RuntimeConfig.LlmConfig.builder().providers(new java.util.LinkedHashMap<>()).build())
+                .build();
+        when(runtimeConfigService.getRuntimeConfig()).thenReturn(current);
+
+        IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
+                () -> facade.updateLlmProvider("openai", RuntimeConfig.LlmProviderConfig.builder().build()));
+
+        assertEquals("Provider 'openai' does not exist", error.getMessage());
+    }
+
+    @Test
+    void shouldThrowWhenRemovingUnknownProvider() {
+        RuntimeConfig current = RuntimeConfig.builder()
+                .modelRouter(RuntimeConfig.ModelRouterConfig.builder().build())
+                .build();
+        when(runtimeConfigService.getRuntimeConfig()).thenReturn(current);
+        when(runtimeConfigService.removeLlmProvider("openai")).thenReturn(false);
+
+        assertThrows(java.util.NoSuchElementException.class, () -> facade.removeLlmProvider("openai"));
+    }
+
+    @Test
+    void shouldDefaultToEmptyShellEnvironmentVariableList() {
+        when(runtimeConfigService.getRuntimeConfigForApi()).thenReturn(RuntimeConfig.builder().build());
+
+        assertEquals(List.of(), facade.getShellEnvironmentVariables());
+    }
+
+    @Test
+    void shouldPreserveExistingMcpCatalogWhenIncomingCatalogMissing() {
+        RuntimeConfig.McpCatalogEntry entry = RuntimeConfig.McpCatalogEntry.builder()
+                .name("filesystem")
+                .command("npx")
+                .build();
+        RuntimeConfig current = RuntimeConfig.builder()
+                .mcp(RuntimeConfig.McpConfig.builder().catalog(List.of(entry)).build())
+                .build();
+        RuntimeConfig.McpConfig incoming = RuntimeConfig.McpConfig.builder().enabled(true).build();
+        RuntimeConfig apiView = RuntimeConfig.builder().build();
+        when(runtimeConfigService.getRuntimeConfig()).thenReturn(current);
+        when(runtimeConfigService.getRuntimeConfigForApi()).thenReturn(apiView);
+
+        RuntimeConfig response = facade.updateMcpConfig(incoming);
+
+        assertEquals(apiView, response);
+        assertEquals(List.of(entry), incoming.getCatalog());
+        verify(runtimeConfigService).updateRuntimeConfig(current);
+    }
+
+    @Test
+    void shouldRejectNullMcpConfig() {
+        assertThrows(IllegalArgumentException.class, () -> facade.updateMcpConfig(null));
+    }
+
+    @Test
+    void shouldMergeWebhookSecretsBeforeSavingPreferences() {
+        UserPreferences prefs = new UserPreferences();
+        prefs.setWebhooks(UserPreferences.WebhookConfig.builder()
+                .token(Secret.of("bearer-secret"))
+                .mappings(List.of(UserPreferences.HookMapping.builder()
+                        .name("build")
+                        .hmacSecret(Secret.of("hmac-secret"))
+                        .build()))
+                .build());
+        UserPreferences.WebhookConfig incoming = UserPreferences.WebhookConfig.builder()
+                .token(Secret.builder().build())
+                .mappings(List.of(UserPreferences.HookMapping.builder()
+                        .name("build")
+                        .hmacSecret(Secret.builder().build())
+                        .build()))
+                .build();
+        when(preferencesService.getPreferences()).thenReturn(prefs);
+
+        facade.updateWebhooksConfig(incoming);
+
+        assertEquals("bearer-secret", incoming.getToken().getValue());
+        assertEquals("hmac-secret", incoming.getMappings().getFirst().getHmacSecret().getValue());
+        verify(preferencesService).savePreferences(prefs);
+    }
+
+    @Test
+    void shouldCreateDefaultVoiceConfigWhenCurrentVoiceMissing() {
+        RuntimeConfig current = RuntimeConfig.builder().build();
+        RuntimeConfig apiView = RuntimeConfig.builder().build();
+        RuntimeConfig.VoiceConfig update = RuntimeConfig.VoiceConfig.builder()
+                .enabled(false)
+                .build();
+        when(runtimeConfigService.getRuntimeConfig()).thenReturn(current);
+        when(runtimeConfigService.getRuntimeConfigForApi()).thenReturn(apiView);
+
+        RuntimeConfig response = facade.updateVoiceConfig(update);
+
+        assertEquals(apiView, response);
+        assertNull(update.getApiKey());
+        assertNull(update.getWhisperSttApiKey());
+        verify(runtimeConfigService).updateRuntimeConfig(current);
+    }
+
+    @Test
+    void shouldApplyAdvancedConfigSections() {
+        RuntimeConfig current = RuntimeConfig.builder().build();
+        RuntimeConfig.RateLimitConfig rateLimit = RuntimeConfig.RateLimitConfig.builder().build();
+        RuntimeConfig.SecurityConfig security = RuntimeConfig.SecurityConfig.builder().build();
+        RuntimeConfig.CompactionConfig compaction = RuntimeConfig.CompactionConfig.builder().build();
+        when(runtimeConfigService.getRuntimeConfig()).thenReturn(current);
+
+        RuntimeConfig response = facade.updateAdvancedConfig(rateLimit, security, compaction);
+
+        assertEquals(current, response);
+        assertEquals(rateLimit, current.getRateLimit());
+        assertEquals(security, current.getSecurity());
+        assertEquals(compaction, current.getCompaction());
+        verify(runtimeConfigService).updateRuntimeConfig(current);
     }
 }

--- a/src/test/java/me/golemcore/bot/application/settings/RuntimeSettingsFacadeTest.java
+++ b/src/test/java/me/golemcore/bot/application/settings/RuntimeSettingsFacadeTest.java
@@ -1,0 +1,63 @@
+package me.golemcore.bot.application.settings;
+
+import me.golemcore.bot.domain.model.RuntimeConfig;
+import me.golemcore.bot.domain.service.MemoryPresetService;
+import me.golemcore.bot.domain.service.ModelSelectionService;
+import me.golemcore.bot.domain.service.RuntimeConfigService;
+import me.golemcore.bot.domain.service.UserPreferencesService;
+import me.golemcore.bot.plugin.runtime.SttProviderRegistry;
+import me.golemcore.bot.plugin.runtime.TtsProviderRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class RuntimeSettingsFacadeTest {
+
+    private RuntimeConfigService runtimeConfigService;
+    private RuntimeSettingsFacade facade;
+
+    @BeforeEach
+    void setUp() {
+        runtimeConfigService = mock(RuntimeConfigService.class);
+        UserPreferencesService preferencesService = mock(UserPreferencesService.class);
+        MemoryPresetService memoryPresetService = mock(MemoryPresetService.class);
+        ModelSelectionService modelSelectionService = mock(ModelSelectionService.class);
+        RuntimeSettingsValidator validator = new RuntimeSettingsValidator(
+                modelSelectionService,
+                new SttProviderRegistry(),
+                new TtsProviderRegistry());
+        RuntimeSettingsMergeService mergeService = new RuntimeSettingsMergeService();
+        facade = new RuntimeSettingsFacade(
+                runtimeConfigService,
+                preferencesService,
+                memoryPresetService,
+                validator,
+                mergeService);
+    }
+
+    @Test
+    void shouldRejectManagedHiveMutationBeforePersistingRuntimeConfig() {
+        RuntimeConfig current = RuntimeConfig.builder()
+                .hive(RuntimeConfig.HiveConfig.builder()
+                        .enabled(false)
+                        .build())
+                .build();
+        RuntimeConfig incoming = RuntimeConfig.builder()
+                .hive(RuntimeConfig.HiveConfig.builder()
+                        .enabled(true)
+                        .build())
+                .build();
+        when(runtimeConfigService.getRuntimeConfig()).thenReturn(current);
+        when(runtimeConfigService.isHiveManagedByProperties()).thenReturn(true);
+
+        assertThrows(IllegalStateException.class, () -> facade.updateRuntimeConfig(incoming));
+
+        verify(runtimeConfigService, never()).updateRuntimeConfig(any());
+    }
+}

--- a/src/test/java/me/golemcore/bot/application/settings/RuntimeSettingsMergeServiceTest.java
+++ b/src/test/java/me/golemcore/bot/application/settings/RuntimeSettingsMergeServiceTest.java
@@ -1,0 +1,136 @@
+package me.golemcore.bot.application.settings;
+
+import me.golemcore.bot.domain.model.RuntimeConfig;
+import me.golemcore.bot.domain.model.Secret;
+import me.golemcore.bot.domain.model.UserPreferences;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RuntimeSettingsMergeServiceTest {
+
+    private final RuntimeSettingsMergeService mergeService = new RuntimeSettingsMergeService();
+
+    @Test
+    void shouldMergeWebhookSecretsFromExistingPreferences() {
+        UserPreferences.WebhookConfig current = UserPreferences.WebhookConfig.builder()
+                .token(Secret.of("existing-token"))
+                .mappings(List.of(UserPreferences.HookMapping.builder()
+                        .name("build")
+                        .hmacSecret(Secret.of("existing-hmac"))
+                        .build()))
+                .build();
+        UserPreferences.WebhookConfig incoming = UserPreferences.WebhookConfig.builder()
+                .token(Secret.builder().encrypted(true).build())
+                .mappings(List.of(
+                        UserPreferences.HookMapping.builder()
+                                .name("build")
+                                .hmacSecret(Secret.builder().build())
+                                .build(),
+                        UserPreferences.HookMapping.builder()
+                                .name("deploy")
+                                .hmacSecret(Secret.of("new-secret"))
+                                .build()))
+                .build();
+
+        mergeService.mergeWebhookSecrets(current, incoming);
+
+        assertEquals("existing-token", incoming.getToken().getValue());
+        assertTrue(Boolean.TRUE.equals(incoming.getToken().getEncrypted()));
+        assertEquals("existing-hmac", incoming.getMappings().getFirst().getHmacSecret().getValue());
+        assertEquals("new-secret", incoming.getMappings().get(1).getHmacSecret().getValue());
+    }
+
+    @Test
+    void shouldPreserveSelfEvolvingEmbeddingsApiKeyWhenMergingSections() {
+        RuntimeConfig baseline = RuntimeConfig.builder()
+                .selfEvolving(RuntimeConfig.SelfEvolvingConfig.builder()
+                        .tactics(RuntimeConfig.SelfEvolvingTacticsConfig.builder()
+                                .search(RuntimeConfig.SelfEvolvingTacticSearchConfig.builder()
+                                        .embeddings(RuntimeConfig.SelfEvolvingTacticEmbeddingsConfig.builder()
+                                                .apiKey(Secret.of("baseline-key"))
+                                                .build())
+                                        .build())
+                                .build())
+                        .build())
+                .build();
+        RuntimeConfig patch = RuntimeConfig.builder()
+                .selfEvolving(RuntimeConfig.SelfEvolvingConfig.builder()
+                        .enabled(true)
+                        .tactics(RuntimeConfig.SelfEvolvingTacticsConfig.builder()
+                                .search(RuntimeConfig.SelfEvolvingTacticSearchConfig.builder()
+                                        .embeddings(RuntimeConfig.SelfEvolvingTacticEmbeddingsConfig.builder()
+                                                .apiKey(Secret.builder().build())
+                                                .build())
+                                        .build())
+                                .build())
+                        .build())
+                .build();
+
+        RuntimeConfig merged = mergeService.mergeRuntimeConfigSections(baseline, patch);
+
+        assertEquals("baseline-key", merged.getSelfEvolving().getTactics().getSearch().getEmbeddings().getApiKey()
+                .getValue());
+    }
+
+    @Test
+    void shouldRetainExistingSecretWhenIncomingSecretHasNoValue() {
+        Secret current = Secret.of("current-secret");
+        Secret incoming = Secret.builder()
+                .encrypted(true)
+                .build();
+
+        Secret merged = mergeService.mergeSecret(current, incoming);
+
+        assertEquals("current-secret", merged.getValue());
+        assertTrue(Boolean.TRUE.equals(merged.getEncrypted()));
+        assertTrue(Boolean.TRUE.equals(merged.getPresent()));
+    }
+
+    @Test
+    void shouldMergeRuntimeSecretsWhenCurrentConfigSectionsExist() {
+        RuntimeConfig current = RuntimeConfig.builder()
+                .telegram(RuntimeConfig.TelegramConfig.builder()
+                        .token(Secret.of("telegram-token"))
+                        .build())
+                .voice(RuntimeConfig.VoiceConfig.builder()
+                        .apiKey(Secret.of("voice-token"))
+                        .whisperSttApiKey(Secret.of("whisper-token"))
+                        .build())
+                .llm(RuntimeConfig.LlmConfig.builder()
+                        .providers(java.util.Map.of("openai", RuntimeConfig.LlmProviderConfig.builder()
+                                .apiKey(Secret.of("llm-token"))
+                                .build()))
+                        .build())
+                .build();
+        RuntimeConfig incoming = RuntimeConfig.builder()
+                .telegram(RuntimeConfig.TelegramConfig.builder()
+                        .token(Secret.builder().build())
+                        .build())
+                .voice(RuntimeConfig.VoiceConfig.builder()
+                        .apiKey(Secret.builder().build())
+                        .whisperSttApiKey(Secret.builder().build())
+                        .build())
+                .llm(RuntimeConfig.LlmConfig.builder()
+                        .providers(new java.util.LinkedHashMap<>(java.util.Map.of(
+                                "openai", RuntimeConfig.LlmProviderConfig.builder()
+                                        .apiKey(Secret.builder().build())
+                                        .build())))
+                        .build())
+                .build();
+
+        mergeService.mergeRuntimeSecrets(current, incoming);
+
+        assertEquals("telegram-token", incoming.getTelegram().getToken().getValue());
+        assertEquals("voice-token", incoming.getVoice().getApiKey().getValue());
+        assertEquals("whisper-token", incoming.getVoice().getWhisperSttApiKey().getValue());
+        assertEquals("llm-token", incoming.getLlm().getProviders().get("openai").getApiKey().getValue());
+        assertFalse(Boolean.FALSE.equals(incoming.getTelegram().getToken().getPresent()));
+        assertNotNull(incoming.getLlm().getProviders());
+    }
+}

--- a/src/test/java/me/golemcore/bot/application/settings/RuntimeSettingsValidatorTest.java
+++ b/src/test/java/me/golemcore/bot/application/settings/RuntimeSettingsValidatorTest.java
@@ -1,23 +1,35 @@
 package me.golemcore.bot.application.settings;
 
 import me.golemcore.bot.domain.model.RuntimeConfig;
+import me.golemcore.bot.domain.model.UserPreferences;
 import me.golemcore.bot.domain.service.ModelSelectionService;
 import me.golemcore.bot.plugin.runtime.SttProviderRegistry;
 import me.golemcore.bot.plugin.runtime.TtsProviderRegistry;
+import me.golemcore.plugin.api.extension.spi.SttProvider;
+import me.golemcore.plugin.api.extension.spi.TtsProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class RuntimeSettingsValidatorTest {
 
+    private ModelSelectionService modelSelectionService;
     private RuntimeSettingsValidator validator;
 
     @BeforeEach
     void setUp() {
+        modelSelectionService = mock(ModelSelectionService.class);
         validator = new RuntimeSettingsValidator(
-                mock(ModelSelectionService.class),
+                modelSelectionService,
                 new SttProviderRegistry(),
                 new TtsProviderRegistry());
     }
@@ -26,5 +38,195 @@ class RuntimeSettingsValidatorTest {
     void shouldRejectNullRuntimeConfigDuringFullUpdateValidation() {
         assertThrows(IllegalArgumentException.class,
                 () -> validator.validateRuntimeConfigUpdate(RuntimeConfig.builder().build(), null, false));
+    }
+
+    @Test
+    void shouldNormalizeNullTelegramAllowedUsersDuringFullValidation() {
+        RuntimeConfig config = RuntimeConfig.builder()
+                .telegram(RuntimeConfig.TelegramConfig.builder().build())
+                .llm(RuntimeConfig.LlmConfig.builder().providers(new java.util.LinkedHashMap<>()).build())
+                .hive(RuntimeConfig.HiveConfig.builder().enabled(false).build())
+                .build();
+
+        validator.validateRuntimeConfigUpdate(RuntimeConfig.builder().build(), config, false);
+
+        assertEquals(List.of(), config.getTelegram().getAllowedUsers());
+    }
+
+    @Test
+    void shouldRejectInvalidProviderConfigFields() {
+        RuntimeConfig.LlmProviderConfig providerConfig = RuntimeConfig.LlmProviderConfig.builder()
+                .requestTimeoutSeconds(0)
+                .build();
+
+        assertThrows(IllegalArgumentException.class, () -> validator.validateProviderConfig("openai", providerConfig));
+
+        providerConfig.setRequestTimeoutSeconds(30);
+        providerConfig.setBaseUrl("ftp://invalid");
+        assertThrows(IllegalArgumentException.class, () -> validator.validateProviderConfig("openai", providerConfig));
+
+        providerConfig.setBaseUrl("https://api.example.com");
+        providerConfig.setApiType("unsupported");
+        assertThrows(IllegalArgumentException.class, () -> validator.validateProviderConfig("openai", providerConfig));
+    }
+
+    @Test
+    void shouldRejectInvalidTurnDeadline() {
+        RuntimeConfig.TurnConfig turnConfig = RuntimeConfig.TurnConfig.builder()
+                .deadline("tomorrow")
+                .build();
+
+        assertThrows(IllegalArgumentException.class, () -> validator.validateTurnConfig(turnConfig));
+    }
+
+    @Test
+    void shouldRejectMemoryConfigWhenMaxBudgetLowerThanSoftBudget() {
+        RuntimeConfig.MemoryConfig memoryConfig = RuntimeConfig.MemoryConfig.builder()
+                .softPromptBudgetTokens(500)
+                .maxPromptBudgetTokens(400)
+                .build();
+
+        assertThrows(IllegalArgumentException.class, () -> validator.validateMemoryConfig(memoryConfig));
+    }
+
+    @Test
+    void shouldNormalizeLegacyVoiceProvidersAndBlankWhisperUrl() {
+        SttProvider sttProvider = mock(SttProvider.class);
+        when(sttProvider.getProviderId()).thenReturn("golemcore/elevenlabs");
+        TtsProvider ttsProvider = mock(TtsProvider.class);
+        when(ttsProvider.getProviderId()).thenReturn("golemcore/whisper");
+        SttProviderRegistry sttProviderRegistry = new SttProviderRegistry();
+        sttProviderRegistry.replaceProviders("golemcore/elevenlabs", List.of(sttProvider));
+        TtsProviderRegistry ttsProviderRegistry = new TtsProviderRegistry();
+        ttsProviderRegistry.replaceProviders("golemcore/whisper", List.of(ttsProvider));
+        RuntimeSettingsValidator loadedValidator = new RuntimeSettingsValidator(
+                modelSelectionService,
+                sttProviderRegistry,
+                ttsProviderRegistry);
+        RuntimeConfig.VoiceConfig voiceConfig = RuntimeConfig.VoiceConfig.builder()
+                .enabled(false)
+                .sttProvider("elevenlabs")
+                .ttsProvider("whisper")
+                .whisperSttUrl("   ")
+                .build();
+
+        loadedValidator.validateVoiceConfig(voiceConfig);
+
+        assertEquals("golemcore/elevenlabs", voiceConfig.getSttProvider());
+        assertEquals("golemcore/whisper", voiceConfig.getTtsProvider());
+        assertNull(voiceConfig.getWhisperSttUrl());
+    }
+
+    @Test
+    void shouldRejectEnabledVoiceConfigWhenNoProvidersAreLoaded() {
+        RuntimeSettingsValidator unloadedValidator = new RuntimeSettingsValidator(
+                modelSelectionService,
+                new SttProviderRegistry(),
+                new TtsProviderRegistry());
+        RuntimeConfig.VoiceConfig voiceConfig = RuntimeConfig.VoiceConfig.builder()
+                .enabled(true)
+                .build();
+
+        assertThrows(IllegalArgumentException.class, () -> unloadedValidator.validateVoiceConfig(voiceConfig));
+    }
+
+    @Test
+    void shouldValidateShellEnvironmentVariableConstraints() {
+        RuntimeConfig.ShellEnvironmentVariable reserved = RuntimeConfig.ShellEnvironmentVariable.builder()
+                .name("HOME")
+                .value("x")
+                .build();
+        RuntimeConfig.ShellEnvironmentVariable invalid = RuntimeConfig.ShellEnvironmentVariable.builder()
+                .name("1BAD")
+                .value("x")
+                .build();
+        RuntimeConfig.ToolsConfig duplicateTools = RuntimeConfig.ToolsConfig.builder()
+                .shellEnvironmentVariables(List.of(
+                        RuntimeConfig.ShellEnvironmentVariable.builder().name("FOO").value("1").build(),
+                        RuntimeConfig.ShellEnvironmentVariable.builder().name("FOO").value("2").build()))
+                .build();
+
+        assertThrows(IllegalArgumentException.class,
+                () -> validator.normalizeAndValidateShellEnvironmentVariable(reserved));
+        assertThrows(IllegalArgumentException.class,
+                () -> validator.normalizeAndValidateShellEnvironmentVariable(invalid));
+        assertThrows(IllegalArgumentException.class,
+                () -> validator.normalizeAndValidateShellEnvironmentVariables(duplicateTools));
+    }
+
+    @Test
+    void shouldNormalizeModelRegistryDefaults() {
+        RuntimeConfig.ModelRegistryConfig modelRegistryConfig = RuntimeConfig.ModelRegistryConfig.builder()
+                .repositoryUrl("  ")
+                .branch(" ")
+                .build();
+
+        validator.validateAndNormalizeModelRegistryConfig(modelRegistryConfig);
+
+        assertNull(modelRegistryConfig.getRepositoryUrl());
+        assertEquals("main", modelRegistryConfig.getBranch());
+    }
+
+    @Test
+    void shouldRejectManagedHiveMutation() {
+        RuntimeConfig current = RuntimeConfig.builder()
+                .hive(RuntimeConfig.HiveConfig.builder().enabled(false).build())
+                .build();
+        RuntimeConfig.HiveConfig incoming = RuntimeConfig.HiveConfig.builder()
+                .enabled(true)
+                .build();
+
+        assertThrows(IllegalStateException.class, () -> validator.rejectManagedHiveMutation(current, incoming, true));
+    }
+
+    @Test
+    void shouldNormalizeWebhookTierSelection() {
+        UserPreferences.WebhookConfig webhookConfig = UserPreferences.WebhookConfig.builder()
+                .mappings(List.of(UserPreferences.HookMapping.builder()
+                        .name("build")
+                        .model("default")
+                        .build()))
+                .build();
+
+        validator.validateWebhookConfig(webhookConfig);
+
+        assertNull(webhookConfig.getMappings().getFirst().getModel());
+    }
+
+    @Test
+    void shouldRejectInvalidMcpCatalogEntry() {
+        RuntimeConfig.McpCatalogEntry entry = RuntimeConfig.McpCatalogEntry.builder()
+                .name("Bad Name")
+                .command("")
+                .build();
+
+        assertThrows(IllegalArgumentException.class, () -> validator.validateMcpCatalogEntry(entry));
+    }
+
+    @Test
+    void shouldRejectModelRouterProviderWhenProviderNotConfigured() {
+        when(modelSelectionService.validateModel("openai/gpt-5", List.of()))
+                .thenReturn(new ModelSelectionService.ValidationResult(false, "provider.not.configured"));
+        RuntimeConfig.ModelRouterConfig modelRouterConfig = RuntimeConfig.ModelRouterConfig.builder()
+                .routing(RuntimeConfig.TierBinding.builder().model("openai/gpt-5").build())
+                .build();
+
+        IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
+                () -> validator.validateModelRouterConfig(modelRouterConfig,
+                        RuntimeConfig.LlmConfig.builder().build()));
+
+        assertTrue(error.getMessage().contains("provider is not configured"));
+    }
+
+    @Test
+    void shouldDefaultMissingProvidersAndCompactionTriggerMode() {
+        RuntimeConfig.LlmConfig llmConfig = RuntimeConfig.LlmConfig.builder().build();
+        RuntimeConfig.CompactionConfig compactionConfig = RuntimeConfig.CompactionConfig.builder().build();
+
+        validator.validateLlmConfig(llmConfig, RuntimeConfig.ModelRouterConfig.builder().build());
+        validator.validateCompactionConfig(compactionConfig);
+
+        assertEquals(Map.of(), llmConfig.getProviders());
+        assertEquals("model_ratio", compactionConfig.getTriggerMode());
     }
 }

--- a/src/test/java/me/golemcore/bot/application/settings/RuntimeSettingsValidatorTest.java
+++ b/src/test/java/me/golemcore/bot/application/settings/RuntimeSettingsValidatorTest.java
@@ -14,6 +14,8 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -54,6 +56,18 @@ class RuntimeSettingsValidatorTest {
     }
 
     @Test
+    void shouldCreateMissingTelegramConfigDuringFullValidation() {
+        RuntimeConfig config = RuntimeConfig.builder()
+                .llm(RuntimeConfig.LlmConfig.builder().providers(new java.util.LinkedHashMap<>()).build())
+                .hive(RuntimeConfig.HiveConfig.builder().enabled(false).build())
+                .build();
+
+        validator.validateRuntimeConfigUpdate(RuntimeConfig.builder().build(), config, false);
+
+        assertEquals(List.of(), config.getTelegram().getAllowedUsers());
+    }
+
+    @Test
     void shouldRejectInvalidProviderConfigFields() {
         RuntimeConfig.LlmProviderConfig providerConfig = RuntimeConfig.LlmProviderConfig.builder()
                 .requestTimeoutSeconds(0)
@@ -71,12 +85,62 @@ class RuntimeSettingsValidatorTest {
     }
 
     @Test
+    void shouldRejectNullAndMalformedLlmConfigInputs() {
+        assertThrows(IllegalArgumentException.class, () -> validator.validateLlmConfig(null,
+                RuntimeConfig.ModelRouterConfig.builder().build()));
+        assertThrows(IllegalArgumentException.class, () -> validator.validateProviderConfig("openai", null));
+        assertThrows(IllegalArgumentException.class, () -> validator.normalizeProviderName("Bad Name"));
+
+        RuntimeConfig.LlmConfig blankProviderKey = RuntimeConfig.LlmConfig.builder()
+                .providers(new java.util.LinkedHashMap<>(Map.of("", RuntimeConfig.LlmProviderConfig.builder().build())))
+                .build();
+        assertThrows(IllegalArgumentException.class,
+                () -> validator.validateLlmConfig(blankProviderKey, RuntimeConfig.ModelRouterConfig.builder().build()));
+
+        RuntimeConfig.LlmConfig spacedProviderKey = RuntimeConfig.LlmConfig.builder()
+                .providers(new java.util.LinkedHashMap<>(Map.of(" openai ", RuntimeConfig.LlmProviderConfig.builder()
+                        .build())))
+                .build();
+        assertThrows(IllegalArgumentException.class,
+                () -> validator.validateLlmConfig(spacedProviderKey,
+                        RuntimeConfig.ModelRouterConfig.builder().build()));
+
+        RuntimeConfig.LlmConfig invalidPatternProviderKey = RuntimeConfig.LlmConfig.builder()
+                .providers(new java.util.LinkedHashMap<>(Map.of("open.ai",
+                        RuntimeConfig.LlmProviderConfig.builder().build())))
+                .build();
+        assertThrows(IllegalArgumentException.class, () -> validator.validateLlmConfig(
+                invalidPatternProviderKey, RuntimeConfig.ModelRouterConfig.builder().build()));
+    }
+
+    @Test
+    void shouldInitializeNullProviderMapAndAllowNullModelRouter() {
+        RuntimeConfig.LlmConfig llmConfig = RuntimeConfig.LlmConfig.builder().providers(null).build();
+
+        assertDoesNotThrow(() -> validator.validateModelRouterConfig(null, llmConfig));
+        validator.validateLlmConfig(llmConfig, RuntimeConfig.ModelRouterConfig.builder().build());
+
+        assertEquals(Map.of(), llmConfig.getProviders());
+    }
+
+    @Test
     void shouldRejectInvalidTurnDeadline() {
         RuntimeConfig.TurnConfig turnConfig = RuntimeConfig.TurnConfig.builder()
                 .deadline("tomorrow")
                 .build();
 
         assertThrows(IllegalArgumentException.class, () -> validator.validateTurnConfig(turnConfig));
+    }
+
+    @Test
+    void shouldRejectInvalidTurnNumericConstraints() {
+        assertThrows(IllegalArgumentException.class, () -> validator.validateTurnConfig(null));
+        assertThrows(IllegalArgumentException.class, () -> validator.validateTurnConfig(
+                RuntimeConfig.TurnConfig.builder().maxLlmCalls(0).build()));
+        assertThrows(IllegalArgumentException.class, () -> validator.validateTurnConfig(
+                RuntimeConfig.TurnConfig.builder().maxToolExecutions(0).build()));
+        assertThrows(IllegalArgumentException.class, () -> validator.validateTurnConfig(
+                RuntimeConfig.TurnConfig.builder().deadline("PT0S").build()));
     }
 
     @Test
@@ -87,6 +151,18 @@ class RuntimeSettingsValidatorTest {
                 .build();
 
         assertThrows(IllegalArgumentException.class, () -> validator.validateMemoryConfig(memoryConfig));
+    }
+
+    @Test
+    void shouldCreateDefaultMemoryNestedSections() {
+        RuntimeConfig.MemoryConfig memoryConfig = RuntimeConfig.MemoryConfig.builder().build();
+
+        validator.validateMemoryConfig(memoryConfig);
+
+        assertNotNull(memoryConfig.getDisclosure());
+        assertNotNull(memoryConfig.getReranking());
+        assertNotNull(memoryConfig.getDiagnostics());
+        assertThrows(IllegalArgumentException.class, () -> validator.validateMemoryConfig(null));
     }
 
     @Test
@@ -177,6 +253,16 @@ class RuntimeSettingsValidatorTest {
                 .build();
 
         assertThrows(IllegalStateException.class, () -> validator.rejectManagedHiveMutation(current, incoming, true));
+    }
+
+    @Test
+    void shouldRejectProviderRemovalWhenModelRouterStillUsesIt() {
+        RuntimeConfig.ModelRouterConfig modelRouterConfig = RuntimeConfig.ModelRouterConfig.builder()
+                .routing(RuntimeConfig.TierBinding.builder().model("openai/gpt-5").build())
+                .build();
+
+        assertThrows(IllegalArgumentException.class,
+                () -> validator.validateProviderRemoval(modelRouterConfig, "openai"));
     }
 
     @Test

--- a/src/test/java/me/golemcore/bot/application/settings/RuntimeSettingsValidatorTest.java
+++ b/src/test/java/me/golemcore/bot/application/settings/RuntimeSettingsValidatorTest.java
@@ -1,0 +1,30 @@
+package me.golemcore.bot.application.settings;
+
+import me.golemcore.bot.domain.model.RuntimeConfig;
+import me.golemcore.bot.domain.service.ModelSelectionService;
+import me.golemcore.bot.plugin.runtime.SttProviderRegistry;
+import me.golemcore.bot.plugin.runtime.TtsProviderRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+class RuntimeSettingsValidatorTest {
+
+    private RuntimeSettingsValidator validator;
+
+    @BeforeEach
+    void setUp() {
+        validator = new RuntimeSettingsValidator(
+                mock(ModelSelectionService.class),
+                new SttProviderRegistry(),
+                new TtsProviderRegistry());
+    }
+
+    @Test
+    void shouldRejectNullRuntimeConfigDuringFullUpdateValidation() {
+        assertThrows(IllegalArgumentException.class,
+                () -> validator.validateRuntimeConfigUpdate(RuntimeConfig.builder().build(), null, false));
+    }
+}


### PR DESCRIPTION
## Summary
- extract `/api/settings/runtime/**` orchestration out of `SettingsController` into a dedicated application layer
- introduce `RuntimeSettingsFacade`, `RuntimeSettingsValidator`, and `RuntimeSettingsMergeService`
- keep the HTTP contract stable while making `SettingsController` a thin adapter
- add targeted tests for the new application seam and null-contract regression in the validator

## Why
This is the next architectural cluster after the import-level hex cleanup. The remaining debt was no longer `domain -> adapter` coupling, but controller-owned application logic: runtime config merge, secret preservation, validation, provider checks, shell env mutation, and MCP/webhooks orchestration all lived inside `SettingsController`.

This PR moves that behavior behind an explicit runtime settings application boundary so the web adapter is no longer the de facto application layer.

