### PR TITLE
refactor(commands): extract model selection command service

### DIFF
--- a/src/main/java/me/golemcore/bot/adapter/inbound/command/CommandRouter.java
+++ b/src/main/java/me/golemcore/bot/adapter/inbound/command/CommandRouter.java
@@ -207,8 +207,8 @@ public class CommandRouter implements CommandPort {
             case "reset" -> handleReset(sessionId, sessionIdentity);
             case "compact" -> handleCompact(sessionId, args);
             case CMD_HELP -> handleHelp();
-            case "tier" -> modelSelectionCommandService.handleTier(args);
-            case "model" -> modelSelectionCommandService.handleModel(args);
+            case "tier" -> toCommandResult(modelSelectionCommandService.handleTier(args));
+            case "model" -> toCommandResult(modelSelectionCommandService.handleModel(args));
             case "sessions" -> handleSessions(channelType);
             case "auto" -> handleAuto(args, channelType, autoSessionChatId, transportChatId);
             case "goals" -> handleGoals();
@@ -236,6 +236,13 @@ public class CommandRouter implements CommandPort {
     private boolean hasExplicitContextString(Map<String, Object> context, String key) {
         Object value = context.get(key);
         return value instanceof String && !((String) value).isBlank();
+    }
+
+    private CommandResult toCommandResult(ModelSelectionCommandService.CommandOutcome outcome) {
+        if (outcome.success()) {
+            return CommandResult.success(outcome.output());
+        }
+        return CommandResult.failure(outcome.output());
     }
 
     @Override

--- a/src/main/java/me/golemcore/bot/adapter/inbound/command/CommandRouter.java
+++ b/src/main/java/me/golemcore/bot/adapter/inbound/command/CommandRouter.java
@@ -117,9 +117,11 @@ public class CommandRouter implements CommandPort {
     private static final String CMD_STATUS = "status";
     private static final int MIN_SCHEDULE_ARGS = 2;
     private static final int MIN_CRON_PARTS_FOR_REPEAT_CHECK = 1;
+    private static final int MIN_REASONING_ARGS = 2;
     private static final String SUBCMD_LIST = "list";
     private static final DateTimeFormatter LATER_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm z");
     private static final String SUBCMD_RESET = "reset";
+    private static final String SUBCMD_REASONING = "reasoning";
 
     private final SkillComponent skillComponent;
     private final List<ToolComponent> toolComponents;
@@ -207,8 +209,8 @@ public class CommandRouter implements CommandPort {
             case "reset" -> handleReset(sessionId, sessionIdentity);
             case "compact" -> handleCompact(sessionId, args);
             case CMD_HELP -> handleHelp();
-            case "tier" -> toCommandResult(modelSelectionCommandService.handleTier(args));
-            case "model" -> toCommandResult(modelSelectionCommandService.handleModel(args));
+            case "tier" -> handleTier(args);
+            case "model" -> handleModel(args);
             case "sessions" -> handleSessions(channelType);
             case "auto" -> handleAuto(args, channelType, autoSessionChatId, transportChatId);
             case "goals" -> handleGoals();
@@ -238,11 +240,155 @@ public class CommandRouter implements CommandPort {
         return value instanceof String && !((String) value).isBlank();
     }
 
-    private CommandResult toCommandResult(ModelSelectionCommandService.CommandOutcome outcome) {
-        if (outcome.success()) {
-            return CommandResult.success(outcome.output());
+    private CommandResult handleTier(List<String> args) {
+        if (args.isEmpty()) {
+            return renderTierOutcome(
+                    modelSelectionCommandService.handleTier(new ModelSelectionCommandService.ShowTierStatus()));
         }
-        return CommandResult.failure(outcome.output());
+
+        String tier = ModelTierCatalog.normalizeTierId(args.get(0));
+        boolean force = args.size() > 1 && "force".equalsIgnoreCase(args.get(1));
+        return renderTierOutcome(modelSelectionCommandService.handleTier(
+                new ModelSelectionCommandService.SetTierSelection(tier, force)));
+    }
+
+    private CommandResult handleModel(List<String> args) {
+        if (args.isEmpty()) {
+            return renderModelOutcome(
+                    modelSelectionCommandService.handleModel(new ModelSelectionCommandService.ShowModelSelection()));
+        }
+
+        String subcommand = ModelTierCatalog.normalizeTierId(args.get(0));
+        if (SUBCMD_LIST.equals(subcommand)) {
+            return renderModelOutcome(
+                    modelSelectionCommandService.handleModel(new ModelSelectionCommandService.ListAvailableModels()));
+        }
+        if (!ModelTierCatalog.isExplicitSelectableTier(subcommand)) {
+            return CommandResult.success(msg("command.model.invalid.tier"));
+        }
+
+        List<String> subArgs = args.subList(1, args.size());
+        if (subArgs.isEmpty()) {
+            return CommandResult.success(msg("command.model.usage"));
+        }
+
+        String action = subArgs.get(0).toLowerCase(Locale.ROOT);
+        if (SUBCMD_RESET.equals(action)) {
+            return renderModelOutcome(modelSelectionCommandService.handleModel(
+                    new ModelSelectionCommandService.ResetModelOverride(subcommand)));
+        }
+        if (SUBCMD_REASONING.equals(action)) {
+            if (subArgs.size() < MIN_REASONING_ARGS) {
+                return CommandResult.success(msg("command.model.usage"));
+            }
+            return renderModelOutcome(modelSelectionCommandService.handleModel(
+                    new ModelSelectionCommandService.SetReasoningLevel(subcommand,
+                            subArgs.get(1).toLowerCase(Locale.ROOT))));
+        }
+
+        return renderModelOutcome(modelSelectionCommandService.handleModel(
+                new ModelSelectionCommandService.SetModelOverride(subcommand, subArgs.get(0))));
+    }
+
+    private CommandResult renderTierOutcome(ModelSelectionCommandService.TierOutcome outcome) {
+        if (outcome instanceof ModelSelectionCommandService.CurrentTier currentTier) {
+            String force = currentTier.force() ? "on" : "off";
+            return CommandResult.success(msg("command.tier.current", currentTier.tier(), force));
+        }
+        if (outcome instanceof ModelSelectionCommandService.TierUpdated tierUpdated) {
+            if (tierUpdated.force()) {
+                return CommandResult.success(msg("command.tier.set.force", tierUpdated.tier()));
+            }
+            return CommandResult.success(msg("command.tier.set", tierUpdated.tier()));
+        }
+        return CommandResult.success(msg("command.tier.invalid"));
+    }
+
+    private CommandResult renderModelOutcome(ModelSelectionCommandService.ModelOutcome outcome) {
+        if (outcome instanceof ModelSelectionCommandService.ModelSelectionOverview overview) {
+            return CommandResult.success(renderModelOverview(overview));
+        }
+        if (outcome instanceof ModelSelectionCommandService.AvailableModels availableModels) {
+            return CommandResult.success(renderAvailableModels(availableModels));
+        }
+        if (outcome instanceof ModelSelectionCommandService.InvalidModelTier) {
+            return CommandResult.success(msg("command.model.invalid.tier"));
+        }
+        if (outcome instanceof ModelSelectionCommandService.ModelOverrideSet modelOverrideSet) {
+            String displayReasoning = modelOverrideSet.defaultReasoning() != null
+                    ? " (reasoning: " + modelOverrideSet.defaultReasoning() + ")"
+                    : "";
+            return CommandResult.success(
+                    msg("command.model.set", modelOverrideSet.tier(), modelOverrideSet.modelSpec()) + displayReasoning);
+        }
+        if (outcome instanceof ModelSelectionCommandService.ProviderNotConfigured providerNotConfigured) {
+            return CommandResult.success(msg(
+                    "command.model.invalid.provider",
+                    providerNotConfigured.modelSpec(),
+                    String.join(", ", providerNotConfigured.configuredProviders())));
+        }
+        if (outcome instanceof ModelSelectionCommandService.InvalidModel invalidModel) {
+            return CommandResult.success(msg("command.model.invalid.model", invalidModel.modelSpec()));
+        }
+        if (outcome instanceof ModelSelectionCommandService.MissingModelOverride missingModelOverride) {
+            return CommandResult.success(msg("command.model.no.override", missingModelOverride.tier()));
+        }
+        if (outcome instanceof ModelSelectionCommandService.MissingReasoningSupport missingReasoningSupport) {
+            return CommandResult.success(msg("command.model.no.reasoning", missingReasoningSupport.modelSpec()));
+        }
+        if (outcome instanceof ModelSelectionCommandService.InvalidReasoningLevel invalidReasoningLevel) {
+            return CommandResult.success(msg(
+                    "command.model.invalid.reasoning",
+                    invalidReasoningLevel.requestedLevel(),
+                    String.join(", ", invalidReasoningLevel.availableLevels())));
+        }
+        if (outcome instanceof ModelSelectionCommandService.ModelReasoningSet modelReasoningSet) {
+            return CommandResult.success(msg(
+                    "command.model.set.reasoning",
+                    modelReasoningSet.tier(),
+                    modelReasoningSet.level()));
+        }
+        ModelSelectionCommandService.ModelOverrideReset modelOverrideReset = (ModelSelectionCommandService.ModelOverrideReset) outcome;
+        return CommandResult.success(msg("command.model.reset", modelOverrideReset.tier()));
+    }
+
+    private String renderModelOverview(ModelSelectionCommandService.ModelSelectionOverview overview) {
+        StringBuilder builder = new StringBuilder();
+        builder.append("**").append(msg("command.model.show.title")).append("**\n\n");
+
+        for (ModelSelectionCommandService.TierSelection tierSelection : overview.tiers()) {
+            String model = tierSelection.model() != null ? tierSelection.model() : "—";
+            String reasoning = tierSelection.reasoning() != null ? tierSelection.reasoning() : "—";
+            String messageKey = tierSelection.hasOverride()
+                    ? "command.model.show.tier.override"
+                    : "command.model.show.tier.default";
+            builder.append(msg(messageKey, tierSelection.tier(), model, reasoning)).append("\n");
+        }
+
+        return builder.toString();
+    }
+
+    private String renderAvailableModels(ModelSelectionCommandService.AvailableModels availableModels) {
+        if (availableModels.modelsByProvider().isEmpty()) {
+            return msg("command.model.list.title") + "\n\nNo models available.";
+        }
+
+        StringBuilder builder = new StringBuilder();
+        builder.append("**").append(msg("command.model.list.title")).append("**\n\n");
+
+        for (Map.Entry<String, List<ModelSelectionCommandService.AvailableModelOption>> entry : availableModels
+                .modelsByProvider().entrySet()) {
+            builder.append(msg("command.model.list.provider", entry.getKey())).append("\n");
+            for (ModelSelectionCommandService.AvailableModelOption model : entry.getValue()) {
+                String reasoningInfo = model.hasReasoning()
+                        ? " [reasoning: " + String.join(", ", model.reasoningLevels()) + "]"
+                        : "";
+                builder.append(msg("command.model.list.model", model.id(), model.displayName(), reasoningInfo))
+                        .append("\n");
+            }
+            builder.append("\n");
+        }
+        return builder.toString();
     }
 
     @Override

--- a/src/main/java/me/golemcore/bot/adapter/inbound/command/CommandRouter.java
+++ b/src/main/java/me/golemcore/bot/adapter/inbound/command/CommandRouter.java
@@ -18,6 +18,7 @@
 
 package me.golemcore.bot.adapter.inbound.command;
 
+import me.golemcore.bot.application.command.ModelSelectionCommandService;
 import me.golemcore.bot.domain.component.SkillComponent;
 import me.golemcore.bot.domain.component.ToolComponent;
 import me.golemcore.bot.domain.model.AutoModeChannelRegisteredEvent;
@@ -39,7 +40,6 @@ import me.golemcore.bot.domain.service.AutoModeService;
 import me.golemcore.bot.domain.service.CompactionOrchestrationService;
 import me.golemcore.bot.domain.service.DelayedActionPolicyService;
 import me.golemcore.bot.domain.service.DelayedSessionActionService;
-import me.golemcore.bot.domain.service.ModelSelectionService;
 import me.golemcore.bot.domain.service.PlanExecutionService;
 import me.golemcore.bot.domain.service.PlanService;
 import me.golemcore.bot.domain.service.RuntimeConfigService;
@@ -117,13 +117,9 @@ public class CommandRouter implements CommandPort {
     private static final String CMD_STATUS = "status";
     private static final int MIN_SCHEDULE_ARGS = 2;
     private static final int MIN_CRON_PARTS_FOR_REPEAT_CHECK = 1;
-    private static final int MIN_REASONING_ARGS = 2;
     private static final String SUBCMD_LIST = "list";
     private static final DateTimeFormatter LATER_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm z");
     private static final String SUBCMD_RESET = "reset";
-    private static final String SUBCMD_REASONING = "reasoning";
-    private static final String ERR_PROVIDER_NOT_CONFIGURED = "provider.not.configured";
-    private static final String ERR_NO_REASONING = "no.reasoning";
 
     private final SkillComponent skillComponent;
     private final List<ToolComponent> toolComponents;
@@ -132,7 +128,7 @@ public class CommandRouter implements CommandPort {
     private final UserPreferencesService preferencesService;
     private final CompactionOrchestrationService compactionOrchestrationService;
     private final AutoModeService autoModeService;
-    private final ModelSelectionService modelSelectionService;
+    private final ModelSelectionCommandService modelSelectionCommandService;
     private final PlanService planService;
     private final PlanExecutionService planExecutionService;
     private final ScheduleService scheduleService;
@@ -156,7 +152,7 @@ public class CommandRouter implements CommandPort {
             UserPreferencesService preferencesService,
             CompactionOrchestrationService compactionOrchestrationService,
             AutoModeService autoModeService,
-            ModelSelectionService modelSelectionService,
+            ModelSelectionCommandService modelSelectionCommandService,
             PlanService planService,
             PlanExecutionService planExecutionService,
             ScheduleService scheduleService,
@@ -173,7 +169,7 @@ public class CommandRouter implements CommandPort {
         this.preferencesService = preferencesService;
         this.compactionOrchestrationService = compactionOrchestrationService;
         this.autoModeService = autoModeService;
-        this.modelSelectionService = modelSelectionService;
+        this.modelSelectionCommandService = modelSelectionCommandService;
         this.planService = planService;
         this.planExecutionService = planExecutionService;
         this.scheduleService = scheduleService;
@@ -211,8 +207,8 @@ public class CommandRouter implements CommandPort {
             case "reset" -> handleReset(sessionId, sessionIdentity);
             case "compact" -> handleCompact(sessionId, args);
             case CMD_HELP -> handleHelp();
-            case "tier" -> handleTier(args);
-            case "model" -> handleModel(args);
+            case "tier" -> modelSelectionCommandService.handleTier(args);
+            case "model" -> modelSelectionCommandService.handleModel(args);
             case "sessions" -> handleSessions(channelType);
             case "auto" -> handleAuto(args, channelType, autoSessionChatId, transportChatId);
             case "goals" -> handleGoals();
@@ -510,191 +506,6 @@ public class CommandRouter implements CommandPort {
             return CommandResult.success(msg("command.sessions.not-available"));
         }
         return CommandResult.success(msg("command.sessions.use-menu"));
-    }
-
-    // ==================== Tier Command ====================
-
-    private CommandResult handleTier(List<String> args) {
-        UserPreferences prefs = preferencesService.getPreferences();
-
-        if (args.isEmpty()) {
-            String tier = prefs.getModelTier() != null ? prefs.getModelTier() : "balanced";
-            String force = prefs.isTierForce() ? "on" : "off";
-            return CommandResult.success(msg("command.tier.current", tier, force));
-        }
-
-        String tierArg = ModelTierCatalog.normalizeTierId(args.get(0));
-        if (!ModelTierCatalog.isExplicitSelectableTier(tierArg)) {
-            return CommandResult.success(msg("command.tier.invalid"));
-        }
-
-        boolean force = args.size() > 1 && "force".equalsIgnoreCase(args.get(1));
-
-        prefs.setModelTier(tierArg);
-        prefs.setTierForce(force);
-        preferencesService.savePreferences(prefs);
-
-        if (force) {
-            return CommandResult.success(msg("command.tier.set.force", tierArg));
-        }
-        return CommandResult.success(msg("command.tier.set", tierArg));
-    }
-
-    // ==================== Model Selection Command ====================
-
-    private CommandResult handleModel(List<String> args) {
-        if (args.isEmpty()) {
-            return handleModelShow();
-        }
-
-        String subcommand = ModelTierCatalog.normalizeTierId(args.get(0));
-        if (SUBCMD_LIST.equals(subcommand)) {
-            return handleModelList();
-        }
-
-        // Tier-based subcommands: /model <tier> ...
-        if (!ModelTierCatalog.isExplicitSelectableTier(subcommand)) {
-            return CommandResult.success(msg("command.model.invalid.tier"));
-        }
-
-        String tier = subcommand;
-        List<String> subArgs = args.subList(1, args.size());
-
-        if (subArgs.isEmpty()) {
-            return CommandResult.success(msg("command.model.usage"));
-        }
-
-        String action = subArgs.get(0).toLowerCase(Locale.ROOT);
-        if (SUBCMD_RESET.equals(action)) {
-            return handleModelReset(tier);
-        }
-        if (SUBCMD_REASONING.equals(action)) {
-            if (subArgs.size() < MIN_REASONING_ARGS) {
-                return CommandResult.success(msg("command.model.usage"));
-            }
-            return handleModelSetReasoning(tier, subArgs.get(1).toLowerCase(Locale.ROOT));
-        }
-
-        // /model <tier> <provider/model>
-        String modelSpec = subArgs.get(0);
-        return handleModelSet(tier, modelSpec);
-    }
-
-    private CommandResult handleModelShow() {
-        UserPreferences prefs = preferencesService.getPreferences();
-        StringBuilder sb = new StringBuilder();
-        sb.append("**").append(msg("command.model.show.title")).append("**\n\n");
-
-        for (String tier : ModelTierCatalog.orderedExplicitTiers()) {
-            ModelSelectionService.ModelSelection selection = modelSelectionService.resolveForTier(tier);
-            String model = selection.model() != null ? selection.model() : "—";
-            String reasoning = selection.reasoning() != null ? selection.reasoning() : "—";
-
-            boolean hasOverride = prefs.getTierOverrides() != null
-                    && prefs.getTierOverrides().containsKey(tier);
-            String msgKey = hasOverride ? "command.model.show.tier.override" : "command.model.show.tier.default";
-            sb.append(msg(msgKey, tier, model, reasoning)).append("\n");
-        }
-
-        return CommandResult.success(sb.toString());
-    }
-
-    private CommandResult handleModelList() {
-        Map<String, List<ModelSelectionService.AvailableModel>> grouped = modelSelectionService
-                .getAvailableModelsGrouped();
-        if (grouped.isEmpty()) {
-            return CommandResult.success(msg("command.model.list.title") + "\n\nNo models available.");
-        }
-
-        StringBuilder sb = new StringBuilder();
-        sb.append("**").append(msg("command.model.list.title")).append("**\n\n");
-
-        for (Map.Entry<String, List<ModelSelectionService.AvailableModel>> entry : grouped.entrySet()) {
-            sb.append(msg("command.model.list.provider", entry.getKey())).append("\n");
-            for (ModelSelectionService.AvailableModel model : entry.getValue()) {
-                String reasoningInfo = model.hasReasoning()
-                        ? " [reasoning: " + String.join(", ", model.reasoningLevels()) + "]"
-                        : "";
-                sb.append(msg("command.model.list.model", model.id(), model.displayName(), reasoningInfo)).append("\n");
-            }
-            sb.append("\n");
-        }
-
-        return CommandResult.success(sb.toString());
-    }
-
-    private CommandResult handleModelSet(String tier, String modelSpec) {
-        ModelSelectionService.ValidationResult validation = modelSelectionService.validateModel(modelSpec);
-        if (!validation.valid()) {
-            if (ERR_PROVIDER_NOT_CONFIGURED.equals(validation.error())) {
-                String configuredStr = String.join(", ",
-                        runtimeConfigService.getConfiguredLlmProviders());
-                return CommandResult.success(msg("command.model.invalid.provider", modelSpec, configuredStr));
-            }
-            return CommandResult.success(msg("command.model.invalid.model", modelSpec));
-        }
-
-        UserPreferences prefs = preferencesService.getPreferences();
-        String defaultReasoning = findDefaultReasoning(modelSpec);
-
-        UserPreferences.TierOverride override = new UserPreferences.TierOverride(modelSpec, defaultReasoning);
-        prefs.getTierOverrides().put(tier, override);
-        preferencesService.savePreferences(prefs);
-
-        String displayReasoning = defaultReasoning != null ? " (reasoning: " + defaultReasoning + ")" : "";
-        return CommandResult.success(msg("command.model.set", tier, modelSpec) + displayReasoning);
-    }
-
-    private CommandResult handleModelSetReasoning(String tier, String level) {
-        UserPreferences prefs = preferencesService.getPreferences();
-        UserPreferences.TierOverride existing = prefs.getTierOverrides() != null
-                ? prefs.getTierOverrides().get(tier)
-                : null;
-
-        if (existing == null || existing.getModel() == null) {
-            return CommandResult.success(msg("command.model.no.override", tier));
-        }
-
-        ModelSelectionService.ValidationResult validation = modelSelectionService.validateReasoning(
-                existing.getModel(), level);
-        if (!validation.valid()) {
-            if (ERR_NO_REASONING.equals(validation.error())) {
-                return CommandResult.success(msg("command.model.no.reasoning", existing.getModel()));
-            }
-            List<String> available = modelSelectionService.getAvailableModels().stream()
-                    .filter(m -> m.id().equals(existing.getModel())
-                            || existing.getModel().endsWith("/" + m.id()))
-                    .flatMap(m -> m.reasoningLevels().stream())
-                    .toList();
-            return CommandResult.success(msg("command.model.invalid.reasoning", level, String.join(", ", available)));
-        }
-
-        existing.setReasoning(level);
-        preferencesService.savePreferences(prefs);
-        return CommandResult.success(msg("command.model.set.reasoning", tier, level));
-    }
-
-    private CommandResult handleModelReset(String tier) {
-        UserPreferences prefs = preferencesService.getPreferences();
-        if (prefs.getTierOverrides() != null) {
-            prefs.getTierOverrides().remove(tier);
-            preferencesService.savePreferences(prefs);
-        }
-        return CommandResult.success(msg("command.model.reset", tier));
-    }
-
-    private String findDefaultReasoning(String modelSpec) {
-        // Extract from models.json
-        List<ModelSelectionService.AvailableModel> models = modelSelectionService.getAvailableModels();
-        for (ModelSelectionService.AvailableModel model : models) {
-            if (model.id().equals(modelSpec) || modelSpec.endsWith("/" + model.id())) {
-                if (model.hasReasoning() && !model.reasoningLevels().isEmpty()) {
-                    List<String> levels = model.reasoningLevels();
-                    return levels.contains("medium") ? "medium" : levels.get(0);
-                }
-            }
-        }
-        return null;
     }
 
     // ==================== Auto Mode Commands ====================

--- a/src/main/java/me/golemcore/bot/application/command/ModelSelectionCommandService.java
+++ b/src/main/java/me/golemcore/bot/application/command/ModelSelectionCommandService.java
@@ -6,7 +6,6 @@ import me.golemcore.bot.domain.model.UserPreferences;
 import me.golemcore.bot.domain.service.ModelSelectionService;
 import me.golemcore.bot.domain.service.RuntimeConfigService;
 import me.golemcore.bot.domain.service.UserPreferencesService;
-import me.golemcore.bot.port.inbound.CommandPort;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -28,18 +27,18 @@ public class ModelSelectionCommandService {
     private final ModelSelectionService modelSelectionService;
     private final RuntimeConfigService runtimeConfigService;
 
-    public CommandPort.CommandResult handleTier(List<String> args) {
+    public CommandOutcome handleTier(List<String> args) {
         UserPreferences preferences = preferencesService.getPreferences();
 
         if (args.isEmpty()) {
             String tier = preferences.getModelTier() != null ? preferences.getModelTier() : "balanced";
             String force = preferences.isTierForce() ? "on" : "off";
-            return CommandPort.CommandResult.success(msg("command.tier.current", tier, force));
+            return CommandOutcome.success(msg("command.tier.current", tier, force));
         }
 
         String tierArg = ModelTierCatalog.normalizeTierId(args.get(0));
         if (!ModelTierCatalog.isExplicitSelectableTier(tierArg)) {
-            return CommandPort.CommandResult.success(msg("command.tier.invalid"));
+            return CommandOutcome.success(msg("command.tier.invalid"));
         }
 
         boolean force = args.size() > 1 && "force".equalsIgnoreCase(args.get(1));
@@ -48,12 +47,12 @@ public class ModelSelectionCommandService {
         preferencesService.savePreferences(preferences);
 
         if (force) {
-            return CommandPort.CommandResult.success(msg("command.tier.set.force", tierArg));
+            return CommandOutcome.success(msg("command.tier.set.force", tierArg));
         }
-        return CommandPort.CommandResult.success(msg("command.tier.set", tierArg));
+        return CommandOutcome.success(msg("command.tier.set", tierArg));
     }
 
-    public CommandPort.CommandResult handleModel(List<String> args) {
+    public CommandOutcome handleModel(List<String> args) {
         if (args.isEmpty()) {
             return handleModelShow();
         }
@@ -63,13 +62,13 @@ public class ModelSelectionCommandService {
             return handleModelList();
         }
         if (!ModelTierCatalog.isExplicitSelectableTier(subcommand)) {
-            return CommandPort.CommandResult.success(msg("command.model.invalid.tier"));
+            return CommandOutcome.success(msg("command.model.invalid.tier"));
         }
 
         String tier = subcommand;
         List<String> subArgs = args.subList(1, args.size());
         if (subArgs.isEmpty()) {
-            return CommandPort.CommandResult.success(msg("command.model.usage"));
+            return CommandOutcome.success(msg("command.model.usage"));
         }
 
         String action = subArgs.get(0).toLowerCase(Locale.ROOT);
@@ -78,7 +77,7 @@ public class ModelSelectionCommandService {
         }
         if (SUBCMD_REASONING.equals(action)) {
             if (subArgs.size() < MIN_REASONING_ARGS) {
-                return CommandPort.CommandResult.success(msg("command.model.usage"));
+                return CommandOutcome.success(msg("command.model.usage"));
             }
             return handleModelSetReasoning(tier, subArgs.get(1).toLowerCase(Locale.ROOT));
         }
@@ -86,7 +85,7 @@ public class ModelSelectionCommandService {
         return handleModelSet(tier, subArgs.get(0));
     }
 
-    private CommandPort.CommandResult handleModelShow() {
+    private CommandOutcome handleModelShow() {
         UserPreferences preferences = preferencesService.getPreferences();
         StringBuilder builder = new StringBuilder();
         builder.append("**").append(msg("command.model.show.title")).append("**\n\n");
@@ -101,14 +100,14 @@ public class ModelSelectionCommandService {
             builder.append(msg(messageKey, tier, model, reasoning)).append("\n");
         }
 
-        return CommandPort.CommandResult.success(builder.toString());
+        return CommandOutcome.success(builder.toString());
     }
 
-    private CommandPort.CommandResult handleModelList() {
+    private CommandOutcome handleModelList() {
         Map<String, List<ModelSelectionService.AvailableModel>> grouped = modelSelectionService
                 .getAvailableModelsGrouped();
         if (grouped.isEmpty()) {
-            return CommandPort.CommandResult.success(msg("command.model.list.title") + "\n\nNo models available.");
+            return CommandOutcome.success(msg("command.model.list.title") + "\n\nNo models available.");
         }
 
         StringBuilder builder = new StringBuilder();
@@ -126,18 +125,18 @@ public class ModelSelectionCommandService {
             builder.append("\n");
         }
 
-        return CommandPort.CommandResult.success(builder.toString());
+        return CommandOutcome.success(builder.toString());
     }
 
-    private CommandPort.CommandResult handleModelSet(String tier, String modelSpec) {
+    private CommandOutcome handleModelSet(String tier, String modelSpec) {
         ModelSelectionService.ValidationResult validation = modelSelectionService.validateModel(modelSpec);
         if (!validation.valid()) {
             if (ERR_PROVIDER_NOT_CONFIGURED.equals(validation.error())) {
                 String configuredProviders = String.join(", ", runtimeConfigService.getConfiguredLlmProviders());
-                return CommandPort.CommandResult.success(
+                return CommandOutcome.success(
                         msg("command.model.invalid.provider", modelSpec, configuredProviders));
             }
-            return CommandPort.CommandResult.success(msg("command.model.invalid.model", modelSpec));
+            return CommandOutcome.success(msg("command.model.invalid.model", modelSpec));
         }
 
         UserPreferences preferences = preferencesService.getPreferences();
@@ -147,45 +146,45 @@ public class ModelSelectionCommandService {
         preferencesService.savePreferences(preferences);
 
         String displayReasoning = defaultReasoning != null ? " (reasoning: " + defaultReasoning + ")" : "";
-        return CommandPort.CommandResult.success(msg("command.model.set", tier, modelSpec) + displayReasoning);
+        return CommandOutcome.success(msg("command.model.set", tier, modelSpec) + displayReasoning);
     }
 
-    private CommandPort.CommandResult handleModelSetReasoning(String tier, String level) {
+    private CommandOutcome handleModelSetReasoning(String tier, String level) {
         UserPreferences preferences = preferencesService.getPreferences();
         UserPreferences.TierOverride existing = preferences.getTierOverrides() != null
                 ? preferences.getTierOverrides().get(tier)
                 : null;
         if (existing == null || existing.getModel() == null) {
-            return CommandPort.CommandResult.success(msg("command.model.no.override", tier));
+            return CommandOutcome.success(msg("command.model.no.override", tier));
         }
 
         ModelSelectionService.ValidationResult validation = modelSelectionService.validateReasoning(
                 existing.getModel(), level);
         if (!validation.valid()) {
             if (ERR_NO_REASONING.equals(validation.error())) {
-                return CommandPort.CommandResult.success(msg("command.model.no.reasoning", existing.getModel()));
+                return CommandOutcome.success(msg("command.model.no.reasoning", existing.getModel()));
             }
             List<String> available = modelSelectionService.getAvailableModels().stream()
                     .filter(model -> model.id().equals(existing.getModel())
                             || existing.getModel().endsWith("/" + model.id()))
                     .flatMap(model -> model.reasoningLevels().stream())
                     .toList();
-            return CommandPort.CommandResult.success(
+            return CommandOutcome.success(
                     msg("command.model.invalid.reasoning", level, String.join(", ", available)));
         }
 
         existing.setReasoning(level);
         preferencesService.savePreferences(preferences);
-        return CommandPort.CommandResult.success(msg("command.model.set.reasoning", tier, level));
+        return CommandOutcome.success(msg("command.model.set.reasoning", tier, level));
     }
 
-    private CommandPort.CommandResult handleModelReset(String tier) {
+    private CommandOutcome handleModelReset(String tier) {
         UserPreferences preferences = preferencesService.getPreferences();
         if (preferences.getTierOverrides() != null) {
             preferences.getTierOverrides().remove(tier);
             preferencesService.savePreferences(preferences);
         }
-        return CommandPort.CommandResult.success(msg("command.model.reset", tier));
+        return CommandOutcome.success(msg("command.model.reset", tier));
     }
 
     private String findDefaultReasoning(String modelSpec) {
@@ -203,5 +202,18 @@ public class ModelSelectionCommandService {
 
     private String msg(String key, Object... args) {
         return preferencesService.getMessage(key, args);
+    }
+
+    public record CommandOutcome(
+            boolean success,
+            String output
+    ) {
+        public static CommandOutcome success(String output) {
+            return new CommandOutcome(true, output);
+        }
+
+        public static CommandOutcome failure(String output) {
+            return new CommandOutcome(false, output);
+        }
     }
 }

--- a/src/main/java/me/golemcore/bot/application/command/ModelSelectionCommandService.java
+++ b/src/main/java/me/golemcore/bot/application/command/ModelSelectionCommandService.java
@@ -8,18 +8,15 @@ import me.golemcore.bot.domain.service.RuntimeConfigService;
 import me.golemcore.bot.domain.service.UserPreferencesService;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
 public class ModelSelectionCommandService {
 
-    private static final String SUBCMD_LIST = "list";
-    private static final String SUBCMD_RESET = "reset";
-    private static final String SUBCMD_REASONING = "reasoning";
-    private static final int MIN_REASONING_ARGS = 2;
     private static final String ERR_PROVIDER_NOT_CONFIGURED = "provider.not.configured";
     private static final String ERR_NO_REASONING = "no.reasoning";
 
@@ -27,164 +24,139 @@ public class ModelSelectionCommandService {
     private final ModelSelectionService modelSelectionService;
     private final RuntimeConfigService runtimeConfigService;
 
-    public CommandOutcome handleTier(List<String> args) {
-        UserPreferences preferences = preferencesService.getPreferences();
-
-        if (args.isEmpty()) {
+    public TierOutcome handleTier(TierRequest request) {
+        if (request instanceof ShowTierStatus) {
+            UserPreferences preferences = preferencesService.getPreferences();
             String tier = preferences.getModelTier() != null ? preferences.getModelTier() : "balanced";
-            String force = preferences.isTierForce() ? "on" : "off";
-            return CommandOutcome.success(msg("command.tier.current", tier, force));
+            return new CurrentTier(tier, preferences.isTierForce());
         }
 
-        String tierArg = ModelTierCatalog.normalizeTierId(args.get(0));
+        SetTierSelection setTier = (SetTierSelection) request;
+        String tierArg = ModelTierCatalog.normalizeTierId(setTier.tier());
         if (!ModelTierCatalog.isExplicitSelectableTier(tierArg)) {
-            return CommandOutcome.success(msg("command.tier.invalid"));
+            return new InvalidTier();
         }
 
-        boolean force = args.size() > 1 && "force".equalsIgnoreCase(args.get(1));
+        UserPreferences preferences = preferencesService.getPreferences();
+        boolean force = setTier.force();
         preferences.setModelTier(tierArg);
         preferences.setTierForce(force);
         preferencesService.savePreferences(preferences);
-
-        if (force) {
-            return CommandOutcome.success(msg("command.tier.set.force", tierArg));
-        }
-        return CommandOutcome.success(msg("command.tier.set", tierArg));
+        return new TierUpdated(tierArg, force);
     }
 
-    public CommandOutcome handleModel(List<String> args) {
-        if (args.isEmpty()) {
+    public ModelOutcome handleModel(ModelRequest request) {
+        if (request instanceof ShowModelSelection) {
             return handleModelShow();
         }
-
-        String subcommand = ModelTierCatalog.normalizeTierId(args.get(0));
-        if (SUBCMD_LIST.equals(subcommand)) {
+        if (request instanceof ListAvailableModels) {
             return handleModelList();
         }
-        if (!ModelTierCatalog.isExplicitSelectableTier(subcommand)) {
-            return CommandOutcome.success(msg("command.model.invalid.tier"));
-        }
 
-        String tier = subcommand;
-        List<String> subArgs = args.subList(1, args.size());
-        if (subArgs.isEmpty()) {
-            return CommandOutcome.success(msg("command.model.usage"));
+        if (request instanceof SetModelOverride setModelOverride) {
+            return handleModelSet(setModelOverride.tier(), setModelOverride.modelSpec());
         }
-
-        String action = subArgs.get(0).toLowerCase(Locale.ROOT);
-        if (SUBCMD_RESET.equals(action)) {
-            return handleModelReset(tier);
+        if (request instanceof SetReasoningLevel setReasoningLevel) {
+            return handleModelSetReasoning(setReasoningLevel.tier(), setReasoningLevel.level());
         }
-        if (SUBCMD_REASONING.equals(action)) {
-            if (subArgs.size() < MIN_REASONING_ARGS) {
-                return CommandOutcome.success(msg("command.model.usage"));
-            }
-            return handleModelSetReasoning(tier, subArgs.get(1).toLowerCase(Locale.ROOT));
-        }
-
-        return handleModelSet(tier, subArgs.get(0));
+        ResetModelOverride resetModelOverride = (ResetModelOverride) request;
+        return handleModelReset(resetModelOverride.tier());
     }
 
-    private CommandOutcome handleModelShow() {
+    private ModelOutcome handleModelShow() {
         UserPreferences preferences = preferencesService.getPreferences();
-        StringBuilder builder = new StringBuilder();
-        builder.append("**").append(msg("command.model.show.title")).append("**\n\n");
-
+        List<TierSelection> selections = new ArrayList<>();
         for (String tier : ModelTierCatalog.orderedExplicitTiers()) {
             ModelSelectionService.ModelSelection selection = modelSelectionService.resolveForTier(tier);
-            String model = selection.model() != null ? selection.model() : "—";
-            String reasoning = selection.reasoning() != null ? selection.reasoning() : "—";
             boolean hasOverride = preferences.getTierOverrides() != null
                     && preferences.getTierOverrides().containsKey(tier);
-            String messageKey = hasOverride ? "command.model.show.tier.override" : "command.model.show.tier.default";
-            builder.append(msg(messageKey, tier, model, reasoning)).append("\n");
+            selections.add(new TierSelection(tier, selection.model(), selection.reasoning(), hasOverride));
         }
-
-        return CommandOutcome.success(builder.toString());
+        return new ModelSelectionOverview(List.copyOf(selections));
     }
 
-    private CommandOutcome handleModelList() {
+    private ModelOutcome handleModelList() {
         Map<String, List<ModelSelectionService.AvailableModel>> grouped = modelSelectionService
                 .getAvailableModelsGrouped();
-        if (grouped.isEmpty()) {
-            return CommandOutcome.success(msg("command.model.list.title") + "\n\nNo models available.");
-        }
-
-        StringBuilder builder = new StringBuilder();
-        builder.append("**").append(msg("command.model.list.title")).append("**\n\n");
-
+        Map<String, List<AvailableModelOption>> modelsByProvider = new LinkedHashMap<>();
         for (Map.Entry<String, List<ModelSelectionService.AvailableModel>> entry : grouped.entrySet()) {
-            builder.append(msg("command.model.list.provider", entry.getKey())).append("\n");
-            for (ModelSelectionService.AvailableModel model : entry.getValue()) {
-                String reasoningInfo = model.hasReasoning()
-                        ? " [reasoning: " + String.join(", ", model.reasoningLevels()) + "]"
-                        : "";
-                builder.append(msg("command.model.list.model", model.id(), model.displayName(), reasoningInfo))
-                        .append("\n");
-            }
-            builder.append("\n");
+            List<AvailableModelOption> options = entry.getValue().stream()
+                    .map(model -> new AvailableModelOption(
+                            model.id(),
+                            model.displayName(),
+                            model.hasReasoning(),
+                            List.copyOf(model.reasoningLevels())))
+                    .toList();
+            modelsByProvider.put(entry.getKey(), options);
         }
-
-        return CommandOutcome.success(builder.toString());
+        return new AvailableModels(modelsByProvider);
     }
 
-    private CommandOutcome handleModelSet(String tier, String modelSpec) {
+    private ModelOutcome handleModelSet(String tier, String modelSpec) {
+        if (!ModelTierCatalog.isExplicitSelectableTier(tier)) {
+            return new InvalidModelTier();
+        }
+
         ModelSelectionService.ValidationResult validation = modelSelectionService.validateModel(modelSpec);
         if (!validation.valid()) {
             if (ERR_PROVIDER_NOT_CONFIGURED.equals(validation.error())) {
-                String configuredProviders = String.join(", ", runtimeConfigService.getConfiguredLlmProviders());
-                return CommandOutcome.success(
-                        msg("command.model.invalid.provider", modelSpec, configuredProviders));
+                return new ProviderNotConfigured(modelSpec,
+                        List.copyOf(runtimeConfigService.getConfiguredLlmProviders()));
             }
-            return CommandOutcome.success(msg("command.model.invalid.model", modelSpec));
+            return new InvalidModel(modelSpec);
         }
 
         UserPreferences preferences = preferencesService.getPreferences();
         String defaultReasoning = findDefaultReasoning(modelSpec);
-        UserPreferences.TierOverride override = new UserPreferences.TierOverride(modelSpec, defaultReasoning);
-        preferences.getTierOverrides().put(tier, override);
+        Map<String, UserPreferences.TierOverride> tierOverrides = ensureTierOverrides(preferences);
+        tierOverrides.put(tier, new UserPreferences.TierOverride(modelSpec, defaultReasoning));
         preferencesService.savePreferences(preferences);
-
-        String displayReasoning = defaultReasoning != null ? " (reasoning: " + defaultReasoning + ")" : "";
-        return CommandOutcome.success(msg("command.model.set", tier, modelSpec) + displayReasoning);
+        return new ModelOverrideSet(tier, modelSpec, defaultReasoning);
     }
 
-    private CommandOutcome handleModelSetReasoning(String tier, String level) {
+    private ModelOutcome handleModelSetReasoning(String tier, String level) {
+        if (!ModelTierCatalog.isExplicitSelectableTier(tier)) {
+            return new InvalidModelTier();
+        }
+
         UserPreferences preferences = preferencesService.getPreferences();
         UserPreferences.TierOverride existing = preferences.getTierOverrides() != null
                 ? preferences.getTierOverrides().get(tier)
                 : null;
         if (existing == null || existing.getModel() == null) {
-            return CommandOutcome.success(msg("command.model.no.override", tier));
+            return new MissingModelOverride(tier);
         }
 
         ModelSelectionService.ValidationResult validation = modelSelectionService.validateReasoning(
                 existing.getModel(), level);
         if (!validation.valid()) {
             if (ERR_NO_REASONING.equals(validation.error())) {
-                return CommandOutcome.success(msg("command.model.no.reasoning", existing.getModel()));
+                return new MissingReasoningSupport(existing.getModel());
             }
             List<String> available = modelSelectionService.getAvailableModels().stream()
                     .filter(model -> model.id().equals(existing.getModel())
                             || existing.getModel().endsWith("/" + model.id()))
                     .flatMap(model -> model.reasoningLevels().stream())
                     .toList();
-            return CommandOutcome.success(
-                    msg("command.model.invalid.reasoning", level, String.join(", ", available)));
+            return new InvalidReasoningLevel(level, available);
         }
 
         existing.setReasoning(level);
         preferencesService.savePreferences(preferences);
-        return CommandOutcome.success(msg("command.model.set.reasoning", tier, level));
+        return new ModelReasoningSet(tier, level);
     }
 
-    private CommandOutcome handleModelReset(String tier) {
+    private ModelOutcome handleModelReset(String tier) {
+        if (!ModelTierCatalog.isExplicitSelectableTier(tier)) {
+            return new InvalidModelTier();
+        }
+
         UserPreferences preferences = preferencesService.getPreferences();
         if (preferences.getTierOverrides() != null) {
             preferences.getTierOverrides().remove(tier);
             preferencesService.savePreferences(preferences);
         }
-        return CommandOutcome.success(msg("command.model.reset", tier));
+        return new ModelOverrideReset(tier);
     }
 
     private String findDefaultReasoning(String modelSpec) {
@@ -200,20 +172,91 @@ public class ModelSelectionCommandService {
         return null;
     }
 
-    private String msg(String key, Object... args) {
-        return preferencesService.getMessage(key, args);
+    private Map<String, UserPreferences.TierOverride> ensureTierOverrides(UserPreferences preferences) {
+        if (preferences.getTierOverrides() == null) {
+            preferences.setTierOverrides(new LinkedHashMap<>());
+        }
+        return preferences.getTierOverrides();
     }
 
-    public record CommandOutcome(
-            boolean success,
-            String output
-    ) {
-        public static CommandOutcome success(String output) {
-            return new CommandOutcome(true, output);
+    public sealed
+
+    interface TierRequest
+    permits ShowTierStatus, SetTierSelection
+    {
         }
 
-        public static CommandOutcome failure(String output) {
-            return new CommandOutcome(false, output);
-        }
-    }
+    public record ShowTierStatus() implements TierRequest {}
+
+    public record SetTierSelection(String tier, boolean force) implements TierRequest {}
+
+    public sealed
+
+        interface TierOutcome
+        permits CurrentTier, TierUpdated, InvalidTier
+        {
+            }
+
+    public record CurrentTier(String tier, boolean force) implements TierOutcome {}
+
+    public record TierUpdated(String tier, boolean force) implements TierOutcome {}
+
+    public record InvalidTier() implements TierOutcome {}
+
+    public sealed
+
+            interface ModelRequest
+            permits ShowModelSelection, ListAvailableModels, SetModelOverride, SetReasoningLevel, ResetModelOverride
+            {
+                }
+
+    public record ShowModelSelection() implements ModelRequest {}
+
+    public record ListAvailableModels() implements ModelRequest {}
+
+    public record SetModelOverride(String tier, String modelSpec) implements ModelRequest {}
+
+    public record SetReasoningLevel(String tier, String level) implements ModelRequest {}
+
+    public record ResetModelOverride(String tier) implements ModelRequest {}
+
+    public sealed
+
+                interface ModelOutcome
+            permits ModelSelectionOverview, AvailableModels, InvalidModelTier, ModelOverrideSet,
+            ProviderNotConfigured, InvalidModel, MissingModelOverride, MissingReasoningSupport,
+            InvalidReasoningLevel, ModelReasoningSet, ModelOverrideReset
+                {
+                    }
+
+    public record ModelSelectionOverview(List<TierSelection> tiers) implements ModelOutcome {}
+
+    public record TierSelection(String tier, String model, String reasoning, boolean hasOverride) {}
+
+    public record AvailableModels(Map<String, List<AvailableModelOption>> modelsByProvider) implements ModelOutcome {}
+
+    public record AvailableModelOption(
+            String id,
+            String displayName,
+            boolean hasReasoning,
+            List<String> reasoningLevels
+    ) {}
+
+    public record InvalidModelTier() implements ModelOutcome {}
+
+    public record ModelOverrideSet(String tier, String modelSpec, String defaultReasoning) implements ModelOutcome {}
+
+    public record ProviderNotConfigured(String modelSpec, List<String> configuredProviders) implements ModelOutcome {}
+
+    public record InvalidModel(String modelSpec) implements ModelOutcome {}
+
+    public record MissingModelOverride(String tier) implements ModelOutcome {}
+
+    public record MissingReasoningSupport(String modelSpec) implements ModelOutcome {}
+
+    public record InvalidReasoningLevel(String requestedLevel, List<String> availableLevels) implements ModelOutcome {}
+
+    public record ModelReasoningSet(String tier, String level) implements ModelOutcome {}
+
+    public record ModelOverrideReset(String tier) implements ModelOutcome {}
 }

--- a/src/main/java/me/golemcore/bot/application/command/ModelSelectionCommandService.java
+++ b/src/main/java/me/golemcore/bot/application/command/ModelSelectionCommandService.java
@@ -1,0 +1,207 @@
+package me.golemcore.bot.application.command;
+
+import lombok.RequiredArgsConstructor;
+import me.golemcore.bot.domain.model.ModelTierCatalog;
+import me.golemcore.bot.domain.model.UserPreferences;
+import me.golemcore.bot.domain.service.ModelSelectionService;
+import me.golemcore.bot.domain.service.RuntimeConfigService;
+import me.golemcore.bot.domain.service.UserPreferencesService;
+import me.golemcore.bot.port.inbound.CommandPort;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class ModelSelectionCommandService {
+
+    private static final String SUBCMD_LIST = "list";
+    private static final String SUBCMD_RESET = "reset";
+    private static final String SUBCMD_REASONING = "reasoning";
+    private static final int MIN_REASONING_ARGS = 2;
+    private static final String ERR_PROVIDER_NOT_CONFIGURED = "provider.not.configured";
+    private static final String ERR_NO_REASONING = "no.reasoning";
+
+    private final UserPreferencesService preferencesService;
+    private final ModelSelectionService modelSelectionService;
+    private final RuntimeConfigService runtimeConfigService;
+
+    public CommandPort.CommandResult handleTier(List<String> args) {
+        UserPreferences preferences = preferencesService.getPreferences();
+
+        if (args.isEmpty()) {
+            String tier = preferences.getModelTier() != null ? preferences.getModelTier() : "balanced";
+            String force = preferences.isTierForce() ? "on" : "off";
+            return CommandPort.CommandResult.success(msg("command.tier.current", tier, force));
+        }
+
+        String tierArg = ModelTierCatalog.normalizeTierId(args.get(0));
+        if (!ModelTierCatalog.isExplicitSelectableTier(tierArg)) {
+            return CommandPort.CommandResult.success(msg("command.tier.invalid"));
+        }
+
+        boolean force = args.size() > 1 && "force".equalsIgnoreCase(args.get(1));
+        preferences.setModelTier(tierArg);
+        preferences.setTierForce(force);
+        preferencesService.savePreferences(preferences);
+
+        if (force) {
+            return CommandPort.CommandResult.success(msg("command.tier.set.force", tierArg));
+        }
+        return CommandPort.CommandResult.success(msg("command.tier.set", tierArg));
+    }
+
+    public CommandPort.CommandResult handleModel(List<String> args) {
+        if (args.isEmpty()) {
+            return handleModelShow();
+        }
+
+        String subcommand = ModelTierCatalog.normalizeTierId(args.get(0));
+        if (SUBCMD_LIST.equals(subcommand)) {
+            return handleModelList();
+        }
+        if (!ModelTierCatalog.isExplicitSelectableTier(subcommand)) {
+            return CommandPort.CommandResult.success(msg("command.model.invalid.tier"));
+        }
+
+        String tier = subcommand;
+        List<String> subArgs = args.subList(1, args.size());
+        if (subArgs.isEmpty()) {
+            return CommandPort.CommandResult.success(msg("command.model.usage"));
+        }
+
+        String action = subArgs.get(0).toLowerCase(Locale.ROOT);
+        if (SUBCMD_RESET.equals(action)) {
+            return handleModelReset(tier);
+        }
+        if (SUBCMD_REASONING.equals(action)) {
+            if (subArgs.size() < MIN_REASONING_ARGS) {
+                return CommandPort.CommandResult.success(msg("command.model.usage"));
+            }
+            return handleModelSetReasoning(tier, subArgs.get(1).toLowerCase(Locale.ROOT));
+        }
+
+        return handleModelSet(tier, subArgs.get(0));
+    }
+
+    private CommandPort.CommandResult handleModelShow() {
+        UserPreferences preferences = preferencesService.getPreferences();
+        StringBuilder builder = new StringBuilder();
+        builder.append("**").append(msg("command.model.show.title")).append("**\n\n");
+
+        for (String tier : ModelTierCatalog.orderedExplicitTiers()) {
+            ModelSelectionService.ModelSelection selection = modelSelectionService.resolveForTier(tier);
+            String model = selection.model() != null ? selection.model() : "—";
+            String reasoning = selection.reasoning() != null ? selection.reasoning() : "—";
+            boolean hasOverride = preferences.getTierOverrides() != null
+                    && preferences.getTierOverrides().containsKey(tier);
+            String messageKey = hasOverride ? "command.model.show.tier.override" : "command.model.show.tier.default";
+            builder.append(msg(messageKey, tier, model, reasoning)).append("\n");
+        }
+
+        return CommandPort.CommandResult.success(builder.toString());
+    }
+
+    private CommandPort.CommandResult handleModelList() {
+        Map<String, List<ModelSelectionService.AvailableModel>> grouped = modelSelectionService
+                .getAvailableModelsGrouped();
+        if (grouped.isEmpty()) {
+            return CommandPort.CommandResult.success(msg("command.model.list.title") + "\n\nNo models available.");
+        }
+
+        StringBuilder builder = new StringBuilder();
+        builder.append("**").append(msg("command.model.list.title")).append("**\n\n");
+
+        for (Map.Entry<String, List<ModelSelectionService.AvailableModel>> entry : grouped.entrySet()) {
+            builder.append(msg("command.model.list.provider", entry.getKey())).append("\n");
+            for (ModelSelectionService.AvailableModel model : entry.getValue()) {
+                String reasoningInfo = model.hasReasoning()
+                        ? " [reasoning: " + String.join(", ", model.reasoningLevels()) + "]"
+                        : "";
+                builder.append(msg("command.model.list.model", model.id(), model.displayName(), reasoningInfo))
+                        .append("\n");
+            }
+            builder.append("\n");
+        }
+
+        return CommandPort.CommandResult.success(builder.toString());
+    }
+
+    private CommandPort.CommandResult handleModelSet(String tier, String modelSpec) {
+        ModelSelectionService.ValidationResult validation = modelSelectionService.validateModel(modelSpec);
+        if (!validation.valid()) {
+            if (ERR_PROVIDER_NOT_CONFIGURED.equals(validation.error())) {
+                String configuredProviders = String.join(", ", runtimeConfigService.getConfiguredLlmProviders());
+                return CommandPort.CommandResult.success(
+                        msg("command.model.invalid.provider", modelSpec, configuredProviders));
+            }
+            return CommandPort.CommandResult.success(msg("command.model.invalid.model", modelSpec));
+        }
+
+        UserPreferences preferences = preferencesService.getPreferences();
+        String defaultReasoning = findDefaultReasoning(modelSpec);
+        UserPreferences.TierOverride override = new UserPreferences.TierOverride(modelSpec, defaultReasoning);
+        preferences.getTierOverrides().put(tier, override);
+        preferencesService.savePreferences(preferences);
+
+        String displayReasoning = defaultReasoning != null ? " (reasoning: " + defaultReasoning + ")" : "";
+        return CommandPort.CommandResult.success(msg("command.model.set", tier, modelSpec) + displayReasoning);
+    }
+
+    private CommandPort.CommandResult handleModelSetReasoning(String tier, String level) {
+        UserPreferences preferences = preferencesService.getPreferences();
+        UserPreferences.TierOverride existing = preferences.getTierOverrides() != null
+                ? preferences.getTierOverrides().get(tier)
+                : null;
+        if (existing == null || existing.getModel() == null) {
+            return CommandPort.CommandResult.success(msg("command.model.no.override", tier));
+        }
+
+        ModelSelectionService.ValidationResult validation = modelSelectionService.validateReasoning(
+                existing.getModel(), level);
+        if (!validation.valid()) {
+            if (ERR_NO_REASONING.equals(validation.error())) {
+                return CommandPort.CommandResult.success(msg("command.model.no.reasoning", existing.getModel()));
+            }
+            List<String> available = modelSelectionService.getAvailableModels().stream()
+                    .filter(model -> model.id().equals(existing.getModel())
+                            || existing.getModel().endsWith("/" + model.id()))
+                    .flatMap(model -> model.reasoningLevels().stream())
+                    .toList();
+            return CommandPort.CommandResult.success(
+                    msg("command.model.invalid.reasoning", level, String.join(", ", available)));
+        }
+
+        existing.setReasoning(level);
+        preferencesService.savePreferences(preferences);
+        return CommandPort.CommandResult.success(msg("command.model.set.reasoning", tier, level));
+    }
+
+    private CommandPort.CommandResult handleModelReset(String tier) {
+        UserPreferences preferences = preferencesService.getPreferences();
+        if (preferences.getTierOverrides() != null) {
+            preferences.getTierOverrides().remove(tier);
+            preferencesService.savePreferences(preferences);
+        }
+        return CommandPort.CommandResult.success(msg("command.model.reset", tier));
+    }
+
+    private String findDefaultReasoning(String modelSpec) {
+        List<ModelSelectionService.AvailableModel> models = modelSelectionService.getAvailableModels();
+        for (ModelSelectionService.AvailableModel model : models) {
+            if (model.id().equals(modelSpec) || modelSpec.endsWith("/" + model.id())) {
+                if (model.hasReasoning() && !model.reasoningLevels().isEmpty()) {
+                    List<String> levels = model.reasoningLevels();
+                    return levels.contains("medium") ? "medium" : levels.get(0);
+                }
+            }
+        }
+        return null;
+    }
+
+    private String msg(String key, Object... args) {
+        return preferencesService.getMessage(key, args);
+    }
+}

--- a/src/test/java/me/golemcore/bot/adapter/inbound/command/CommandRouterDelayedActionsTest.java
+++ b/src/test/java/me/golemcore/bot/adapter/inbound/command/CommandRouterDelayedActionsTest.java
@@ -12,7 +12,6 @@ import me.golemcore.bot.domain.service.AutoModeService;
 import me.golemcore.bot.domain.service.CompactionOrchestrationService;
 import me.golemcore.bot.domain.service.DelayedActionPolicyService;
 import me.golemcore.bot.domain.service.DelayedSessionActionService;
-import me.golemcore.bot.domain.service.ModelSelectionService;
 import me.golemcore.bot.domain.service.PlanExecutionService;
 import me.golemcore.bot.domain.service.PlanService;
 import me.golemcore.bot.domain.service.RuntimeConfigService;
@@ -105,10 +104,7 @@ class CommandRouterDelayedActionsTest {
                 preferencesService,
                 mock(CompactionOrchestrationService.class),
                 mock(AutoModeService.class),
-                new ModelSelectionCommandService(
-                        preferencesService,
-                        mock(ModelSelectionService.class),
-                        mock(RuntimeConfigService.class)),
+                mock(ModelSelectionCommandService.class),
                 mock(PlanService.class),
                 mock(PlanExecutionService.class),
                 mock(ScheduleService.class),
@@ -189,10 +185,7 @@ class CommandRouterDelayedActionsTest {
                 preferencesService,
                 mock(CompactionOrchestrationService.class),
                 mock(AutoModeService.class),
-                new ModelSelectionCommandService(
-                        preferencesService,
-                        mock(ModelSelectionService.class),
-                        runtimeConfigService),
+                mock(ModelSelectionCommandService.class),
                 mock(PlanService.class),
                 mock(PlanExecutionService.class),
                 mock(ScheduleService.class),

--- a/src/test/java/me/golemcore/bot/adapter/inbound/command/CommandRouterDelayedActionsTest.java
+++ b/src/test/java/me/golemcore/bot/adapter/inbound/command/CommandRouterDelayedActionsTest.java
@@ -1,5 +1,6 @@
 package me.golemcore.bot.adapter.inbound.command;
 
+import me.golemcore.bot.application.command.ModelSelectionCommandService;
 import me.golemcore.bot.domain.component.SkillComponent;
 import me.golemcore.bot.domain.component.ToolComponent;
 import me.golemcore.bot.domain.model.DelayedActionDeliveryMode;
@@ -104,7 +105,10 @@ class CommandRouterDelayedActionsTest {
                 preferencesService,
                 mock(CompactionOrchestrationService.class),
                 mock(AutoModeService.class),
-                mock(ModelSelectionService.class),
+                new ModelSelectionCommandService(
+                        preferencesService,
+                        mock(ModelSelectionService.class),
+                        mock(RuntimeConfigService.class)),
                 mock(PlanService.class),
                 mock(PlanExecutionService.class),
                 mock(ScheduleService.class),
@@ -185,7 +189,10 @@ class CommandRouterDelayedActionsTest {
                 preferencesService,
                 mock(CompactionOrchestrationService.class),
                 mock(AutoModeService.class),
-                mock(ModelSelectionService.class),
+                new ModelSelectionCommandService(
+                        preferencesService,
+                        mock(ModelSelectionService.class),
+                        runtimeConfigService),
                 mock(PlanService.class),
                 mock(PlanExecutionService.class),
                 mock(ScheduleService.class),

--- a/src/test/java/me/golemcore/bot/adapter/inbound/command/CommandRouterTest.java
+++ b/src/test/java/me/golemcore/bot/adapter/inbound/command/CommandRouterTest.java
@@ -16,11 +16,9 @@ import me.golemcore.bot.domain.model.SessionIdentity;
 import me.golemcore.bot.domain.model.Skill;
 import me.golemcore.bot.domain.model.ToolDefinition;
 import me.golemcore.bot.domain.model.UsageStats;
-import me.golemcore.bot.domain.model.UserPreferences;
 import me.golemcore.bot.domain.service.AutoModeService;
 import me.golemcore.bot.domain.service.CompactionOrchestrationService;
 import me.golemcore.bot.domain.service.DelayedActionPolicyService;
-import me.golemcore.bot.domain.service.ModelSelectionService;
 import me.golemcore.bot.domain.service.PlanExecutionService;
 import me.golemcore.bot.domain.service.PlanService;
 import me.golemcore.bot.domain.service.RuntimeConfigService;
@@ -40,7 +38,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -81,8 +78,6 @@ class CommandRouterTest {
     private static final String TOOL_FILESYSTEM = "filesystem";
     private static final String TOOL_SHELL = "shell";
     private static final String CMD_TIER = "tier";
-    private static final String TIER_BALANCED = "balanced";
-    private static final String TIER_CODING = "coding";
     private static final String TIER_SMART = "smart";
     private static final String SUB_STATUS = "status";
     private static final String SUB_OFF = "off";
@@ -96,7 +91,7 @@ class CommandRouterTest {
     private UserPreferencesService preferencesService;
     private CompactionOrchestrationService compactionService;
     private AutoModeService autoModeService;
-    private ModelSelectionService modelSelectionService;
+    private ModelSelectionCommandService modelSelectionCommandService;
     private PlanService planService;
     private PlanExecutionService planExecutionService;
     private RuntimeConfigService runtimeConfigService;
@@ -143,7 +138,7 @@ class CommandRouterTest {
         });
 
         autoModeService = mock(AutoModeService.class);
-        modelSelectionService = mock(ModelSelectionService.class);
+        modelSelectionCommandService = mock(ModelSelectionCommandService.class);
         planService = mock(PlanService.class);
         planExecutionService = mock(PlanExecutionService.class);
         runtimeConfigService = mock(RuntimeConfigService.class);
@@ -168,7 +163,7 @@ class CommandRouterTest {
                 preferencesService,
                 compactionService,
                 autoModeService,
-                new ModelSelectionCommandService(preferencesService, modelSelectionService, runtimeConfigService),
+                modelSelectionCommandService,
                 planService,
                 planExecutionService,
                 scheduleService,
@@ -1079,96 +1074,15 @@ class CommandRouterTest {
     // ===== Tier commands =====
 
     @Test
-    void tierNoArgsShowsCurrentDefault() throws Exception {
-        when(preferencesService.getPreferences()).thenReturn(
-                UserPreferences.builder().build()); // modelTier=null, tierForce=false
+    void tierCommandDelegatesToApplicationService() throws Exception {
+        when(modelSelectionCommandService.handleTier(List.of())).thenReturn(
+                ModelSelectionCommandService.CommandOutcome.success("tier current"));
 
         CommandPort.CommandResult result = router.execute(CMD_TIER, List.of(), CTX).get();
+
         assertTrue(result.success());
-        assertTrue(result.output().contains("command.tier.current"));
-        assertTrue(result.output().contains(TIER_BALANCED));
-        assertTrue(result.output().contains("off"));
-    }
-
-    @Test
-    void tierNoArgsShowsCurrentWithForce() throws Exception {
-        when(preferencesService.getPreferences()).thenReturn(
-                UserPreferences.builder().modelTier(TIER_SMART).tierForce(true).build());
-
-        CommandPort.CommandResult result = router.execute(CMD_TIER, List.of(), CTX).get();
-        assertTrue(result.success());
-        assertTrue(result.output().contains(TIER_SMART));
-        assertTrue(result.output().contains("on"));
-    }
-
-    @Test
-    void tierSetsCodingTier() throws Exception {
-        UserPreferences prefs = UserPreferences.builder().build();
-        when(preferencesService.getPreferences()).thenReturn(prefs);
-
-        CommandPort.CommandResult result = router.execute(CMD_TIER, List.of(TIER_CODING), CTX).get();
-        assertTrue(result.success());
-        assertTrue(result.output().contains("command.tier.set"));
-        assertTrue(result.output().contains(TIER_CODING));
-        assertEquals(TIER_CODING, prefs.getModelTier());
-        assertFalse(prefs.isTierForce());
-        verify(preferencesService).savePreferences(prefs);
-    }
-
-    @Test
-    void tierSetsWithForce() throws Exception {
-        UserPreferences prefs = UserPreferences.builder().build();
-        when(preferencesService.getPreferences()).thenReturn(prefs);
-
-        CommandPort.CommandResult result = router.execute(CMD_TIER, List.of(TIER_SMART, "force"), CTX).get();
-        assertTrue(result.success());
-        assertTrue(result.output().contains("command.tier.set.force"));
-        assertTrue(result.output().contains(TIER_SMART));
-        assertEquals(TIER_SMART, prefs.getModelTier());
-        assertTrue(prefs.isTierForce());
-        verify(preferencesService).savePreferences(prefs);
-    }
-
-    @Test
-    void tierClearsForceWhenSettingWithoutForce() throws Exception {
-        UserPreferences prefs = UserPreferences.builder().modelTier(TIER_SMART).tierForce(true).build();
-        when(preferencesService.getPreferences()).thenReturn(prefs);
-
-        CommandPort.CommandResult result = router.execute(CMD_TIER, List.of(TIER_BALANCED), CTX).get();
-        assertTrue(result.success());
-        assertEquals(TIER_BALANCED, prefs.getModelTier());
-        assertFalse(prefs.isTierForce());
-    }
-
-    @Test
-    void tierRejectsInvalidTier() throws Exception {
-        when(preferencesService.getPreferences()).thenReturn(UserPreferences.builder().build());
-
-        CommandPort.CommandResult result = router.execute(CMD_TIER, List.of("turbo"), CTX).get();
-        assertTrue(result.success());
-        assertTrue(result.output().contains("command.tier.invalid"));
-        verify(preferencesService, never()).savePreferences(any());
-    }
-
-    @Test
-    void tierAcceptsAllValidTiers() throws Exception {
-        for (String tier : List.of(
-                TIER_BALANCED,
-                TIER_SMART,
-                "deep",
-                TIER_CODING,
-                "special1",
-                "special2",
-                "special3",
-                "special4",
-                "special5")) {
-            UserPreferences prefs = UserPreferences.builder().build();
-            when(preferencesService.getPreferences()).thenReturn(prefs);
-
-            CommandPort.CommandResult result = router.execute(CMD_TIER, List.of(tier), CTX).get();
-            assertTrue(result.success());
-            assertEquals(tier, prefs.getModelTier());
-        }
+        assertEquals("tier current", result.output());
+        verify(modelSelectionCommandService).handleTier(List.of());
     }
 
     // ===== formatTokens =====
@@ -1421,248 +1335,26 @@ class CommandRouterTest {
     private static final String CMD_MODEL = "model";
 
     @Test
-    void modelShowCommand() throws Exception {
-        when(preferencesService.getPreferences()).thenReturn(
-                UserPreferences.builder().tierOverrides(new HashMap<>()).build());
-        for (String tier : List.of(
-                TIER_BALANCED,
-                TIER_SMART,
-                "deep",
-                TIER_CODING,
-                "special1",
-                "special2",
-                "special3",
-                "special4",
-                "special5")) {
-            when(modelSelectionService.resolveForTier(tier))
-                    .thenReturn(new ModelSelectionService.ModelSelection("some-model", "medium"));
-        }
-
-        CommandPort.CommandResult result = router.execute(CMD_MODEL, List.of(), CTX).get();
-        assertTrue(result.success());
-        assertTrue(result.output().contains("command.model.show.title"));
-    }
-
-    @Test
-    void modelShowCommandIncludesSpecialTiers() throws Exception {
-        when(preferencesService.getPreferences()).thenReturn(
-                UserPreferences.builder().tierOverrides(new HashMap<>()).build());
-        for (String tier : List.of(
-                TIER_BALANCED,
-                TIER_SMART,
-                "deep",
-                TIER_CODING,
-                "special1",
-                "special2",
-                "special3",
-                "special4",
-                "special5")) {
-            when(modelSelectionService.resolveForTier(tier))
-                    .thenReturn(new ModelSelectionService.ModelSelection("model-for-" + tier, "medium"));
-        }
-
-        CommandPort.CommandResult result = router.execute(CMD_MODEL, List.of(), CTX).get();
-
-        assertTrue(result.success());
-        assertTrue(result.output().contains("special1"));
-        assertTrue(result.output().contains("special5"));
-    }
-
-    @Test
-    void modelShowCommandWithOverride() throws Exception {
-        when(preferencesService.getPreferences()).thenReturn(
-                UserPreferences.builder()
-                        .tierOverrides(new HashMap<>(Map.of(TIER_CODING,
-                                new UserPreferences.TierOverride("openai/gpt-5.1", "high"))))
-                        .build());
-        for (String tier : List.of(
-                TIER_BALANCED,
-                TIER_SMART,
-                "deep",
-                TIER_CODING,
-                "special1",
-                "special2",
-                "special3",
-                "special4",
-                "special5")) {
-            when(modelSelectionService.resolveForTier(tier))
-                    .thenReturn(new ModelSelectionService.ModelSelection("some-model", "medium"));
-        }
-
-        CommandPort.CommandResult result = router.execute(CMD_MODEL, List.of(), CTX).get();
-        assertTrue(result.success());
-        assertTrue(result.output().contains("command.model.show.tier.override"));
-    }
-
-    @Test
-    void modelListCommand() throws Exception {
-        Map<String, List<ModelSelectionService.AvailableModel>> grouped = new LinkedHashMap<>();
-        grouped.put("openai", List.of(
-                new ModelSelectionService.AvailableModel("gpt-5.1", "openai", "GPT-5.1",
-                        true, List.of("low", "medium", "high"), true)));
-        when(modelSelectionService.getAvailableModelsGrouped()).thenReturn(grouped);
+    void modelCommandDelegatesToApplicationService() throws Exception {
+        when(modelSelectionCommandService.handleModel(List.of("list"))).thenReturn(
+                ModelSelectionCommandService.CommandOutcome.success("model list"));
 
         CommandPort.CommandResult result = router.execute(CMD_MODEL, List.of("list"), CTX).get();
+
         assertTrue(result.success());
-        assertTrue(result.output().contains("command.model.list.title"));
-        assertTrue(result.output().contains("gpt-5.1"));
+        assertEquals("model list", result.output());
+        verify(modelSelectionCommandService).handleModel(List.of("list"));
     }
 
     @Test
-    void modelListCommandEmpty() throws Exception {
-        when(modelSelectionService.getAvailableModelsGrouped()).thenReturn(Collections.emptyMap());
+    void modelCommandTranslatesApplicationFailure() throws Exception {
+        when(modelSelectionCommandService.handleModel(List.of("coding", "broken"))).thenReturn(
+                ModelSelectionCommandService.CommandOutcome.failure("model failure"));
 
-        CommandPort.CommandResult result = router.execute(CMD_MODEL, List.of("list"), CTX).get();
-        assertTrue(result.success());
-        assertTrue(result.output().contains("No models available"));
-    }
+        CommandPort.CommandResult result = router.execute(CMD_MODEL, List.of("coding", "broken"), CTX).get();
 
-    @Test
-    void modelInvalidTier() throws Exception {
-        CommandPort.CommandResult result = router.execute(CMD_MODEL,
-                List.of("unknown", "openai/gpt-5.1"), CTX).get();
-        assertTrue(result.success());
-        assertTrue(result.output().contains("command.model.invalid.tier"));
-    }
-
-    @Test
-    void modelTierNoSubcommand() throws Exception {
-        CommandPort.CommandResult result = router.execute(CMD_MODEL,
-                List.of(TIER_CODING), CTX).get();
-        assertTrue(result.success());
-        assertTrue(result.output().contains("command.model.usage"));
-    }
-
-    @Test
-    void modelTierNoSubcommandAcceptsSpecialTier() throws Exception {
-        CommandPort.CommandResult result = router.execute(CMD_MODEL,
-                List.of("special3"), CTX).get();
-        assertTrue(result.success());
-        assertTrue(result.output().contains("command.model.usage"));
-    }
-
-    @Test
-    void modelSetCommand() throws Exception {
-        when(modelSelectionService.validateModel("openai/gpt-5.1"))
-                .thenReturn(new ModelSelectionService.ValidationResult(true, null));
-        when(preferencesService.getPreferences()).thenReturn(
-                UserPreferences.builder().tierOverrides(new HashMap<>()).build());
-        when(modelSelectionService.getAvailableModels()).thenReturn(List.of(
-                new ModelSelectionService.AvailableModel("gpt-5.1", "openai", "GPT-5.1",
-                        true, List.of("low", "medium", "high"), true)));
-
-        CommandPort.CommandResult result = router.execute(CMD_MODEL,
-                List.of(TIER_CODING, "openai/gpt-5.1"), CTX).get();
-        assertTrue(result.success());
-        assertTrue(result.output().contains("command.model.set"));
-        verify(preferencesService).savePreferences(any(UserPreferences.class));
-    }
-
-    @Test
-    void modelSetCommandInvalidModel() throws Exception {
-        when(modelSelectionService.validateModel("unknown/bad"))
-                .thenReturn(new ModelSelectionService.ValidationResult(false, "model.not.found"));
-
-        CommandPort.CommandResult result = router.execute(CMD_MODEL,
-                List.of(TIER_CODING, "unknown/bad"), CTX).get();
-        assertTrue(result.success());
-        assertTrue(result.output().contains("command.model.invalid.model"));
-    }
-
-    @Test
-    void modelSetCommandProviderNotConfigured() throws Exception {
-        when(modelSelectionService.validateModel("google/gemini"))
-                .thenReturn(new ModelSelectionService.ValidationResult(false, "provider.not.configured"));
-
-        CommandPort.CommandResult result = router.execute(CMD_MODEL,
-                List.of(TIER_CODING, "google/gemini"), CTX).get();
-        assertTrue(result.success());
-        assertTrue(result.output().contains("command.model.invalid.provider"));
-    }
-
-    @Test
-    void modelResetCommand() throws Exception {
-        when(preferencesService.getPreferences()).thenReturn(
-                UserPreferences.builder()
-                        .tierOverrides(new HashMap<>(Map.of(TIER_CODING,
-                                new UserPreferences.TierOverride("openai/gpt-5.1", "medium"))))
-                        .build());
-
-        CommandPort.CommandResult result = router.execute(CMD_MODEL,
-                List.of(TIER_CODING, "reset"), CTX).get();
-        assertTrue(result.success());
-        assertTrue(result.output().contains("command.model.reset"));
-        verify(preferencesService).savePreferences(any(UserPreferences.class));
-    }
-
-    @Test
-    void modelSetReasoningCommand() throws Exception {
-        UserPreferences prefs = UserPreferences.builder()
-                .tierOverrides(new HashMap<>(Map.of(TIER_CODING,
-                        new UserPreferences.TierOverride("openai/gpt-5.1", "medium"))))
-                .build();
-        when(preferencesService.getPreferences()).thenReturn(prefs);
-        when(modelSelectionService.validateReasoning("openai/gpt-5.1", "high"))
-                .thenReturn(new ModelSelectionService.ValidationResult(true, null));
-
-        CommandPort.CommandResult result = router.execute(CMD_MODEL,
-                List.of(TIER_CODING, "reasoning", "high"), CTX).get();
-        assertTrue(result.success());
-        assertTrue(result.output().contains("command.model.set.reasoning"));
-        verify(preferencesService).savePreferences(prefs);
-    }
-
-    @Test
-    void modelSetReasoningNoOverride() throws Exception {
-        when(preferencesService.getPreferences()).thenReturn(
-                UserPreferences.builder().tierOverrides(new HashMap<>()).build());
-
-        CommandPort.CommandResult result = router.execute(CMD_MODEL,
-                List.of(TIER_CODING, "reasoning", "high"), CTX).get();
-        assertTrue(result.success());
-        assertTrue(result.output().contains("command.model.no.override"));
-    }
-
-    @Test
-    void modelSetReasoningNoReasoningSupport() throws Exception {
-        UserPreferences prefs = UserPreferences.builder()
-                .tierOverrides(new HashMap<>(Map.of(TIER_CODING,
-                        new UserPreferences.TierOverride("openai/gpt-5.1", null))))
-                .build();
-        when(preferencesService.getPreferences()).thenReturn(prefs);
-        when(modelSelectionService.validateReasoning("openai/gpt-5.1", "high"))
-                .thenReturn(new ModelSelectionService.ValidationResult(false, "no.reasoning"));
-
-        CommandPort.CommandResult result = router.execute(CMD_MODEL,
-                List.of(TIER_CODING, "reasoning", "high"), CTX).get();
-        assertTrue(result.success());
-        assertTrue(result.output().contains("command.model.no.reasoning"));
-    }
-
-    @Test
-    void modelSetReasoningInvalidLevel() throws Exception {
-        UserPreferences prefs = UserPreferences.builder()
-                .tierOverrides(new HashMap<>(Map.of(TIER_CODING,
-                        new UserPreferences.TierOverride("openai/gpt-5.1", "medium"))))
-                .build();
-        when(preferencesService.getPreferences()).thenReturn(prefs);
-        when(modelSelectionService.validateReasoning("openai/gpt-5.1", "xhigh"))
-                .thenReturn(new ModelSelectionService.ValidationResult(false, "level.not.available"));
-        when(modelSelectionService.getAvailableModels()).thenReturn(List.of(
-                new ModelSelectionService.AvailableModel("gpt-5.1", "openai", "GPT-5.1",
-                        true, List.of("low", "medium", "high"), true)));
-
-        CommandPort.CommandResult result = router.execute(CMD_MODEL,
-                List.of(TIER_CODING, "reasoning", "xhigh"), CTX).get();
-        assertTrue(result.success());
-        assertTrue(result.output().contains("command.model.invalid.reasoning"));
-    }
-
-    @Test
-    void modelReasoningMissingLevel() throws Exception {
-        CommandPort.CommandResult result = router.execute(CMD_MODEL,
-                List.of(TIER_CODING, "reasoning"), CTX).get();
-        assertTrue(result.success());
-        assertTrue(result.output().contains("command.model.usage"));
+        assertFalse(result.success());
+        assertEquals("model failure", result.output());
+        verify(modelSelectionCommandService).handleModel(List.of("coding", "broken"));
     }
 }

--- a/src/test/java/me/golemcore/bot/adapter/inbound/command/CommandRouterTest.java
+++ b/src/test/java/me/golemcore/bot/adapter/inbound/command/CommandRouterTest.java
@@ -1,5 +1,6 @@
 package me.golemcore.bot.adapter.inbound.command;
 
+import me.golemcore.bot.application.command.ModelSelectionCommandService;
 import me.golemcore.bot.domain.component.SkillComponent;
 import me.golemcore.bot.domain.component.ToolComponent;
 import me.golemcore.bot.domain.model.AutoModeChannelRegisteredEvent;
@@ -167,7 +168,7 @@ class CommandRouterTest {
                 preferencesService,
                 compactionService,
                 autoModeService,
-                modelSelectionService,
+                new ModelSelectionCommandService(preferencesService, modelSelectionService, runtimeConfigService),
                 planService,
                 planExecutionService,
                 scheduleService,

--- a/src/test/java/me/golemcore/bot/adapter/inbound/command/CommandRouterTest.java
+++ b/src/test/java/me/golemcore/bot/adapter/inbound/command/CommandRouterTest.java
@@ -55,6 +55,7 @@ import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @SuppressWarnings({ "PMD.AvoidDuplicateLiterals", "unchecked" })
@@ -1074,15 +1075,29 @@ class CommandRouterTest {
     // ===== Tier commands =====
 
     @Test
-    void tierCommandDelegatesToApplicationService() throws Exception {
-        when(modelSelectionCommandService.handleTier(List.of())).thenReturn(
-                ModelSelectionCommandService.CommandOutcome.success("tier current"));
+    void tierCommandRendersCurrentTierFromApplicationOutcome() throws Exception {
+        when(modelSelectionCommandService.handleTier(new ModelSelectionCommandService.ShowTierStatus())).thenReturn(
+                new ModelSelectionCommandService.CurrentTier("smart", true));
 
         CommandPort.CommandResult result = router.execute(CMD_TIER, List.of(), CTX).get();
 
         assertTrue(result.success());
-        assertEquals("tier current", result.output());
-        verify(modelSelectionCommandService).handleTier(List.of());
+        assertEquals("command.tier.current smart on", result.output());
+        verify(modelSelectionCommandService).handleTier(new ModelSelectionCommandService.ShowTierStatus());
+    }
+
+    @Test
+    void tierCommandParsesForceFlagInAdapter() throws Exception {
+        when(modelSelectionCommandService
+                .handleTier(new ModelSelectionCommandService.SetTierSelection(TIER_SMART, true)))
+                .thenReturn(new ModelSelectionCommandService.TierUpdated(TIER_SMART, true));
+
+        CommandPort.CommandResult result = router.execute(CMD_TIER, List.of(TIER_SMART, "force"), CTX).get();
+
+        assertTrue(result.success());
+        assertEquals("command.tier.set.force smart", result.output());
+        verify(modelSelectionCommandService)
+                .handleTier(new ModelSelectionCommandService.SetTierSelection(TIER_SMART, true));
     }
 
     // ===== formatTokens =====
@@ -1335,26 +1350,56 @@ class CommandRouterTest {
     private static final String CMD_MODEL = "model";
 
     @Test
-    void modelCommandDelegatesToApplicationService() throws Exception {
-        when(modelSelectionCommandService.handleModel(List.of("list"))).thenReturn(
-                ModelSelectionCommandService.CommandOutcome.success("model list"));
+    void modelListCommandDelegatesAndRendersCatalog() throws Exception {
+        when(modelSelectionCommandService.handleModel(new ModelSelectionCommandService.ListAvailableModels()))
+                .thenReturn(
+                        new ModelSelectionCommandService.AvailableModels(Map.of(
+                                "openai", List.of(new ModelSelectionCommandService.AvailableModelOption(
+                                        "gpt-5",
+                                        "GPT-5",
+                                        true,
+                                        List.of("low", "medium"))))));
 
         CommandPort.CommandResult result = router.execute(CMD_MODEL, List.of("list"), CTX).get();
 
         assertTrue(result.success());
-        assertEquals("model list", result.output());
-        verify(modelSelectionCommandService).handleModel(List.of("list"));
+        assertTrue(result.output().contains("command.model.list.title"));
+        assertTrue(result.output().contains("gpt-5"));
+        assertTrue(result.output().contains("reasoning: low, medium"));
+        verify(modelSelectionCommandService).handleModel(new ModelSelectionCommandService.ListAvailableModels());
     }
 
     @Test
-    void modelCommandTranslatesApplicationFailure() throws Exception {
-        when(modelSelectionCommandService.handleModel(List.of("coding", "broken"))).thenReturn(
-                ModelSelectionCommandService.CommandOutcome.failure("model failure"));
+    void modelCommandRejectsInvalidTierInAdapter() throws Exception {
+        CommandPort.CommandResult result = router.execute(CMD_MODEL, List.of("unknown", "broken"), CTX).get();
 
-        CommandPort.CommandResult result = router.execute(CMD_MODEL, List.of("coding", "broken"), CTX).get();
+        assertTrue(result.success());
+        assertEquals("command.model.invalid.tier", result.output());
+        verifyNoInteractions(modelSelectionCommandService);
+    }
 
-        assertFalse(result.success());
-        assertEquals("model failure", result.output());
-        verify(modelSelectionCommandService).handleModel(List.of("coding", "broken"));
+    @Test
+    void modelReasoningCommandRequiresLevelInAdapter() throws Exception {
+        CommandPort.CommandResult result = router.execute(CMD_MODEL, List.of("coding", "reasoning"), CTX).get();
+
+        assertTrue(result.success());
+        assertEquals("command.model.usage", result.output());
+        verifyNoInteractions(modelSelectionCommandService);
+    }
+
+    @Test
+    void modelCommandRendersProviderMismatchFromApplicationOutcome() throws Exception {
+        when(modelSelectionCommandService.handleModel(
+                new ModelSelectionCommandService.SetModelOverride("coding", "anthropic/claude"))).thenReturn(
+                        new ModelSelectionCommandService.ProviderNotConfigured(
+                                "anthropic/claude",
+                                List.of("openai", "google")));
+
+        CommandPort.CommandResult result = router.execute(CMD_MODEL, List.of("coding", "anthropic/claude"), CTX).get();
+
+        assertTrue(result.success());
+        assertEquals("command.model.invalid.provider anthropic/claude openai, google", result.output());
+        verify(modelSelectionCommandService).handleModel(
+                new ModelSelectionCommandService.SetModelOverride("coding", "anthropic/claude"));
     }
 }

--- a/src/test/java/me/golemcore/bot/adapter/inbound/command/CommandRouterTest.java
+++ b/src/test/java/me/golemcore/bot/adapter/inbound/command/CommandRouterTest.java
@@ -1100,6 +1100,32 @@ class CommandRouterTest {
                 .handleTier(new ModelSelectionCommandService.SetTierSelection(TIER_SMART, true));
     }
 
+    @Test
+    void tierCommandRendersNonForcedUpdate() throws Exception {
+        when(modelSelectionCommandService
+                .handleTier(new ModelSelectionCommandService.SetTierSelection(TIER_SMART, false)))
+                .thenReturn(new ModelSelectionCommandService.TierUpdated(TIER_SMART, false));
+
+        CommandPort.CommandResult result = router.execute(CMD_TIER, List.of(TIER_SMART), CTX).get();
+
+        assertTrue(result.success());
+        assertEquals("command.tier.set smart", result.output());
+        verify(modelSelectionCommandService)
+                .handleTier(new ModelSelectionCommandService.SetTierSelection(TIER_SMART, false));
+    }
+
+    @Test
+    void tierCommandRendersInvalidOutcomeFromApplicationService() throws Exception {
+        when(modelSelectionCommandService
+                .handleTier(new ModelSelectionCommandService.SetTierSelection(TIER_SMART, false)))
+                .thenReturn(new ModelSelectionCommandService.InvalidTier());
+
+        CommandPort.CommandResult result = router.execute(CMD_TIER, List.of(TIER_SMART), CTX).get();
+
+        assertTrue(result.success());
+        assertEquals("command.tier.invalid", result.output());
+    }
+
     // ===== formatTokens =====
 
     @Test
@@ -1370,11 +1396,65 @@ class CommandRouterTest {
     }
 
     @Test
+    void modelShowCommandDelegatesAndRendersOverview() throws Exception {
+        when(modelSelectionCommandService.handleModel(new ModelSelectionCommandService.ShowModelSelection()))
+                .thenReturn(new ModelSelectionCommandService.ModelSelectionOverview(List.of(
+                        new ModelSelectionCommandService.TierSelection("balanced", null, null, false),
+                        new ModelSelectionCommandService.TierSelection("coding", "openai/gpt-5", "medium", true))));
+
+        CommandPort.CommandResult result = router.execute(CMD_MODEL, List.of(), CTX).get();
+
+        assertTrue(result.success());
+        assertTrue(result.output().contains("command.model.show.title"));
+        assertTrue(result.output().contains("command.model.show.tier.default balanced"));
+        assertTrue(result.output().contains("—"));
+        assertTrue(result.output().contains("command.model.show.tier.override coding openai/gpt-5 medium"));
+        verify(modelSelectionCommandService).handleModel(new ModelSelectionCommandService.ShowModelSelection());
+    }
+
+    @Test
+    void modelListCommandRendersEmptyCatalog() throws Exception {
+        when(modelSelectionCommandService.handleModel(new ModelSelectionCommandService.ListAvailableModels()))
+                .thenReturn(new ModelSelectionCommandService.AvailableModels(Map.of()));
+
+        CommandPort.CommandResult result = router.execute(CMD_MODEL, List.of("list"), CTX).get();
+
+        assertTrue(result.success());
+        assertEquals("command.model.list.title\n\nNo models available.", result.output());
+    }
+
+    @Test
+    void modelListCommandOmitsReasoningSuffixWhenModelHasNoReasoning() throws Exception {
+        when(modelSelectionCommandService.handleModel(new ModelSelectionCommandService.ListAvailableModels()))
+                .thenReturn(new ModelSelectionCommandService.AvailableModels(Map.of(
+                        "openai", List.of(new ModelSelectionCommandService.AvailableModelOption(
+                                "gpt-5-mini",
+                                "GPT-5 Mini",
+                                false,
+                                List.of())))));
+
+        CommandPort.CommandResult result = router.execute(CMD_MODEL, List.of("list"), CTX).get();
+
+        assertTrue(result.success());
+        assertTrue(result.output().contains("command.model.list.model gpt-5-mini GPT-5 Mini"));
+        assertFalse(result.output().contains("reasoning:"));
+    }
+
+    @Test
     void modelCommandRejectsInvalidTierInAdapter() throws Exception {
         CommandPort.CommandResult result = router.execute(CMD_MODEL, List.of("unknown", "broken"), CTX).get();
 
         assertTrue(result.success());
         assertEquals("command.model.invalid.tier", result.output());
+        verifyNoInteractions(modelSelectionCommandService);
+    }
+
+    @Test
+    void modelCommandShowsUsageWhenActionMissing() throws Exception {
+        CommandPort.CommandResult result = router.execute(CMD_MODEL, List.of("coding"), CTX).get();
+
+        assertTrue(result.success());
+        assertEquals("command.model.usage", result.output());
         verifyNoInteractions(modelSelectionCommandService);
     }
 
@@ -1385,6 +1465,56 @@ class CommandRouterTest {
         assertTrue(result.success());
         assertEquals("command.model.usage", result.output());
         verifyNoInteractions(modelSelectionCommandService);
+    }
+
+    @Test
+    void modelResetCommandDelegatesAndRendersResetOutcome() throws Exception {
+        when(modelSelectionCommandService.handleModel(new ModelSelectionCommandService.ResetModelOverride("coding")))
+                .thenReturn(new ModelSelectionCommandService.ModelOverrideReset("coding"));
+
+        CommandPort.CommandResult result = router.execute(CMD_MODEL, List.of("coding", "reset"), CTX).get();
+
+        assertTrue(result.success());
+        assertEquals("command.model.reset coding", result.output());
+        verify(modelSelectionCommandService).handleModel(new ModelSelectionCommandService.ResetModelOverride("coding"));
+    }
+
+    @Test
+    void modelReasoningCommandDelegatesAndRendersUpdate() throws Exception {
+        when(modelSelectionCommandService
+                .handleModel(new ModelSelectionCommandService.SetReasoningLevel("coding", "high")))
+                .thenReturn(new ModelSelectionCommandService.ModelReasoningSet("coding", "high"));
+
+        CommandPort.CommandResult result = router.execute(CMD_MODEL, List.of("coding", "reasoning", "high"), CTX).get();
+
+        assertTrue(result.success());
+        assertEquals("command.model.set.reasoning coding high", result.output());
+        verify(modelSelectionCommandService)
+                .handleModel(new ModelSelectionCommandService.SetReasoningLevel("coding", "high"));
+    }
+
+    @Test
+    void modelCommandRendersSuccessfulOverrideWithDefaultReasoning() throws Exception {
+        when(modelSelectionCommandService.handleModel(
+                new ModelSelectionCommandService.SetModelOverride("coding", "openai/gpt-5"))).thenReturn(
+                        new ModelSelectionCommandService.ModelOverrideSet("coding", "openai/gpt-5", "medium"));
+
+        CommandPort.CommandResult result = router.execute(CMD_MODEL, List.of("coding", "openai/gpt-5"), CTX).get();
+
+        assertTrue(result.success());
+        assertEquals("command.model.set coding openai/gpt-5 (reasoning: medium)", result.output());
+    }
+
+    @Test
+    void modelCommandRendersSuccessfulOverrideWithoutDefaultReasoning() throws Exception {
+        when(modelSelectionCommandService.handleModel(
+                new ModelSelectionCommandService.SetModelOverride("coding", "openai/gpt-5-mini"))).thenReturn(
+                        new ModelSelectionCommandService.ModelOverrideSet("coding", "openai/gpt-5-mini", null));
+
+        CommandPort.CommandResult result = router.execute(CMD_MODEL, List.of("coding", "openai/gpt-5-mini"), CTX).get();
+
+        assertTrue(result.success());
+        assertEquals("command.model.set coding openai/gpt-5-mini", result.output());
     }
 
     @Test
@@ -1401,5 +1531,68 @@ class CommandRouterTest {
         assertEquals("command.model.invalid.provider anthropic/claude openai, google", result.output());
         verify(modelSelectionCommandService).handleModel(
                 new ModelSelectionCommandService.SetModelOverride("coding", "anthropic/claude"));
+    }
+
+    @Test
+    void modelCommandRendersInvalidTierFromApplicationOutcome() throws Exception {
+        when(modelSelectionCommandService.handleModel(
+                new ModelSelectionCommandService.SetModelOverride("coding", "openai/gpt-5"))).thenReturn(
+                        new ModelSelectionCommandService.InvalidModelTier());
+
+        CommandPort.CommandResult result = router.execute(CMD_MODEL, List.of("coding", "openai/gpt-5"), CTX).get();
+
+        assertTrue(result.success());
+        assertEquals("command.model.invalid.tier", result.output());
+    }
+
+    @Test
+    void modelCommandRendersInvalidModelFromApplicationOutcome() throws Exception {
+        when(modelSelectionCommandService.handleModel(
+                new ModelSelectionCommandService.SetModelOverride("coding", "unknown/bad"))).thenReturn(
+                        new ModelSelectionCommandService.InvalidModel("unknown/bad"));
+
+        CommandPort.CommandResult result = router.execute(CMD_MODEL, List.of("coding", "unknown/bad"), CTX).get();
+
+        assertTrue(result.success());
+        assertEquals("command.model.invalid.model unknown/bad", result.output());
+    }
+
+    @Test
+    void modelCommandRendersMissingOverrideFromApplicationOutcome() throws Exception {
+        when(modelSelectionCommandService
+                .handleModel(new ModelSelectionCommandService.SetReasoningLevel("coding", "high")))
+                .thenReturn(new ModelSelectionCommandService.MissingModelOverride("coding"));
+
+        CommandPort.CommandResult result = router.execute(CMD_MODEL, List.of("coding", "reasoning", "high"), CTX).get();
+
+        assertTrue(result.success());
+        assertEquals("command.model.no.override coding", result.output());
+    }
+
+    @Test
+    void modelCommandRendersMissingReasoningSupportFromApplicationOutcome() throws Exception {
+        when(modelSelectionCommandService
+                .handleModel(new ModelSelectionCommandService.SetReasoningLevel("coding", "high")))
+                .thenReturn(new ModelSelectionCommandService.MissingReasoningSupport("openai/gpt-5-mini"));
+
+        CommandPort.CommandResult result = router.execute(CMD_MODEL, List.of("coding", "reasoning", "high"), CTX).get();
+
+        assertTrue(result.success());
+        assertEquals("command.model.no.reasoning openai/gpt-5-mini", result.output());
+    }
+
+    @Test
+    void modelCommandRendersInvalidReasoningLevelFromApplicationOutcome() throws Exception {
+        when(modelSelectionCommandService
+                .handleModel(new ModelSelectionCommandService.SetReasoningLevel("coding", "xhigh")))
+                .thenReturn(new ModelSelectionCommandService.InvalidReasoningLevel(
+                        "xhigh",
+                        List.of("low", "medium", "high")));
+
+        CommandPort.CommandResult result = router.execute(CMD_MODEL, List.of("coding", "reasoning", "xhigh"), CTX)
+                .get();
+
+        assertTrue(result.success());
+        assertEquals("command.model.invalid.reasoning xhigh low, medium, high", result.output());
     }
 }

--- a/src/test/java/me/golemcore/bot/application/command/ModelSelectionCommandServiceTest.java
+++ b/src/test/java/me/golemcore/bot/application/command/ModelSelectionCommandServiceTest.java
@@ -1,0 +1,180 @@
+package me.golemcore.bot.application.command;
+
+import me.golemcore.bot.domain.model.UserPreferences;
+import me.golemcore.bot.domain.service.ModelSelectionService;
+import me.golemcore.bot.domain.service.RuntimeConfigService;
+import me.golemcore.bot.domain.service.UserPreferencesService;
+import me.golemcore.bot.port.inbound.CommandPort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.RETURNS_DEFAULTS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ModelSelectionCommandServiceTest {
+
+    private UserPreferencesService preferencesService;
+    private ModelSelectionService modelSelectionService;
+    private RuntimeConfigService runtimeConfigService;
+    private UserPreferences preferences;
+    private ModelSelectionCommandService service;
+
+    @BeforeEach
+    void setUp() {
+        preferencesService = mock(UserPreferencesService.class, invocation -> {
+            if ("getMessage".equals(invocation.getMethod().getName())) {
+                String key = (String) invocation.getArguments()[0];
+                StringBuilder builder = new StringBuilder(key);
+                Object[] args = java.util.Arrays.copyOfRange(
+                        invocation.getArguments(),
+                        1,
+                        invocation.getArguments().length);
+                for (Object arg : args) {
+                    builder.append(" ").append(arg);
+                }
+                return builder.toString();
+            }
+            return RETURNS_DEFAULTS.answer(invocation);
+        });
+        modelSelectionService = mock(ModelSelectionService.class);
+        runtimeConfigService = mock(RuntimeConfigService.class);
+        preferences = UserPreferences.builder()
+                .tierOverrides(new LinkedHashMap<>())
+                .build();
+        when(preferencesService.getPreferences()).thenReturn(preferences);
+        service = new ModelSelectionCommandService(preferencesService, modelSelectionService, runtimeConfigService);
+    }
+
+    @Test
+    void shouldShowCurrentTierWhenNoArgs() {
+        preferences.setModelTier("coding");
+        preferences.setTierForce(true);
+
+        CommandPort.CommandResult result = service.handleTier(List.of());
+
+        assertTrue(result.success());
+        assertTrue(result.output().contains("command.tier.current"));
+        assertTrue(result.output().contains("coding"));
+        assertTrue(result.output().contains("on"));
+    }
+
+    @Test
+    void shouldSetTierAndForceWhenRequested() {
+        CommandPort.CommandResult result = service.handleTier(List.of("smart", "force"));
+
+        assertTrue(result.success());
+        assertEquals("smart", preferences.getModelTier());
+        assertTrue(preferences.isTierForce());
+        verify(preferencesService).savePreferences(preferences);
+    }
+
+    @Test
+    void shouldRejectInvalidTier() {
+        CommandPort.CommandResult result = service.handleTier(List.of("turbo"));
+
+        assertTrue(result.success());
+        assertEquals("command.tier.invalid", result.output());
+    }
+
+    @Test
+    void shouldShowResolvedModelsForEachTier() {
+        preferences.getTierOverrides().put("balanced", new UserPreferences.TierOverride("openai/gpt-5", "medium"));
+        for (String tier : me.golemcore.bot.domain.model.ModelTierCatalog.orderedExplicitTiers()) {
+            when(modelSelectionService.resolveForTier(tier))
+                    .thenReturn(new ModelSelectionService.ModelSelection("openai/" + tier, "medium"));
+        }
+
+        CommandPort.CommandResult result = service.handleModel(List.of());
+
+        assertTrue(result.success());
+        assertTrue(result.output().contains("command.model.show.title"));
+        assertTrue(result.output().contains("command.model.show.tier.override"));
+        assertTrue(result.output().contains("command.model.show.tier.default"));
+    }
+
+    @Test
+    void shouldListModelsGroupedByProvider() {
+        when(modelSelectionService.getAvailableModelsGrouped()).thenReturn(Map.of(
+                "openai", List.of(
+                        new ModelSelectionService.AvailableModel(
+                                "gpt-5",
+                                "openai",
+                                "GPT-5",
+                                true,
+                                List.of("low", "medium"),
+                                false))));
+
+        CommandPort.CommandResult result = service.handleModel(List.of("list"));
+
+        assertTrue(result.success());
+        assertTrue(result.output().contains("command.model.list.provider"));
+        assertTrue(result.output().contains("gpt-5"));
+        assertTrue(result.output().contains("[reasoning: low, medium]"));
+    }
+
+    @Test
+    void shouldSetModelOverrideWithDefaultReasoning() {
+        when(modelSelectionService.validateModel("openai/gpt-5"))
+                .thenReturn(new ModelSelectionService.ValidationResult(true, null));
+        when(modelSelectionService.getAvailableModels()).thenReturn(List.of(
+                new ModelSelectionService.AvailableModel(
+                        "gpt-5",
+                        "openai",
+                        "GPT-5",
+                        true,
+                        List.of("low", "medium"),
+                        false)));
+
+        CommandPort.CommandResult result = service.handleModel(List.of("balanced", "openai/gpt-5"));
+
+        assertTrue(result.success());
+        assertEquals("openai/gpt-5", preferences.getTierOverrides().get("balanced").getModel());
+        assertEquals("medium", preferences.getTierOverrides().get("balanced").getReasoning());
+        verify(preferencesService).savePreferences(preferences);
+    }
+
+    @Test
+    void shouldExplainProviderMismatchUsingConfiguredProviders() {
+        when(modelSelectionService.validateModel("anthropic/claude"))
+                .thenReturn(new ModelSelectionService.ValidationResult(false, "provider.not.configured"));
+        when(runtimeConfigService.getConfiguredLlmProviders()).thenReturn(List.of("openai", "google"));
+
+        CommandPort.CommandResult result = service.handleModel(List.of("balanced", "anthropic/claude"));
+
+        assertTrue(result.success());
+        assertTrue(result.output().contains("command.model.invalid.provider"));
+        assertTrue(result.output().contains("openai, google"));
+    }
+
+    @Test
+    void shouldSetReasoningLevelForExistingOverride() {
+        preferences.getTierOverrides().put("balanced", new UserPreferences.TierOverride("openai/gpt-5", "low"));
+        when(modelSelectionService.validateReasoning("openai/gpt-5", "medium"))
+                .thenReturn(new ModelSelectionService.ValidationResult(true, null));
+
+        CommandPort.CommandResult result = service.handleModel(List.of("balanced", "reasoning", "medium"));
+
+        assertTrue(result.success());
+        assertEquals("medium", preferences.getTierOverrides().get("balanced").getReasoning());
+        verify(preferencesService).savePreferences(preferences);
+    }
+
+    @Test
+    void shouldResetTierOverride() {
+        preferences.getTierOverrides().put("balanced", new UserPreferences.TierOverride("openai/gpt-5", "low"));
+
+        CommandPort.CommandResult result = service.handleModel(List.of("balanced", "reset"));
+
+        assertTrue(result.success());
+        assertTrue(preferences.getTierOverrides().isEmpty());
+        verify(preferencesService).savePreferences(preferences);
+    }
+}

--- a/src/test/java/me/golemcore/bot/application/command/ModelSelectionCommandServiceTest.java
+++ b/src/test/java/me/golemcore/bot/application/command/ModelSelectionCommandServiceTest.java
@@ -194,6 +194,49 @@ class ModelSelectionCommandServiceTest {
     }
 
     @Test
+    void shouldInitializeTierOverridesWhenMissingAndAllowNullDefaultReasoning() {
+        preferences.setTierOverrides(null);
+        when(modelSelectionService.validateModel("openai/gpt-5-mini"))
+                .thenReturn(new ModelSelectionService.ValidationResult(true, null));
+        when(modelSelectionService.getAvailableModels()).thenReturn(List.of());
+
+        ModelSelectionCommandService.ModelOverrideSet result = assertInstanceOf(
+                ModelSelectionCommandService.ModelOverrideSet.class,
+                service.handleModel(
+                        new ModelSelectionCommandService.SetModelOverride("balanced", "openai/gpt-5-mini")));
+
+        assertEquals("balanced", result.tier());
+        assertEquals("openai/gpt-5-mini", result.modelSpec());
+        assertNull(result.defaultReasoning());
+        assertEquals("openai/gpt-5-mini", preferences.getTierOverrides().get("balanced").getModel());
+        assertNull(preferences.getTierOverrides().get("balanced").getReasoning());
+        verify(preferencesService).savePreferences(preferences);
+    }
+
+    @Test
+    void shouldKeepDefaultReasoningNullWhenCatalogContainsOnlyOtherModels() {
+        when(modelSelectionService.validateModel("openai/gpt-5-mini"))
+                .thenReturn(new ModelSelectionService.ValidationResult(true, null));
+        when(modelSelectionService.getAvailableModels()).thenReturn(List.of(
+                new ModelSelectionService.AvailableModel(
+                        "gpt-5",
+                        "openai",
+                        "GPT-5",
+                        true,
+                        List.of("low", "medium"),
+                        false)));
+
+        ModelSelectionCommandService.ModelOverrideSet result = assertInstanceOf(
+                ModelSelectionCommandService.ModelOverrideSet.class,
+                service.handleModel(
+                        new ModelSelectionCommandService.SetModelOverride("balanced", "openai/gpt-5-mini")));
+
+        assertNull(result.defaultReasoning());
+        assertNull(preferences.getTierOverrides().get("balanced").getReasoning());
+        verify(preferencesService).savePreferences(preferences);
+    }
+
+    @Test
     void shouldRejectUnknownModel() {
         when(modelSelectionService.validateModel("unknown/bad"))
                 .thenReturn(new ModelSelectionService.ValidationResult(false, "model.not.found"));
@@ -246,6 +289,16 @@ class ModelSelectionCommandServiceTest {
     }
 
     @Test
+    void shouldRejectReasoningWhenTierIsInvalid() {
+        ModelSelectionCommandService.InvalidModelTier result = assertInstanceOf(
+                ModelSelectionCommandService.InvalidModelTier.class,
+                service.handleModel(new ModelSelectionCommandService.SetReasoningLevel("unknown", "high")));
+
+        assertInstanceOf(ModelSelectionCommandService.InvalidModelTier.class, result);
+        verify(preferencesService, never()).savePreferences(any());
+    }
+
+    @Test
     void shouldRejectReasoningForNonReasoningModel() {
         preferences.getTierOverrides().put("coding", new UserPreferences.TierOverride("openai/gpt-5", null));
         when(modelSelectionService.validateReasoning("openai/gpt-5", "high"))
@@ -291,6 +344,16 @@ class ModelSelectionCommandServiceTest {
         assertEquals("balanced", result.tier());
         assertNull(preferences.getTierOverrides().get("balanced"));
         verify(preferencesService).savePreferences(preferences);
+    }
+
+    @Test
+    void shouldRejectResetWhenTierIsInvalid() {
+        ModelSelectionCommandService.InvalidModelTier result = assertInstanceOf(
+                ModelSelectionCommandService.InvalidModelTier.class,
+                service.handleModel(new ModelSelectionCommandService.ResetModelOverride("unknown")));
+
+        assertInstanceOf(ModelSelectionCommandService.InvalidModelTier.class, result);
+        verify(preferencesService, never()).savePreferences(any());
     }
 
     private void stubSelections(String prefix) {

--- a/src/test/java/me/golemcore/bot/application/command/ModelSelectionCommandServiceTest.java
+++ b/src/test/java/me/golemcore/bot/application/command/ModelSelectionCommandServiceTest.java
@@ -1,10 +1,10 @@
 package me.golemcore.bot.application.command;
 
+import me.golemcore.bot.domain.model.ModelTierCatalog;
 import me.golemcore.bot.domain.model.UserPreferences;
 import me.golemcore.bot.domain.service.ModelSelectionService;
 import me.golemcore.bot.domain.service.RuntimeConfigService;
 import me.golemcore.bot.domain.service.UserPreferencesService;
-import me.golemcore.bot.port.inbound.CommandPort;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -13,9 +13,12 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.RETURNS_DEFAULTS;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -58,7 +61,7 @@ class ModelSelectionCommandServiceTest {
         preferences.setModelTier("coding");
         preferences.setTierForce(true);
 
-        CommandPort.CommandResult result = service.handleTier(List.of());
+        ModelSelectionCommandService.CommandOutcome result = service.handleTier(List.of());
 
         assertTrue(result.success());
         assertTrue(result.output().contains("command.tier.current"));
@@ -68,7 +71,7 @@ class ModelSelectionCommandServiceTest {
 
     @Test
     void shouldSetTierAndForceWhenRequested() {
-        CommandPort.CommandResult result = service.handleTier(List.of("smart", "force"));
+        ModelSelectionCommandService.CommandOutcome result = service.handleTier(List.of("smart", "force"));
 
         assertTrue(result.success());
         assertEquals("smart", preferences.getModelTier());
@@ -77,27 +80,53 @@ class ModelSelectionCommandServiceTest {
     }
 
     @Test
-    void shouldRejectInvalidTier() {
-        CommandPort.CommandResult result = service.handleTier(List.of("turbo"));
+    void shouldClearForceWhenSettingWithoutForce() {
+        preferences.setModelTier("smart");
+        preferences.setTierForce(true);
+
+        ModelSelectionCommandService.CommandOutcome result = service.handleTier(List.of("balanced"));
 
         assertTrue(result.success());
-        assertEquals("command.tier.invalid", result.output());
+        assertEquals("balanced", preferences.getModelTier());
+        assertFalse(preferences.isTierForce());
+        verify(preferencesService).savePreferences(preferences);
     }
 
     @Test
-    void shouldShowResolvedModelsForEachTier() {
-        preferences.getTierOverrides().put("balanced", new UserPreferences.TierOverride("openai/gpt-5", "medium"));
-        for (String tier : me.golemcore.bot.domain.model.ModelTierCatalog.orderedExplicitTiers()) {
-            when(modelSelectionService.resolveForTier(tier))
-                    .thenReturn(new ModelSelectionService.ModelSelection("openai/" + tier, "medium"));
-        }
+    void shouldRejectInvalidTier() {
+        ModelSelectionCommandService.CommandOutcome result = service.handleTier(List.of("turbo"));
 
-        CommandPort.CommandResult result = service.handleModel(List.of());
+        assertTrue(result.success());
+        assertEquals("command.tier.invalid", result.output());
+        verify(preferencesService, never()).savePreferences(any());
+    }
+
+    @Test
+    void shouldAcceptAllSelectableTiers() {
+        for (String tier : ModelTierCatalog.orderedExplicitTiers()) {
+            preferences.setTierForce(true);
+
+            ModelSelectionCommandService.CommandOutcome result = service.handleTier(List.of(tier));
+
+            assertTrue(result.success());
+            assertEquals(tier, preferences.getModelTier());
+            assertFalse(preferences.isTierForce());
+        }
+    }
+
+    @Test
+    void shouldShowResolvedModelsForEachTierIncludingSpecials() {
+        preferences.getTierOverrides().put("balanced", new UserPreferences.TierOverride("openai/gpt-5", "medium"));
+        stubSelections("model-for-");
+
+        ModelSelectionCommandService.CommandOutcome result = service.handleModel(List.of());
 
         assertTrue(result.success());
         assertTrue(result.output().contains("command.model.show.title"));
         assertTrue(result.output().contains("command.model.show.tier.override"));
         assertTrue(result.output().contains("command.model.show.tier.default"));
+        assertTrue(result.output().contains("special1"));
+        assertTrue(result.output().contains("special5"));
     }
 
     @Test
@@ -112,12 +141,47 @@ class ModelSelectionCommandServiceTest {
                                 List.of("low", "medium"),
                                 false))));
 
-        CommandPort.CommandResult result = service.handleModel(List.of("list"));
+        ModelSelectionCommandService.CommandOutcome result = service.handleModel(List.of("list"));
 
         assertTrue(result.success());
         assertTrue(result.output().contains("command.model.list.provider"));
         assertTrue(result.output().contains("gpt-5"));
         assertTrue(result.output().contains("[reasoning: low, medium]"));
+    }
+
+    @Test
+    void shouldReturnFriendlyMessageWhenNoModelsAvailable() {
+        when(modelSelectionService.getAvailableModelsGrouped()).thenReturn(Map.of());
+
+        ModelSelectionCommandService.CommandOutcome result = service.handleModel(List.of("list"));
+
+        assertTrue(result.success());
+        assertTrue(result.output().contains("command.model.list.title"));
+        assertTrue(result.output().contains("No models available."));
+    }
+
+    @Test
+    void shouldRejectInvalidModelTier() {
+        ModelSelectionCommandService.CommandOutcome result = service.handleModel(List.of("unknown", "openai/gpt-5"));
+
+        assertTrue(result.success());
+        assertEquals("command.model.invalid.tier", result.output());
+    }
+
+    @Test
+    void shouldReturnUsageWhenModelTierMissingAction() {
+        ModelSelectionCommandService.CommandOutcome result = service.handleModel(List.of("coding"));
+
+        assertTrue(result.success());
+        assertEquals("command.model.usage", result.output());
+    }
+
+    @Test
+    void shouldAcceptSpecialTierForModelUsage() {
+        ModelSelectionCommandService.CommandOutcome result = service.handleModel(List.of("special3"));
+
+        assertTrue(result.success());
+        assertEquals("command.model.usage", result.output());
     }
 
     @Test
@@ -133,7 +197,7 @@ class ModelSelectionCommandServiceTest {
                         List.of("low", "medium"),
                         false)));
 
-        CommandPort.CommandResult result = service.handleModel(List.of("balanced", "openai/gpt-5"));
+        ModelSelectionCommandService.CommandOutcome result = service.handleModel(List.of("balanced", "openai/gpt-5"));
 
         assertTrue(result.success());
         assertEquals("openai/gpt-5", preferences.getTierOverrides().get("balanced").getModel());
@@ -142,12 +206,25 @@ class ModelSelectionCommandServiceTest {
     }
 
     @Test
+    void shouldRejectUnknownModel() {
+        when(modelSelectionService.validateModel("unknown/bad"))
+                .thenReturn(new ModelSelectionService.ValidationResult(false, "model.not.found"));
+
+        ModelSelectionCommandService.CommandOutcome result = service.handleModel(List.of("coding", "unknown/bad"));
+
+        assertTrue(result.success());
+        assertEquals("command.model.invalid.model unknown/bad", result.output());
+        verify(preferencesService, never()).savePreferences(any());
+    }
+
+    @Test
     void shouldExplainProviderMismatchUsingConfiguredProviders() {
         when(modelSelectionService.validateModel("anthropic/claude"))
                 .thenReturn(new ModelSelectionService.ValidationResult(false, "provider.not.configured"));
         when(runtimeConfigService.getConfiguredLlmProviders()).thenReturn(List.of("openai", "google"));
 
-        CommandPort.CommandResult result = service.handleModel(List.of("balanced", "anthropic/claude"));
+        ModelSelectionCommandService.CommandOutcome result = service
+                .handleModel(List.of("balanced", "anthropic/claude"));
 
         assertTrue(result.success());
         assertTrue(result.output().contains("command.model.invalid.provider"));
@@ -160,7 +237,8 @@ class ModelSelectionCommandServiceTest {
         when(modelSelectionService.validateReasoning("openai/gpt-5", "medium"))
                 .thenReturn(new ModelSelectionService.ValidationResult(true, null));
 
-        CommandPort.CommandResult result = service.handleModel(List.of("balanced", "reasoning", "medium"));
+        ModelSelectionCommandService.CommandOutcome result = service
+                .handleModel(List.of("balanced", "reasoning", "medium"));
 
         assertTrue(result.success());
         assertEquals("medium", preferences.getTierOverrides().get("balanced").getReasoning());
@@ -168,13 +246,71 @@ class ModelSelectionCommandServiceTest {
     }
 
     @Test
+    void shouldRejectReasoningWhenOverrideMissing() {
+        ModelSelectionCommandService.CommandOutcome result = service
+                .handleModel(List.of("coding", "reasoning", "high"));
+
+        assertTrue(result.success());
+        assertEquals("command.model.no.override coding", result.output());
+    }
+
+    @Test
+    void shouldRejectReasoningForNonReasoningModel() {
+        preferences.getTierOverrides().put("coding", new UserPreferences.TierOverride("openai/gpt-5", null));
+        when(modelSelectionService.validateReasoning("openai/gpt-5", "high"))
+                .thenReturn(new ModelSelectionService.ValidationResult(false, "no.reasoning"));
+
+        ModelSelectionCommandService.CommandOutcome result = service
+                .handleModel(List.of("coding", "reasoning", "high"));
+
+        assertTrue(result.success());
+        assertEquals("command.model.no.reasoning openai/gpt-5", result.output());
+    }
+
+    @Test
+    void shouldExplainInvalidReasoningLevel() {
+        preferences.getTierOverrides().put("coding", new UserPreferences.TierOverride("openai/gpt-5", "medium"));
+        when(modelSelectionService.validateReasoning("openai/gpt-5", "xhigh"))
+                .thenReturn(new ModelSelectionService.ValidationResult(false, "level.not.available"));
+        when(modelSelectionService.getAvailableModels()).thenReturn(List.of(
+                new ModelSelectionService.AvailableModel(
+                        "gpt-5",
+                        "openai",
+                        "GPT-5",
+                        true,
+                        List.of("low", "medium", "high"),
+                        false)));
+
+        ModelSelectionCommandService.CommandOutcome result = service
+                .handleModel(List.of("coding", "reasoning", "xhigh"));
+
+        assertTrue(result.success());
+        assertEquals("command.model.invalid.reasoning xhigh low, medium, high", result.output());
+    }
+
+    @Test
+    void shouldReturnUsageWhenReasoningLevelMissing() {
+        ModelSelectionCommandService.CommandOutcome result = service.handleModel(List.of("coding", "reasoning"));
+
+        assertTrue(result.success());
+        assertEquals("command.model.usage", result.output());
+    }
+
+    @Test
     void shouldResetTierOverride() {
         preferences.getTierOverrides().put("balanced", new UserPreferences.TierOverride("openai/gpt-5", "low"));
 
-        CommandPort.CommandResult result = service.handleModel(List.of("balanced", "reset"));
+        ModelSelectionCommandService.CommandOutcome result = service.handleModel(List.of("balanced", "reset"));
 
         assertTrue(result.success());
         assertTrue(preferences.getTierOverrides().isEmpty());
         verify(preferencesService).savePreferences(preferences);
+    }
+
+    private void stubSelections(String prefix) {
+        for (String tier : ModelTierCatalog.orderedExplicitTiers()) {
+            when(modelSelectionService.resolveForTier(tier))
+                    .thenReturn(new ModelSelectionService.ModelSelection(prefix + tier, "medium"));
+        }
     }
 }

--- a/src/test/java/me/golemcore/bot/application/command/ModelSelectionCommandServiceTest.java
+++ b/src/test/java/me/golemcore/bot/application/command/ModelSelectionCommandServiceTest.java
@@ -14,9 +14,10 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.RETURNS_DEFAULTS;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -32,21 +33,7 @@ class ModelSelectionCommandServiceTest {
 
     @BeforeEach
     void setUp() {
-        preferencesService = mock(UserPreferencesService.class, invocation -> {
-            if ("getMessage".equals(invocation.getMethod().getName())) {
-                String key = (String) invocation.getArguments()[0];
-                StringBuilder builder = new StringBuilder(key);
-                Object[] args = java.util.Arrays.copyOfRange(
-                        invocation.getArguments(),
-                        1,
-                        invocation.getArguments().length);
-                for (Object arg : args) {
-                    builder.append(" ").append(arg);
-                }
-                return builder.toString();
-            }
-            return RETURNS_DEFAULTS.answer(invocation);
-        });
+        preferencesService = mock(UserPreferencesService.class);
         modelSelectionService = mock(ModelSelectionService.class);
         runtimeConfigService = mock(RuntimeConfigService.class);
         preferences = UserPreferences.builder()
@@ -61,19 +48,22 @@ class ModelSelectionCommandServiceTest {
         preferences.setModelTier("coding");
         preferences.setTierForce(true);
 
-        ModelSelectionCommandService.CommandOutcome result = service.handleTier(List.of());
+        ModelSelectionCommandService.CurrentTier result = assertInstanceOf(
+                ModelSelectionCommandService.CurrentTier.class,
+                service.handleTier(new ModelSelectionCommandService.ShowTierStatus()));
 
-        assertTrue(result.success());
-        assertTrue(result.output().contains("command.tier.current"));
-        assertTrue(result.output().contains("coding"));
-        assertTrue(result.output().contains("on"));
+        assertEquals("coding", result.tier());
+        assertTrue(result.force());
     }
 
     @Test
     void shouldSetTierAndForceWhenRequested() {
-        ModelSelectionCommandService.CommandOutcome result = service.handleTier(List.of("smart", "force"));
+        ModelSelectionCommandService.TierUpdated result = assertInstanceOf(
+                ModelSelectionCommandService.TierUpdated.class,
+                service.handleTier(new ModelSelectionCommandService.SetTierSelection("smart", true)));
 
-        assertTrue(result.success());
+        assertEquals("smart", result.tier());
+        assertTrue(result.force());
         assertEquals("smart", preferences.getModelTier());
         assertTrue(preferences.isTierForce());
         verify(preferencesService).savePreferences(preferences);
@@ -84,9 +74,12 @@ class ModelSelectionCommandServiceTest {
         preferences.setModelTier("smart");
         preferences.setTierForce(true);
 
-        ModelSelectionCommandService.CommandOutcome result = service.handleTier(List.of("balanced"));
+        ModelSelectionCommandService.TierUpdated result = assertInstanceOf(
+                ModelSelectionCommandService.TierUpdated.class,
+                service.handleTier(new ModelSelectionCommandService.SetTierSelection("balanced", false)));
 
-        assertTrue(result.success());
+        assertEquals("balanced", result.tier());
+        assertFalse(result.force());
         assertEquals("balanced", preferences.getModelTier());
         assertFalse(preferences.isTierForce());
         verify(preferencesService).savePreferences(preferences);
@@ -94,10 +87,11 @@ class ModelSelectionCommandServiceTest {
 
     @Test
     void shouldRejectInvalidTier() {
-        ModelSelectionCommandService.CommandOutcome result = service.handleTier(List.of("turbo"));
+        ModelSelectionCommandService.InvalidTier result = assertInstanceOf(
+                ModelSelectionCommandService.InvalidTier.class,
+                service.handleTier(new ModelSelectionCommandService.SetTierSelection("turbo", false)));
 
-        assertTrue(result.success());
-        assertEquals("command.tier.invalid", result.output());
+        assertInstanceOf(ModelSelectionCommandService.InvalidTier.class, result);
         verify(preferencesService, never()).savePreferences(any());
     }
 
@@ -106,9 +100,12 @@ class ModelSelectionCommandServiceTest {
         for (String tier : ModelTierCatalog.orderedExplicitTiers()) {
             preferences.setTierForce(true);
 
-            ModelSelectionCommandService.CommandOutcome result = service.handleTier(List.of(tier));
+            ModelSelectionCommandService.TierUpdated result = assertInstanceOf(
+                    ModelSelectionCommandService.TierUpdated.class,
+                    service.handleTier(new ModelSelectionCommandService.SetTierSelection(tier, false)));
 
-            assertTrue(result.success());
+            assertEquals(tier, result.tier());
+            assertFalse(result.force());
             assertEquals(tier, preferences.getModelTier());
             assertFalse(preferences.isTierForce());
         }
@@ -119,14 +116,15 @@ class ModelSelectionCommandServiceTest {
         preferences.getTierOverrides().put("balanced", new UserPreferences.TierOverride("openai/gpt-5", "medium"));
         stubSelections("model-for-");
 
-        ModelSelectionCommandService.CommandOutcome result = service.handleModel(List.of());
+        ModelSelectionCommandService.ModelSelectionOverview result = assertInstanceOf(
+                ModelSelectionCommandService.ModelSelectionOverview.class,
+                service.handleModel(new ModelSelectionCommandService.ShowModelSelection()));
 
-        assertTrue(result.success());
-        assertTrue(result.output().contains("command.model.show.title"));
-        assertTrue(result.output().contains("command.model.show.tier.override"));
-        assertTrue(result.output().contains("command.model.show.tier.default"));
-        assertTrue(result.output().contains("special1"));
-        assertTrue(result.output().contains("special5"));
+        assertEquals(ModelTierCatalog.orderedExplicitTiers().size(), result.tiers().size());
+        assertTrue(result.tiers().stream()
+                .anyMatch(selection -> "balanced".equals(selection.tier()) && selection.hasOverride()));
+        assertTrue(result.tiers().stream().anyMatch(selection -> "special1".equals(selection.tier())));
+        assertTrue(result.tiers().stream().anyMatch(selection -> "special5".equals(selection.tier())));
     }
 
     @Test
@@ -141,47 +139,33 @@ class ModelSelectionCommandServiceTest {
                                 List.of("low", "medium"),
                                 false))));
 
-        ModelSelectionCommandService.CommandOutcome result = service.handleModel(List.of("list"));
+        ModelSelectionCommandService.AvailableModels result = assertInstanceOf(
+                ModelSelectionCommandService.AvailableModels.class,
+                service.handleModel(new ModelSelectionCommandService.ListAvailableModels()));
 
-        assertTrue(result.success());
-        assertTrue(result.output().contains("command.model.list.provider"));
-        assertTrue(result.output().contains("gpt-5"));
-        assertTrue(result.output().contains("[reasoning: low, medium]"));
+        assertTrue(result.modelsByProvider().containsKey("openai"));
+        assertEquals("gpt-5", result.modelsByProvider().get("openai").get(0).id());
+        assertEquals(List.of("low", "medium"), result.modelsByProvider().get("openai").get(0).reasoningLevels());
     }
 
     @Test
-    void shouldReturnFriendlyMessageWhenNoModelsAvailable() {
+    void shouldReturnEmptyCatalogWhenNoModelsAvailable() {
         when(modelSelectionService.getAvailableModelsGrouped()).thenReturn(Map.of());
 
-        ModelSelectionCommandService.CommandOutcome result = service.handleModel(List.of("list"));
+        ModelSelectionCommandService.AvailableModels result = assertInstanceOf(
+                ModelSelectionCommandService.AvailableModels.class,
+                service.handleModel(new ModelSelectionCommandService.ListAvailableModels()));
 
-        assertTrue(result.success());
-        assertTrue(result.output().contains("command.model.list.title"));
-        assertTrue(result.output().contains("No models available."));
+        assertTrue(result.modelsByProvider().isEmpty());
     }
 
     @Test
     void shouldRejectInvalidModelTier() {
-        ModelSelectionCommandService.CommandOutcome result = service.handleModel(List.of("unknown", "openai/gpt-5"));
+        ModelSelectionCommandService.InvalidModelTier result = assertInstanceOf(
+                ModelSelectionCommandService.InvalidModelTier.class,
+                service.handleModel(new ModelSelectionCommandService.SetModelOverride("unknown", "openai/gpt-5")));
 
-        assertTrue(result.success());
-        assertEquals("command.model.invalid.tier", result.output());
-    }
-
-    @Test
-    void shouldReturnUsageWhenModelTierMissingAction() {
-        ModelSelectionCommandService.CommandOutcome result = service.handleModel(List.of("coding"));
-
-        assertTrue(result.success());
-        assertEquals("command.model.usage", result.output());
-    }
-
-    @Test
-    void shouldAcceptSpecialTierForModelUsage() {
-        ModelSelectionCommandService.CommandOutcome result = service.handleModel(List.of("special3"));
-
-        assertTrue(result.success());
-        assertEquals("command.model.usage", result.output());
+        assertInstanceOf(ModelSelectionCommandService.InvalidModelTier.class, result);
     }
 
     @Test
@@ -197,9 +181,13 @@ class ModelSelectionCommandServiceTest {
                         List.of("low", "medium"),
                         false)));
 
-        ModelSelectionCommandService.CommandOutcome result = service.handleModel(List.of("balanced", "openai/gpt-5"));
+        ModelSelectionCommandService.ModelOverrideSet result = assertInstanceOf(
+                ModelSelectionCommandService.ModelOverrideSet.class,
+                service.handleModel(new ModelSelectionCommandService.SetModelOverride("balanced", "openai/gpt-5")));
 
-        assertTrue(result.success());
+        assertEquals("balanced", result.tier());
+        assertEquals("openai/gpt-5", result.modelSpec());
+        assertEquals("medium", result.defaultReasoning());
         assertEquals("openai/gpt-5", preferences.getTierOverrides().get("balanced").getModel());
         assertEquals("medium", preferences.getTierOverrides().get("balanced").getReasoning());
         verify(preferencesService).savePreferences(preferences);
@@ -210,10 +198,11 @@ class ModelSelectionCommandServiceTest {
         when(modelSelectionService.validateModel("unknown/bad"))
                 .thenReturn(new ModelSelectionService.ValidationResult(false, "model.not.found"));
 
-        ModelSelectionCommandService.CommandOutcome result = service.handleModel(List.of("coding", "unknown/bad"));
+        ModelSelectionCommandService.InvalidModel result = assertInstanceOf(
+                ModelSelectionCommandService.InvalidModel.class,
+                service.handleModel(new ModelSelectionCommandService.SetModelOverride("coding", "unknown/bad")));
 
-        assertTrue(result.success());
-        assertEquals("command.model.invalid.model unknown/bad", result.output());
+        assertEquals("unknown/bad", result.modelSpec());
         verify(preferencesService, never()).savePreferences(any());
     }
 
@@ -223,12 +212,12 @@ class ModelSelectionCommandServiceTest {
                 .thenReturn(new ModelSelectionService.ValidationResult(false, "provider.not.configured"));
         when(runtimeConfigService.getConfiguredLlmProviders()).thenReturn(List.of("openai", "google"));
 
-        ModelSelectionCommandService.CommandOutcome result = service
-                .handleModel(List.of("balanced", "anthropic/claude"));
+        ModelSelectionCommandService.ProviderNotConfigured result = assertInstanceOf(
+                ModelSelectionCommandService.ProviderNotConfigured.class,
+                service.handleModel(new ModelSelectionCommandService.SetModelOverride("balanced", "anthropic/claude")));
 
-        assertTrue(result.success());
-        assertTrue(result.output().contains("command.model.invalid.provider"));
-        assertTrue(result.output().contains("openai, google"));
+        assertEquals("anthropic/claude", result.modelSpec());
+        assertEquals(List.of("openai", "google"), result.configuredProviders());
     }
 
     @Test
@@ -237,21 +226,23 @@ class ModelSelectionCommandServiceTest {
         when(modelSelectionService.validateReasoning("openai/gpt-5", "medium"))
                 .thenReturn(new ModelSelectionService.ValidationResult(true, null));
 
-        ModelSelectionCommandService.CommandOutcome result = service
-                .handleModel(List.of("balanced", "reasoning", "medium"));
+        ModelSelectionCommandService.ModelReasoningSet result = assertInstanceOf(
+                ModelSelectionCommandService.ModelReasoningSet.class,
+                service.handleModel(new ModelSelectionCommandService.SetReasoningLevel("balanced", "medium")));
 
-        assertTrue(result.success());
+        assertEquals("balanced", result.tier());
+        assertEquals("medium", result.level());
         assertEquals("medium", preferences.getTierOverrides().get("balanced").getReasoning());
         verify(preferencesService).savePreferences(preferences);
     }
 
     @Test
     void shouldRejectReasoningWhenOverrideMissing() {
-        ModelSelectionCommandService.CommandOutcome result = service
-                .handleModel(List.of("coding", "reasoning", "high"));
+        ModelSelectionCommandService.MissingModelOverride result = assertInstanceOf(
+                ModelSelectionCommandService.MissingModelOverride.class,
+                service.handleModel(new ModelSelectionCommandService.SetReasoningLevel("coding", "high")));
 
-        assertTrue(result.success());
-        assertEquals("command.model.no.override coding", result.output());
+        assertEquals("coding", result.tier());
     }
 
     @Test
@@ -260,11 +251,11 @@ class ModelSelectionCommandServiceTest {
         when(modelSelectionService.validateReasoning("openai/gpt-5", "high"))
                 .thenReturn(new ModelSelectionService.ValidationResult(false, "no.reasoning"));
 
-        ModelSelectionCommandService.CommandOutcome result = service
-                .handleModel(List.of("coding", "reasoning", "high"));
+        ModelSelectionCommandService.MissingReasoningSupport result = assertInstanceOf(
+                ModelSelectionCommandService.MissingReasoningSupport.class,
+                service.handleModel(new ModelSelectionCommandService.SetReasoningLevel("coding", "high")));
 
-        assertTrue(result.success());
-        assertEquals("command.model.no.reasoning openai/gpt-5", result.output());
+        assertEquals("openai/gpt-5", result.modelSpec());
     }
 
     @Test
@@ -281,29 +272,24 @@ class ModelSelectionCommandServiceTest {
                         List.of("low", "medium", "high"),
                         false)));
 
-        ModelSelectionCommandService.CommandOutcome result = service
-                .handleModel(List.of("coding", "reasoning", "xhigh"));
+        ModelSelectionCommandService.InvalidReasoningLevel result = assertInstanceOf(
+                ModelSelectionCommandService.InvalidReasoningLevel.class,
+                service.handleModel(new ModelSelectionCommandService.SetReasoningLevel("coding", "xhigh")));
 
-        assertTrue(result.success());
-        assertEquals("command.model.invalid.reasoning xhigh low, medium, high", result.output());
-    }
-
-    @Test
-    void shouldReturnUsageWhenReasoningLevelMissing() {
-        ModelSelectionCommandService.CommandOutcome result = service.handleModel(List.of("coding", "reasoning"));
-
-        assertTrue(result.success());
-        assertEquals("command.model.usage", result.output());
+        assertEquals("xhigh", result.requestedLevel());
+        assertEquals(List.of("low", "medium", "high"), result.availableLevels());
     }
 
     @Test
     void shouldResetTierOverride() {
         preferences.getTierOverrides().put("balanced", new UserPreferences.TierOverride("openai/gpt-5", "low"));
 
-        ModelSelectionCommandService.CommandOutcome result = service.handleModel(List.of("balanced", "reset"));
+        ModelSelectionCommandService.ModelOverrideReset result = assertInstanceOf(
+                ModelSelectionCommandService.ModelOverrideReset.class,
+                service.handleModel(new ModelSelectionCommandService.ResetModelOverride("balanced")));
 
-        assertTrue(result.success());
-        assertTrue(preferences.getTierOverrides().isEmpty());
+        assertEquals("balanced", result.tier());
+        assertNull(preferences.getTierOverrides().get("balanced"));
         verify(preferencesService).savePreferences(preferences);
     }
 


### PR DESCRIPTION
## Summary
- extract `/tier` and `/model` policy/orchestration out of `CommandRouter` into a dedicated application service
- keep `CommandRouter` as a thinner inbound adapter that delegates model-selection commands
- add direct unit coverage for the new service while preserving existing router behavior tests
