### PR TITLE
refactor(architecture): canonicalize webhook context keys

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ Common env vars (Spring) for local/Docker:
 
 ## Architecture
 
-Spring Boot 4.0.2, Java 17, Hexagonal Architecture (Ports & Adapters).
+Spring Boot 4.0.5, Java 25, Hexagonal Architecture (Ports & Adapters).
 
 ### Package Structure
 

--- a/src/main/java/me/golemcore/bot/adapter/inbound/webhook/WebhookController.java
+++ b/src/main/java/me/golemcore/bot/adapter/inbound/webhook/WebhookController.java
@@ -23,6 +23,7 @@ import me.golemcore.bot.adapter.inbound.webhook.dto.AgentRequest;
 import me.golemcore.bot.adapter.inbound.webhook.dto.WakeRequest;
 import me.golemcore.bot.adapter.inbound.webhook.dto.WebhookResponse;
 import me.golemcore.bot.domain.loop.AgentLoop;
+import me.golemcore.bot.domain.model.ContextAttributes;
 import me.golemcore.bot.domain.model.Message;
 import me.golemcore.bot.domain.model.ModelTierCatalog;
 import me.golemcore.bot.domain.model.UserPreferences;
@@ -194,9 +195,9 @@ public class WebhookController {
                 metadata.put("webhook.modelTier", modelTier);
             }
             if (request.isDeliver()) {
-                metadata.put("webhook.deliver", true);
-                metadata.put("webhook.deliver.channel", request.getChannel());
-                metadata.put("webhook.deliver.to", request.getTo());
+                metadata.put(ContextAttributes.WEBHOOK_DELIVER, true);
+                metadata.put(ContextAttributes.WEBHOOK_DELIVER_CHANNEL, request.getChannel());
+                metadata.put(ContextAttributes.WEBHOOK_DELIVER_TO, request.getTo());
             }
 
             String deliveryId = null;
@@ -304,9 +305,9 @@ public class WebhookController {
             metadata.put("webhook.modelTier", modelTier);
         }
         if (mapping.isDeliver()) {
-            metadata.put("webhook.deliver", true);
-            metadata.put("webhook.deliver.channel", mapping.getChannel());
-            metadata.put("webhook.deliver.to", mapping.getTo());
+            metadata.put(ContextAttributes.WEBHOOK_DELIVER, true);
+            metadata.put(ContextAttributes.WEBHOOK_DELIVER_CHANNEL, mapping.getChannel());
+            metadata.put(ContextAttributes.WEBHOOK_DELIVER_TO, mapping.getTo());
         }
 
         channelAdapter.registerPendingRun(chatId, runId, null, modelTier, null);

--- a/src/main/java/me/golemcore/bot/domain/model/ContextAttributes.java
+++ b/src/main/java/me/golemcore/bot/domain/model/ContextAttributes.java
@@ -214,6 +214,15 @@ public final class ContextAttributes {
     /** WebSocketSession — reference to WebSocket session for streaming. */
     public static final String WEB_STREAM_SINK = "web.stream.sink";
 
+    /** Boolean ? webhook delivery should be routed to an external channel. */
+    public static final String WEBHOOK_DELIVER = "webhook.deliver";
+
+    /** String ? webhook delivery target channel type. */
+    public static final String WEBHOOK_DELIVER_CHANNEL = "webhook.deliver.channel";
+
+    /** String ? webhook delivery target chat identifier. */
+    public static final String WEBHOOK_DELIVER_TO = "webhook.deliver.to";
+
     /**
      * String ? transport chat id used for outbound delivery (for example Telegram
      * chat id when logical session key differs).

--- a/src/main/java/me/golemcore/bot/domain/system/ResponseRoutingSystem.java
+++ b/src/main/java/me/golemcore/bot/domain/system/ResponseRoutingSystem.java
@@ -68,10 +68,6 @@ import java.util.concurrent.TimeoutException;
 @Slf4j
 public class ResponseRoutingSystem implements AgentSystem {
 
-    private static final String WEBHOOK_DELIVER_FLAG = "webhook.deliver";
-    private static final String WEBHOOK_DELIVER_CHANNEL = "webhook.deliver.channel";
-    private static final String WEBHOOK_DELIVER_TO = "webhook.deliver.to";
-
     private record VoiceRoutingResult(boolean sentVoice, boolean sentTextFallback, String errorMessage) {
         private static VoiceRoutingResult none() {
             return new VoiceRoutingResult(false, false, null);
@@ -599,8 +595,8 @@ public class ResponseRoutingSystem implements AgentSystem {
             }
             webhookDeliveryCandidateSeen = true;
 
-            String channelType = readMetadataString(metadata, WEBHOOK_DELIVER_CHANNEL);
-            String chatId = readMetadataString(metadata, WEBHOOK_DELIVER_TO);
+            String channelType = readMetadataString(metadata, ContextAttributes.WEBHOOK_DELIVER_CHANNEL);
+            String chatId = readMetadataString(metadata, ContextAttributes.WEBHOOK_DELIVER_TO);
             if (channelType == null || chatId == null) {
                 continue;
             }
@@ -621,7 +617,7 @@ public class ResponseRoutingSystem implements AgentSystem {
             return false;
         }
 
-        Object value = metadata.get(WEBHOOK_DELIVER_FLAG);
+        Object value = metadata.get(ContextAttributes.WEBHOOK_DELIVER);
         if (value instanceof Boolean booleanValue) {
             return booleanValue;
         }

--- a/src/main/java/me/golemcore/bot/infrastructure/config/AutoConfiguration.java
+++ b/src/main/java/me/golemcore/bot/infrastructure/config/AutoConfiguration.java
@@ -113,7 +113,8 @@ public class AutoConfiguration {
     }
 
     @Bean
-    public ManagedLocalOllamaSupervisor managedLocalOllamaSupervisor(Clock clock,
+    public static ManagedLocalOllamaSupervisor managedLocalOllamaSupervisor(Clock clock,
+            RuntimeConfigService runtimeConfigService,
             OllamaRuntimeProbePort runtimeProbePort,
             OllamaProcessPort processPort) {
         RuntimeConfig.SelfEvolvingConfig selfEvolvingConfig = runtimeConfigService.getSelfEvolvingConfig();
@@ -155,7 +156,8 @@ public class AutoConfiguration {
     }
 
     @Bean
-    public SelfEvolvingTacticSearchStatusProjectionService selfEvolvingTacticSearchStatusProjectionService(
+    public static SelfEvolvingTacticSearchStatusProjectionService selfEvolvingTacticSearchStatusProjectionService(
+            RuntimeConfigService runtimeConfigService,
             ManagedLocalOllamaSupervisor managedLocalOllamaSupervisor,
             Clock clock) {
         return new SelfEvolvingTacticSearchStatusProjectionService(
@@ -200,12 +202,12 @@ public class AutoConfiguration {
         return channelProps != null && channelProps.isEnabled();
     }
 
-    private String resolveOllamaBaseUrl(String configuredBaseUrl) {
+    private static String resolveOllamaBaseUrl(String configuredBaseUrl) {
         String baseUrl = trimToNull(configuredBaseUrl);
         return baseUrl != null ? baseUrl : "http://127.0.0.1:11434";
     }
 
-    private String trimToNull(String value) {
+    private static String trimToNull(String value) {
         if (value == null) {
             return null;
         }

--- a/src/test/java/me/golemcore/bot/adapter/inbound/webhook/WebhookControllerTest.java
+++ b/src/test/java/me/golemcore/bot/adapter/inbound/webhook/WebhookControllerTest.java
@@ -5,6 +5,8 @@ import me.golemcore.bot.adapter.inbound.webhook.dto.AgentRequest;
 import me.golemcore.bot.adapter.inbound.webhook.dto.WakeRequest;
 import me.golemcore.bot.adapter.inbound.webhook.dto.WebhookResponse;
 import me.golemcore.bot.domain.loop.AgentLoop;
+import me.golemcore.bot.domain.model.ContextAttributes;
+import me.golemcore.bot.domain.model.Message;
 import me.golemcore.bot.domain.model.Secret;
 import me.golemcore.bot.domain.model.UserPreferences;
 import me.golemcore.bot.domain.service.UserPreferencesService;
@@ -19,6 +21,7 @@ import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -248,6 +251,29 @@ class WebhookControllerTest {
     }
 
     @Test
+    void agentShouldAttachDeliveryMetadataUsingCanonicalKeys() {
+        AgentRequest request = AgentRequest.builder()
+                .message("Summarize issues")
+                .deliver(true)
+                .channel("telegram")
+                .to("tg-user-42")
+                .metadata(Map.of("source", "ci"))
+                .build();
+
+        controller.agent(toJsonBytes(request), new HttpHeaders()).block();
+
+        ArgumentCaptor<AgentLoop.InboundMessageEvent> captor = ArgumentCaptor
+                .forClass(AgentLoop.InboundMessageEvent.class);
+        verify(eventPublisher).publishEvent(captor.capture());
+
+        Message message = captor.getValue().message();
+        assertEquals("ci", message.getMetadata().get("source"));
+        assertEquals(true, message.getMetadata().get(ContextAttributes.WEBHOOK_DELIVER));
+        assertEquals("telegram", message.getMetadata().get(ContextAttributes.WEBHOOK_DELIVER_CHANNEL));
+        assertEquals("tg-user-42", message.getMetadata().get(ContextAttributes.WEBHOOK_DELIVER_TO));
+    }
+
+    @Test
     void agentShouldAcceptSpecialTier() {
         AgentRequest request = AgentRequest.builder()
                 .message("Test msg")
@@ -393,6 +419,33 @@ class WebhookControllerTest {
         assertNotNull(response);
         assertEquals(HttpStatus.ACCEPTED, response.getStatusCode());
         assertNotNull(response.getBody().getRunId());
+    }
+
+    @Test
+    void customHookAgentActionShouldAttachDeliveryMetadataUsingCanonicalKeys() {
+        UserPreferences.HookMapping mapping = UserPreferences.HookMapping.builder()
+                .name("agent-hook")
+                .action("agent")
+                .messageTemplate("Process: {event}")
+                .deliver(true)
+                .channel("telegram")
+                .to("tg-user-42")
+                .build();
+        when(preferencesService.getPreferences()).thenReturn(buildPrefsWithMapping(mapping));
+        when(authenticator.authenticate(any(), any(), any())).thenReturn(true);
+        when(transformer.transform(any(), any())).thenReturn("Process: deploy");
+
+        byte[] body = "{\"event\":\"deploy\"}".getBytes();
+        controller.customHook("agent-hook", body, new HttpHeaders()).block();
+
+        ArgumentCaptor<AgentLoop.InboundMessageEvent> captor = ArgumentCaptor
+                .forClass(AgentLoop.InboundMessageEvent.class);
+        verify(eventPublisher).publishEvent(captor.capture());
+
+        Message message = captor.getValue().message();
+        assertEquals(true, message.getMetadata().get(ContextAttributes.WEBHOOK_DELIVER));
+        assertEquals("telegram", message.getMetadata().get(ContextAttributes.WEBHOOK_DELIVER_CHANNEL));
+        assertEquals("tg-user-42", message.getMetadata().get(ContextAttributes.WEBHOOK_DELIVER_TO));
     }
 
     @Test

--- a/src/test/resources/architecture/application-low-level-dependency-allowlist.txt
+++ b/src/test/resources/architecture/application-low-level-dependency-allowlist.txt
@@ -1,3 +1,2 @@
-# Remaining application-layer IO/serialization debt to be extracted behind outbound adapters.
-me.golemcore.bot.application.skills.SkillMarketplaceService
-me.golemcore.bot.application.update.UpdateService
+# No remaining application-layer IO/serialization debt is allowed here.
+# Add entries only with explicit architecture review.


### PR DESCRIPTION
## Summary

- Canonicalized the webhook delivery metadata contract by adding shared `ContextAttributes` keys and updating both inbound webhook creation and response routing to use them.
- Aligned the architecture guide with the current Spring Boot 4.0.5 / Java 25 baseline and converted the injected-field `AutoConfiguration` bean factories to static methods with explicit dependencies.
- Tightened the application low-level dependency allowlist now that no application classes import the forbidden IO/serialization types.
- Added targeted webhook delivery metadata tests to cover the Sonar new-code quality gate.
