### PR TITLE
test(ci): add bot integration suite

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -77,6 +77,37 @@ jobs:
         if: always() && matrix.arch == 'amd64' && steps.codecov-token.outputs.available != 'true'
         run: echo "Skipping Codecov upload because CODECOV_TOKEN is unavailable for this event."
 
+  integration-tests:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Checkout plugin APIs
+        uses: actions/checkout@v6
+        with:
+          repository: alexk-dev/golemcore-plugins
+          ref: ${{ env.PLUGIN_API_REPO_REF }}
+          path: golemcore-plugins
+
+      - name: Install plugin API artifacts
+        run: mvn -B -ntp -Djgitver.skip=true -f golemcore-plugins/pom.xml -pl extension-api,runtime-api -am install -DskipTests
+
+      - name: Run integration test suite
+        run: >
+          ./mvnw -B -ntp test
+          -Dtest=DashboardSecurityIntegrationTest,RuntimeSettingsHttpIntegrationTest,HiveSdlcDefaultSettingsIntegrationTest
+          -DskipGitHooks=true
+
   code-quality:
     name: Code Quality
     runs-on: ubuntu-latest
@@ -138,7 +169,7 @@ jobs:
   sonar:
     name: SonarCloud Analysis
     runs-on: ubuntu-latest
-    needs: [test]
+    needs: [test, integration-tests]
 
     steps:
       - name: Check Sonar token availability
@@ -194,7 +225,7 @@ jobs:
   build-app-images:
     name: App (${{ matrix.arch }})
     runs-on: ubuntu-latest
-    needs: [test, code-quality]
+    needs: [test, integration-tests, code-quality]
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
 
     permissions:

--- a/docs/qa-integration-test-plan.md
+++ b/docs/qa-integration-test-plan.md
@@ -1,0 +1,31 @@
+# QA Integration Test Plan — golemcore-bot
+
+## Goal
+
+Add a senior-QA oriented integration test suite that exercises real Spring wiring and persisted runtime state without reaching external services. The suite is intentionally designed to expose production defects rather than mock them away.
+
+## Boundaries
+
+- No real external network calls, LLM calls, Telegram calls, or Hive calls.
+- Use Spring Boot/WebFlux integration tests, temporary filesystem storage, and test doubles for telemetry or remote ports when needed.
+- Keep tests deterministic and focused on externally observable contracts: HTTP status, JSON response shape, persistence on disk, security behaviour, and cross-section runtime settings semantics.
+
+## Test matrix
+
+| Area | Risk | Integration coverage |
+| --- | --- | --- |
+| Application boot | Broken bean graph, missing properties, lifecycle startup failures | Full `@SpringBootTest` smoke already exists and remains the baseline |
+| Dashboard auth + security | JWT filter or security matchers accidentally expose/lock API endpoints | Real random-port login flow, protected `/api/settings/runtime`, unauthorized access, refresh-cookie flow |
+| Runtime settings persistence | UI saves appear successful but are not persisted or returned correctly | Real HTTP `GET/PUT /api/settings/runtime/*` against temp storage, then verify follow-up `GET` |
+| Runtime settings validation | Invalid config accepted or wrong status mapping | Invalid shell env, invalid Hive URL, invalid turn deadline/ranges via HTTP endpoints |
+| Secret retention | Updating settings with masked/empty secrets drops existing secrets | Add focused integration contract via runtime settings service/API path where practical |
+| Hive SDLC toggles | Hive enabled but dependent SDLC feature toggles not defaulted/independently controllable | Verify runtime Hive config and adjacent plan/self-evolving Hive defaults remain visible and mutable through settings API |
+| Webhooks | Auth bypass, payload validation, wrong mapping action | Existing Webhook HTTP integration remains; extend later if failures point there |
+| Tool/filesystem safety | Traversal/sandbox regressions | Existing adapter/tool tests remain; extend later if shell/filesystem defects appear |
+
+## First implementation slice
+
+1. Add a reusable Spring random-port integration base with temp storage and disabled plugin/update side effects.
+2. Add Dashboard auth/security integration tests.
+3. Add Runtime settings HTTP integration tests for persistence, validation, and Hive-related feature toggles.
+4. Run the new tests and record failures as production defects; do not weaken assertions to hide bugs.

--- a/src/test/java/me/golemcore/bot/integration/DashboardSecurityIntegrationTest.java
+++ b/src/test/java/me/golemcore/bot/integration/DashboardSecurityIntegrationTest.java
@@ -1,0 +1,75 @@
+package me.golemcore.bot.integration;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DashboardSecurityIntegrationTest extends GolemCoreBotIntegrationTestBase {
+
+    @Test
+    void shouldRejectProtectedApiWithoutJwt() {
+        webTestClient().get()
+                .uri("/api/settings/runtime")
+                .exchange()
+                .expectStatus().isUnauthorized();
+    }
+
+    @Test
+    void shouldRejectProtectedApiWithInvalidJwt() {
+        webTestClient().get()
+                .uri("/api/settings/runtime")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer invalid-token")
+                .exchange()
+                .expectStatus().isUnauthorized();
+    }
+
+    @Test
+    void shouldLoginAndAccessProtectedRuntimeSettings() {
+        String accessToken = loginAndExtractAccessToken();
+
+        authenticatedGet("/api/settings/runtime", accessToken)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.hive.enabled").exists()
+                .jsonPath("$.plan.enabled").exists();
+    }
+
+    @Test
+    void shouldIssueRefreshCookieAndRefreshAccessToken() {
+        WebTestClient.ResponseSpec loginResponse = webTestClient().post()
+                .uri("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue("{\"password\":\"" + ADMIN_PASSWORD + "\"}")
+                .exchange()
+                .expectStatus().isOk();
+        String refreshCookie = loginResponse.returnResult(String.class)
+                .getResponseHeaders()
+                .getFirst(HttpHeaders.SET_COOKIE);
+
+        assertNotNull(refreshCookie);
+        assertTrue(refreshCookie.contains("refresh_token="));
+
+        webTestClient().post()
+                .uri("/api/auth/refresh")
+                .header(HttpHeaders.COOKIE, refreshCookie)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.accessToken").isNotEmpty();
+    }
+
+    @Test
+    void shouldRejectWrongDashboardPassword() {
+        webTestClient().post()
+                .uri("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue("{\"password\":\"wrong\"}")
+                .exchange()
+                .expectStatus().isUnauthorized();
+    }
+}

--- a/src/test/java/me/golemcore/bot/integration/GolemCoreBotIntegrationTestBase.java
+++ b/src/test/java/me/golemcore/bot/integration/GolemCoreBotIntegrationTestBase.java
@@ -1,0 +1,120 @@
+package me.golemcore.bot.integration;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import me.golemcore.bot.infrastructure.telemetry.GaTelemetryClient;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("integration-test")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@Import(GolemCoreBotIntegrationTestConfiguration.class)
+abstract class GolemCoreBotIntegrationTestBase {
+
+    protected static final String ADMIN_PASSWORD = "integration-admin-password";
+
+    private static final String JWT_SECRET = "integration-test-jwt-secret-key-that-is-long-enough-for-hmac-sha256";
+
+    @TempDir
+    static Path tempDir;
+
+    @LocalServerPort
+    protected int port;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    @MockitoBean
+    GaTelemetryClient gaTelemetryClient;
+
+    @DynamicPropertySource
+    static void overrideProperties(DynamicPropertyRegistry registry) {
+        registry.add("bot.storage.local.base-path", () -> tempDir.resolve("workspace").toString());
+        registry.add("bot.tools.filesystem.workspace", () -> tempDir.resolve("sandbox").toString());
+        registry.add("bot.tools.shell.workspace", () -> tempDir.resolve("sandbox").toString());
+        registry.add("bot.dashboard.enabled", () -> "true");
+        registry.add("bot.dashboard.admin-password", () -> ADMIN_PASSWORD);
+        registry.add("bot.dashboard.jwt-secret", () -> JWT_SECRET);
+        registry.add("bot.llm.provider", () -> "none");
+        registry.add("bot.plugins.enabled", () -> "false");
+        registry.add("bot.plugins.auto-start", () -> "false");
+        registry.add("bot.plugins.auto-reload", () -> "false");
+        registry.add("bot.update.enabled", () -> "false");
+        registry.add("bot.skills.marketplace-enabled", () -> "false");
+        registry.add("bot.self-evolving.bootstrap.enabled", () -> "false");
+        registry.add("bot.self-evolving.bootstrap.tactics.enabled", () -> "false");
+        registry.add("bot.self-evolving.bootstrap.tactics.search.mode", () -> "bm25");
+        registry.add("bot.self-evolving.bootstrap.tactics.search.embeddings.local.auto-install", () -> "false");
+        registry.add("bot.self-evolving.bootstrap.tactics.search.embeddings.local.pull-on-start", () -> "false");
+    }
+
+    protected WebTestClient webTestClient() {
+        return WebTestClient.bindToServer()
+                .baseUrl("http://localhost:" + port)
+                .build();
+    }
+
+    protected String loginAndExtractAccessToken() {
+        String body = webTestClient().post()
+                .uri("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue("{\"password\":\"" + ADMIN_PASSWORD + "\"}")
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(String.class)
+                .returnResult()
+                .getResponseBody();
+        return parseJson(body).path("accessToken").asText();
+    }
+
+    protected WebTestClient.RequestHeadersSpec<?> authenticatedGet(String uri, String accessToken) {
+        return webTestClient().get()
+                .uri(uri)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
+    }
+
+    protected WebTestClient.RequestHeadersSpec<?> authenticatedPut(String uri, String accessToken, String body) {
+        return webTestClient().put()
+                .uri(uri)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(body);
+    }
+
+    protected JsonNode getRuntimeConfig(String accessToken) {
+        String body = authenticatedGet("/api/settings/runtime", accessToken)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody(String.class)
+                .returnResult()
+                .getResponseBody();
+        return parseJson(body);
+    }
+
+    protected JsonNode parseJson(String body) {
+        try {
+            return objectMapper.readTree(body);
+        } catch (Exception exception) {
+            throw new IllegalStateException("Failed to parse test response JSON", exception);
+        }
+    }
+
+    protected JsonNode readPersistedPreferenceSection(String fileName) throws Exception {
+        Path sectionPath = tempDir.resolve("workspace").resolve("preferences").resolve(fileName);
+        return objectMapper.readTree(Files.readString(sectionPath));
+    }
+}

--- a/src/test/java/me/golemcore/bot/integration/GolemCoreBotIntegrationTestConfiguration.java
+++ b/src/test/java/me/golemcore/bot/integration/GolemCoreBotIntegrationTestConfiguration.java
@@ -1,0 +1,57 @@
+package me.golemcore.bot.integration;
+
+import me.golemcore.bot.port.outbound.OllamaProcessPort;
+import me.golemcore.bot.port.outbound.OllamaRuntimeApiPort;
+import me.golemcore.bot.port.outbound.VoiceProviderCatalogPort;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+
+import static org.mockito.Mockito.mock;
+
+@TestConfiguration(proxyBeanMethods = false)
+@Profile("integration-test")
+class GolemCoreBotIntegrationTestConfiguration {
+
+    @Bean
+    @Primary
+    VoiceProviderCatalogPort voiceProviderCatalogPort() {
+        return new StaticVoiceProviderCatalogPort();
+    }
+
+    @Bean
+    @Primary
+    OllamaRuntimeApiPort testOllamaRuntimeApiPort() {
+        return mock(OllamaRuntimeApiPort.class);
+    }
+
+    @Bean
+    @Primary
+    OllamaProcessPort testOllamaProcessPort() {
+        return mock(OllamaProcessPort.class);
+    }
+
+    private static final class StaticVoiceProviderCatalogPort implements VoiceProviderCatalogPort {
+
+        @Override
+        public boolean hasSttProvider(String providerId) {
+            return "golemcore/elevenlabs".equals(providerId) || "golemcore/whisper".equals(providerId);
+        }
+
+        @Override
+        public boolean hasTtsProvider(String providerId) {
+            return "golemcore/elevenlabs".equals(providerId) || "golemcore/whisper".equals(providerId);
+        }
+
+        @Override
+        public String firstSttProviderId() {
+            return "golemcore/elevenlabs";
+        }
+
+        @Override
+        public String firstTtsProviderId() {
+            return "golemcore/elevenlabs";
+        }
+    }
+}

--- a/src/test/java/me/golemcore/bot/integration/HiveSdlcDefaultSettingsIntegrationTest.java
+++ b/src/test/java/me/golemcore/bot/integration/HiveSdlcDefaultSettingsIntegrationTest.java
@@ -1,0 +1,33 @@
+package me.golemcore.bot.integration;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class HiveSdlcDefaultSettingsIntegrationTest extends GolemCoreBotIntegrationTestBase {
+
+    @Test
+    void shouldEnableHiveSdlcDefaultsWhenHiveIntegrationIsActive() {
+        String accessToken = loginAndExtractAccessToken();
+
+        authenticatedPut("/api/settings/runtime/hive", accessToken, """
+                {
+                  "enabled": true,
+                  "serverUrl": "https://hive.example.com",
+                  "displayName": "QA Bot",
+                  "hostLabel": "qa-host",
+                  "autoConnect": true,
+                  "managedByProperties": false
+                }
+                """)
+                .exchange()
+                .expectStatus().isOk();
+
+        JsonNode runtimeConfig = getRuntimeConfig(accessToken);
+        assertTrue(runtimeConfig.path("hive").path("enabled").asBoolean());
+        assertTrue(runtimeConfig.path("selfEvolving").path("promotion").path("hiveApprovalPreferred").asBoolean());
+        assertTrue(runtimeConfig.path("selfEvolving").path("hive").path("publishInspectionProjection").asBoolean());
+        assertTrue(runtimeConfig.path("selfEvolving").path("hive").path("readonlyInspection").asBoolean());
+    }
+}

--- a/src/test/java/me/golemcore/bot/integration/RuntimeSettingsHttpIntegrationTest.java
+++ b/src/test/java/me/golemcore/bot/integration/RuntimeSettingsHttpIntegrationTest.java
@@ -1,0 +1,208 @@
+package me.golemcore.bot.integration;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RuntimeSettingsHttpIntegrationTest extends GolemCoreBotIntegrationTestBase {
+
+    @Test
+    void shouldPersistHivePlanAndSelfEvolvingSettingsThroughHttpApi() throws Exception {
+        String accessToken = loginAndExtractAccessToken();
+
+        authenticatedPut("/api/settings/runtime/hive", accessToken, """
+                {
+                  "enabled": true,
+                  "serverUrl": "https://hive.example.com",
+                  "displayName": "QA Bot",
+                  "hostLabel": "qa-host",
+                  "autoConnect": true,
+                  "managedByProperties": false
+                }
+                """)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.hive.enabled").isEqualTo(true)
+                .jsonPath("$.hive.serverUrl").isEqualTo("https://hive.example.com")
+                .jsonPath("$.hive.autoConnect").isEqualTo(true);
+
+        authenticatedPut("/api/settings/runtime/plan", accessToken, """
+                {
+                  "enabled": true,
+                  "maxPlans": 7,
+                  "maxStepsPerPlan": 80,
+                  "stopOnFailure": false
+                }
+                """)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.plan.enabled").isEqualTo(true)
+                .jsonPath("$.plan.stopOnFailure").isEqualTo(false);
+
+        JsonNode runtimeConfig = getRuntimeConfig(accessToken);
+        assertTrue(runtimeConfig.path("hive").path("enabled").asBoolean());
+        assertTrue(runtimeConfig.path("plan").path("enabled").asBoolean());
+        assertTrue(runtimeConfig.path("selfEvolving").path("promotion").has("hiveApprovalPreferred"));
+        assertTrue(runtimeConfig.path("selfEvolving").path("hive").has("publishInspectionProjection"));
+        assertTrue(runtimeConfig.path("selfEvolving").path("hive").has("readonlyInspection"));
+
+        JsonNode persistedHive = readPersistedPreferenceSection("hive.json");
+        JsonNode persistedPlan = readPersistedPreferenceSection("plan.json");
+        assertEquals("https://hive.example.com", persistedHive.path("serverUrl").asText());
+        assertTrue(persistedHive.path("autoConnect").asBoolean());
+        assertTrue(persistedPlan.path("enabled").asBoolean());
+        assertFalse(persistedPlan.path("stopOnFailure").asBoolean());
+    }
+
+    @Test
+    void shouldAllowDisablingHiveAdjacentSdlcFeatureTogglesIndependently() {
+        String accessToken = loginAndExtractAccessToken();
+
+        authenticatedPut("/api/settings/runtime/hive", accessToken, """
+                {
+                  "enabled": true,
+                  "serverUrl": "https://hive.example.com",
+                  "displayName": "QA Bot",
+                  "hostLabel": "qa-host",
+                  "autoConnect": false,
+                  "managedByProperties": false
+                }
+                """)
+                .exchange()
+                .expectStatus().isOk();
+
+        JsonNode current = getRuntimeConfig(accessToken);
+        ObjectNode selfEvolvingPatch = current.path("selfEvolving").deepCopy();
+        ((ObjectNode) selfEvolvingPatch.path("hive"))
+                .put("publishInspectionProjection", false)
+                .put("readonlyInspection", false);
+        ((ObjectNode) selfEvolvingPatch.path("promotion"))
+                .put("hiveApprovalPreferred", false);
+
+        authenticatedPut("/api/settings/runtime", accessToken,
+                objectMapper.createObjectNode().set("selfEvolving", selfEvolvingPatch).toString())
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.hive.enabled").isEqualTo(true)
+                .jsonPath("$.selfEvolving.promotion.hiveApprovalPreferred").isEqualTo(false)
+                .jsonPath("$.selfEvolving.hive.publishInspectionProjection").isEqualTo(false)
+                .jsonPath("$.selfEvolving.hive.readonlyInspection").isEqualTo(false);
+    }
+
+    @Test
+    void shouldPersistShellEnvironmentVariableLifecycleThroughHttpApi() throws Exception {
+        String accessToken = loginAndExtractAccessToken();
+
+        authenticatedPut("/api/settings/runtime/tools", accessToken, """
+                {
+                  "filesystemEnabled": true,
+                  "shellEnabled": true,
+                  "skillManagementEnabled": true,
+                  "skillTransitionEnabled": true,
+                  "tierEnabled": true,
+                  "goalManagementEnabled": true,
+                  "shellEnvironmentVariables": [
+                    { "name": " QA_TOKEN ", "value": "secret-value" }
+                  ]
+                }
+                """)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.tools.shellEnvironmentVariables[0].name").isEqualTo("QA_TOKEN")
+                .jsonPath("$.tools.shellEnvironmentVariables[0].value").isEqualTo("secret-value");
+
+        authenticatedPut("/api/settings/runtime/tools/shell/env/QA_TOKEN", accessToken, """
+                { "name": "QA_TOKEN", "value": "updated-value" }
+                """)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.tools.shellEnvironmentVariables[0].value").isEqualTo("updated-value");
+
+        JsonNode persistedTools = readPersistedPreferenceSection("tools.json");
+        assertEquals("QA_TOKEN", persistedTools.path("shellEnvironmentVariables").get(0).path("name").asText());
+        assertEquals("updated-value", persistedTools.path("shellEnvironmentVariables").get(0).path("value").asText());
+    }
+
+    @Test
+    void shouldRejectInvalidRuntimeSettingsWithClientErrorStatus() {
+        String accessToken = loginAndExtractAccessToken();
+
+        authenticatedPut("/api/settings/runtime/hive", accessToken, """
+                { "enabled": true, "serverUrl": "not-a-url", "managedByProperties": false }
+                """)
+                .exchange()
+                .expectStatus().is4xxClientError();
+
+        authenticatedPut("/api/settings/runtime/turn", accessToken, """
+                { "maxLlmCalls": 0, "maxToolExecutions": 1, "deadline": "PT1M" }
+                """)
+                .exchange()
+                .expectStatus().is4xxClientError();
+
+        authenticatedPut("/api/settings/runtime/tools", accessToken, """
+                {
+                  "shellEnvironmentVariables": [
+                    { "name": "1INVALID", "value": "bad" }
+                  ]
+                }
+                """)
+                .exchange()
+                .expectStatus().is4xxClientError();
+    }
+
+    @Test
+    void shouldPreserveSecretsWhenRuntimeUpdateSendsRedactedSecretObjects() throws Exception {
+        String accessToken = loginAndExtractAccessToken();
+
+        authenticatedPut("/api/settings/runtime/llm", accessToken, """
+                {
+                  "providers": {
+                    "openai": {
+                      "apiKey": { "value": "real-secret", "encrypted": false, "present": true },
+                      "baseUrl": "https://api.openai.com",
+                      "apiType": "openai",
+                      "requestTimeoutSeconds": 30
+                    }
+                  }
+                }
+                """)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.llm.providers.openai.apiKey.present").isEqualTo(true)
+                .jsonPath("$.llm.providers.openai.apiKey.value").doesNotExist();
+
+        authenticatedPut("/api/settings/runtime/llm", accessToken, """
+                {
+                  "providers": {
+                    "openai": {
+                      "apiKey": { "value": null, "encrypted": false, "present": true },
+                      "baseUrl": "https://api.openai.com/v1",
+                      "apiType": "openai",
+                      "requestTimeoutSeconds": 60
+                    }
+                  }
+                }
+                """)
+                .exchange()
+                .expectStatus().isOk()
+                .expectBody()
+                .jsonPath("$.llm.providers.openai.apiKey.present").isEqualTo(true)
+                .jsonPath("$.llm.providers.openai.baseUrl").isEqualTo("https://api.openai.com/v1");
+
+        JsonNode persistedLlm = readPersistedPreferenceSection("llm.json");
+        assertEquals("real-secret",
+                persistedLlm.path("providers").path("openai").path("apiKey").path("value").asText());
+        assertEquals("https://api.openai.com/v1",
+                persistedLlm.path("providers").path("openai").path("baseUrl").asText());
+    }
+}


### PR DESCRIPTION
## Summary

- Add a QA integration test plan covering application wiring, dashboard security, runtime settings persistence, validation, secret retention, and Hive SDLC toggles.
- Add Spring Boot random-port integration test infrastructure with temporary storage/workspace and test doubles for external-only ports.
- Add integration coverage for dashboard auth, runtime settings HTTP persistence/validation, secret retention, and Hive SDLC defaults/toggle behavior.
- Add a GitHub Actions Integration Tests job to run the new suite and gate downstream CI jobs on it.
