### PR TITLE
feat(webhook): add sync schema responses

### DIFF
--- a/dashboard/src/api/webhooks.ts
+++ b/dashboard/src/api/webhooks.ts
@@ -16,6 +16,9 @@ export interface HookMapping {
   deliver: boolean;
   channel: string | null;
   to: string | null;
+  syncResponse: boolean;
+  responseJsonSchema: string | null;
+  responseValidationModelTier: string | null;
 }
 
 export type HookMappingDraft = HookMapping;
@@ -115,6 +118,9 @@ function normalizeMapping(raw: unknown): HookMapping {
     deliver: Boolean(record.deliver),
     channel: toNullableString(record.channel),
     to: toNullableString(record.to),
+    syncResponse: Boolean(record.syncResponse),
+    responseJsonSchema: toSchemaEditorValue(record.responseJsonSchema),
+    responseValidationModelTier: toNullableString(record.responseValidationModelTier),
   };
 }
 
@@ -131,6 +137,9 @@ function toBackendMapping(mapping: HookMapping): UnknownRecord {
     deliver: mapping.deliver,
     channel: toNullableString(mapping.channel),
     to: toNullableString(mapping.to),
+    syncResponse: mapping.syncResponse,
+    responseJsonSchema: toBackendJsonSchema(mapping.responseJsonSchema),
+    responseValidationModelTier: toNullableString(mapping.responseValidationModelTier),
   };
 }
 
@@ -184,6 +193,9 @@ export function createEmptyWebhookMapping(): HookMappingDraft {
     deliver: false,
     channel: null,
     to: null,
+    syncResponse: false,
+    responseJsonSchema: null,
+    responseValidationModelTier: null,
   };
 }
 
@@ -264,6 +276,26 @@ function validateMappingDelivery(mapping: HookMapping, index: number, issues: st
   }
 }
 
+function validateMappingResponseSchema(mapping: HookMapping, index: number, issues: string[]): void {
+  if (mapping.action !== 'agent') {
+    return;
+  }
+
+  if (mapping.responseJsonSchema == null || mapping.responseJsonSchema.trim().length === 0) {
+    return;
+  }
+
+  const prefix = `Mapping #${index + 1}`;
+  if (!mapping.syncResponse) {
+    issues.push(`${prefix}: synchronous response is required when response JSON Schema is configured.`);
+  }
+  try {
+    JSON.parse(mapping.responseJsonSchema);
+  } catch {
+    issues.push(`${prefix}: response JSON Schema must be valid JSON.`);
+  }
+}
+
 export function validateWebhookConfig(config: WebhookConfig): WebhookValidationResult {
   const issues: string[] = [];
   const seenNames = new Set<string>();
@@ -274,12 +306,34 @@ export function validateWebhookConfig(config: WebhookConfig): WebhookValidationR
     validateMappingName(mapping, index, seenNames, issues);
     validateMappingAuth(mapping, index, issues);
     validateMappingDelivery(mapping, index, issues);
+    validateMappingResponseSchema(mapping, index, issues);
   });
 
   return {
     valid: issues.length === 0,
     issues,
   };
+}
+
+function toSchemaEditorValue(value: unknown): string | null {
+  if (typeof value === 'string') {
+    return toNullableTemplate(value);
+  }
+  if (value == null) {
+    return null;
+  }
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return null;
+  }
+}
+
+function toBackendJsonSchema(value: string | null | undefined): unknown {
+  if (value == null || value.trim().length === 0) {
+    return null;
+  }
+  return JSON.parse(value);
 }
 
 export async function getWebhookConfig(): Promise<WebhookConfig> {

--- a/dashboard/src/components/webhooks/HookMappingAgentSection.tsx
+++ b/dashboard/src/components/webhooks/HookMappingAgentSection.tsx
@@ -5,8 +5,9 @@ import { cn } from '../../lib/utils';
 import { getExplicitModelTierOptions } from '../../lib/modelTiers';
 import HelpTip from '../common/HelpTip';
 import { Badge } from '../ui/badge';
-import { Input, Select } from '../ui/field';
+import { Input, Select, Textarea } from '../ui/field';
 import { HookMappingFieldHeading } from './HookMappingFieldHeading';
+import { SynchronousResponseHeader } from './SynchronousResponseHeader';
 import {
   controlClassName,
   fieldHelpClassName,
@@ -114,8 +115,66 @@ export function HookAgentSection({
           />
         </div>
       </div>
+
+      <div className={cn(surfaceClassName, 'xl:col-span-2')}>
+        <SynchronousResponseHeader
+          syncResponse={mapping.syncResponse}
+          onToggle={(syncResponse) => onChange(nextMappingWithSynchronousResponse(mapping, syncResponse))}
+        />
+        <div className={cn('mt-5 grid gap-4 lg:grid-cols-[minmax(12rem,16rem)_minmax(0,1fr)]', !mapping.syncResponse && 'opacity-75')}>
+          <div>
+            <HookMappingFieldHeading
+              label="Schema Repair Tier"
+              help="Optional tier used to reformat responses that do not match the JSON Schema."
+            />
+            <Select
+              value={mapping.responseValidationModelTier ?? ''}
+              disabled={!mapping.syncResponse}
+              onChange={(event) => onChange({ ...mapping, responseValidationModelTier: toNullableString(event.target.value) })}
+              className={controlClassName}
+            >
+              <option value="">Default</option>
+              {getExplicitModelTierOptions().map((option) => (
+                <option key={option.value} value={option.value}>{option.label}</option>
+              ))}
+            </Select>
+            <p className={fieldHelpClassName}>
+              Leave empty to reuse the hook model tier or the balanced tier.
+            </p>
+          </div>
+          <div>
+            <HookMappingFieldHeading
+              label="Response JSON Schema"
+              help="Optional schema for the synchronous HTTP response body. The final agent output is validated and repaired up to three times."
+            />
+            <Textarea
+              rows={7}
+              value={mapping.responseJsonSchema ?? ''}
+              disabled={!mapping.syncResponse}
+              onChange={(event) => onChange({ ...mapping, responseJsonSchema: toNullableString(event.target.value) })}
+              placeholder={'{\n  "type": "object",\n  "required": ["version", "response"],\n  "properties": {\n    "version": { "const": "1.0" },\n    "response": { "type": "object" }\n  }\n}'}
+              className="min-h-[12rem] rounded-2xl border-border/80 bg-background/80 font-mono text-sm shadow-none"
+            />
+          </div>
+        </div>
+      </div>
     </div>
   );
+}
+
+function nextMappingWithSynchronousResponse(
+  mapping: HookMappingDraft,
+  syncResponse: boolean,
+): HookMappingDraft {
+  if (syncResponse) {
+    return { ...mapping, syncResponse };
+  }
+  return {
+    ...mapping,
+    syncResponse,
+    responseJsonSchema: null,
+    responseValidationModelTier: null,
+  };
 }
 
 function DeliveryHeader({

--- a/dashboard/src/components/webhooks/HookMappingFormSections.tsx
+++ b/dashboard/src/components/webhooks/HookMappingFormSections.tsx
@@ -1,6 +1,6 @@
 import { type ReactElement, useState } from 'react';
 import { FiEye, FiEyeOff } from 'react-icons/fi';
-import type { HookMappingDraft } from '../../api/webhooks';
+import type { HookAction, HookMappingDraft } from '../../api/webhooks';
 import { cn } from '../../lib/utils';
 import { Badge } from '../ui/badge';
 import { Button } from '../ui/button';
@@ -77,7 +77,7 @@ export function HookIdentitySection({
           />
           <Select
             value={mapping.action}
-            onChange={(event) => onChange({ ...mapping, action: resolveHookAction(event.target.value) })}
+            onChange={(event) => onChange(nextMappingWithAction(mapping, resolveHookAction(event.target.value)))}
             className={controlClassName}
           >
             <option value="wake">Wake</option>
@@ -133,6 +133,19 @@ export function HookIdentitySection({
       </div>
     </div>
   );
+}
+
+function nextMappingWithAction(mapping: HookMappingDraft, action: HookAction): HookMappingDraft {
+  if (action === 'agent') {
+    return { ...mapping, action };
+  }
+  return {
+    ...mapping,
+    action,
+    syncResponse: false,
+    responseJsonSchema: null,
+    responseValidationModelTier: null,
+  };
 }
 
 interface HookSecuritySectionProps {

--- a/dashboard/src/components/webhooks/SynchronousResponseHeader.tsx
+++ b/dashboard/src/components/webhooks/SynchronousResponseHeader.tsx
@@ -1,0 +1,55 @@
+import type { ReactElement } from 'react';
+import { cn } from '../../lib/utils';
+import HelpTip from '../common/HelpTip';
+
+interface SynchronousResponseHeaderProps {
+  syncResponse: boolean;
+  onToggle: (syncResponse: boolean) => void;
+}
+
+export function SynchronousResponseHeader({
+  syncResponse,
+  onToggle,
+}: SynchronousResponseHeaderProps): ReactElement {
+  return (
+    <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+      <div className="space-y-1">
+        <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
+          <span>Synchronous HTTP Response</span>
+          <HelpTip text="Wait for the completed agent response and return it to the webhook caller." />
+        </div>
+        <p className="text-sm leading-6 text-muted-foreground">
+          Return the final agent output in the webhook HTTP response body.
+        </p>
+      </div>
+
+      <button
+        type="button"
+        role="switch"
+        aria-checked={syncResponse}
+        onClick={() => onToggle(!syncResponse)}
+        className={cn(
+          'inline-flex items-center gap-3 self-start rounded-lg border px-3 py-2 text-sm font-semibold transition-all',
+          syncResponse
+            ? 'border-primary/30 bg-primary/10 text-foreground shadow-soft'
+            : 'border-border/80 bg-background/80 text-muted-foreground',
+        )}
+      >
+        <span
+          className={cn(
+            'relative h-6 w-11 rounded-full transition-colors',
+            syncResponse ? 'bg-primary' : 'bg-muted',
+          )}
+        >
+          <span
+            className={cn(
+              'absolute left-0.5 top-0.5 h-5 w-5 rounded-full bg-white shadow transition-transform',
+              syncResponse ? 'translate-x-5' : 'translate-x-0',
+            )}
+          />
+        </span>
+        <span>{syncResponse ? 'Enabled' : 'Disabled'}</span>
+      </button>
+    </div>
+  );
+}

--- a/docs/WEBHOOKS.md
+++ b/docs/WEBHOOKS.md
@@ -132,6 +132,9 @@ Full agent turn. Runs a complete agent pipeline (LLM + tools) in an isolated ses
 | `chatId` | string | No | `"hook:<uuid>"` | Session identifier |
 | `model` | string | No | — | Model tier (`balanced`, `smart`, `coding`, `deep`) |
 | `callbackUrl` | string | No | — | URL to POST results to when done |
+| `syncResponse` | boolean | No | `false` | Wait for the agent result and return it in the HTTP response |
+| `responseJsonSchema` | object | No | — | JSON Schema for the synchronous HTTP response body |
+| `responseValidationModelTier` | string | No | — | Model tier used for response schema repair calls |
 | `deliver` | boolean | No | `false` | Route response to a messaging channel |
 | `channel` | string | No | — | Target channel type (e.g. `"telegram"`) |
 | `to` | string | No | — | Target chat ID on delivery channel |
@@ -172,6 +175,65 @@ On failure:
   "durationMs": 300000
 }
 ```
+
+**Synchronous response**:
+
+Set `syncResponse=true` to wait for the completed agent output and return `200 OK` from the original HTTP call:
+
+```json
+{
+  "status": "completed",
+  "runId": "550e8400-e29b-41d4-a716-446655440000",
+  "chatId": "hook:...",
+  "response": "Here is the summary..."
+}
+```
+
+If `responseJsonSchema` is provided, the schema describes the top-level HTTP response body. The bot adds schema instructions to the system prompt, validates the final agent output, and makes up to three repair calls when the output does not match the schema. The repair calls use `responseValidationModelTier` when set, otherwise the hook model tier or `balanced`.
+
+Example Alice-style response contract:
+
+```json
+{
+  "message": "Answer the user in Alice skill format",
+  "syncResponse": true,
+  "model": "smart",
+  "responseValidationModelTier": "balanced",
+  "responseJsonSchema": {
+    "type": "object",
+    "required": ["version", "response"],
+    "additionalProperties": false,
+    "properties": {
+      "version": { "const": "1.0" },
+      "response": {
+        "type": "object",
+        "required": ["text", "tts", "end_session"],
+        "additionalProperties": false,
+        "properties": {
+          "text": { "type": "string" },
+          "tts": { "type": "string" },
+          "end_session": { "type": "boolean" }
+        }
+      }
+    }
+  }
+}
+```
+
+For schema-backed synchronous runs, the successful HTTP body is the validated JSON payload itself:
+
+```json
+{
+  "version": "1.0",
+  "response": {
+    "text": "Response text",
+    "tts": "Text for speech",
+    "end_session": true
+  }
+}
+```
+
+When `callbackUrl` is also set, callback delivery remains independent and contains the raw completed agent text. The JSON Schema contract applies to the original synchronous HTTP response body.
 
 **Use cases:**
 - Automated code review on PR open
@@ -260,6 +322,9 @@ Custom mappings transform raw JSON payloads from external services into structur
 | `hmacPrefix` | string | — | Prefix to strip from signature (e.g. `"sha256="`) |
 | `messageTemplate` | string | — | Template with `{json.path}` placeholders |
 | `model` | string | — | Model tier override (for agent action) |
+| `syncResponse` | boolean | `false` | Return the final agent result in the HTTP response |
+| `responseJsonSchema` | object | — | JSON Schema for the synchronous HTTP response body |
+| `responseValidationModelTier` | string | — | Model tier used for schema repair calls |
 | `deliver` | boolean | `false` | Route response to a messaging channel |
 | `channel` | string | — | Target channel type for delivery |
 | `to` | string | — | Target chat ID for delivery |

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
         <totp.version>1.7.1</totp.version>
         <protobuf.version>4.34.1</protobuf.version>
         <protobuf.maven.plugin.version>0.6.1</protobuf.maven.plugin.version>
+        <json.schema.validator.version>1.5.6</json.schema.validator.version>
 
         <spotbugs.version>4.9.8.3</spotbugs.version>
         <pmd.version>3.28.0</pmd.version>
@@ -207,6 +208,11 @@
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.networknt</groupId>
+            <artifactId>json-schema-validator</artifactId>
+            <version>${json.schema.validator.version}</version>
         </dependency>
 
         <!-- Protocol Buffers -->

--- a/src/main/java/me/golemcore/bot/adapter/inbound/webhook/WebhookController.java
+++ b/src/main/java/me/golemcore/bot/adapter/inbound/webhook/WebhookController.java
@@ -46,13 +46,20 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Inbound HTTP webhook controller (OpenClaw-style, WebFlux).
@@ -90,6 +97,7 @@ public class WebhookController {
     private final WebhookChannelAdapter channelAdapter;
     private final WebhookPayloadTransformer transformer;
     private final WebhookDeliveryTracker deliveryTracker;
+    private final WebhookResponseSchemaService responseSchemaService;
     private final ApplicationEventPublisher eventPublisher;
     private final InputSanitizer inputSanitizer;
     private final ObjectMapper objectMapper = new ObjectMapper();
@@ -134,7 +142,7 @@ public class WebhookController {
 
             log.info("[Webhook] Wake event accepted for chatId={}", chatId);
             return ResponseEntity.ok(WebhookResponse.accepted(chatId));
-        });
+        }).subscribeOn(Schedulers.boundedElastic());
     }
 
     // ==================== /agent ====================
@@ -145,7 +153,7 @@ public class WebhookController {
      * adapter.
      */
     @PostMapping("/agent")
-    public Mono<ResponseEntity<WebhookResponse>> agent(
+    public Mono<ResponseEntity<?>> agent(
             @RequestBody(required = false) byte[] body,
             @RequestHeader HttpHeaders headers) {
 
@@ -178,9 +186,18 @@ public class WebhookController {
                     ? request.getTimeoutSeconds()
                     : config.getDefaultTimeoutSeconds();
             String modelTier;
+            String responseValidationModelTier;
             try {
                 modelTier = normalizeOptionalModelTier(request.getModel(), "'model'");
+                responseValidationModelTier = normalizeOptionalModelTier(
+                        request.getResponseValidationModelTier(), "'responseValidationModelTier'");
+                validateSynchronousResponseContract(
+                        request.isSyncResponse(),
+                        request.getResponseJsonSchema(),
+                        "'responseJsonSchema'");
             } catch (IllegalArgumentException e) {
+                return badRequest(e.getMessage());
+            } catch (WebhookResponseSchemaService.SchemaProcessingException e) {
                 return badRequest(e.getMessage());
             }
 
@@ -194,6 +211,7 @@ public class WebhookController {
             if (modelTier != null) {
                 metadata.put("webhook.modelTier", modelTier);
             }
+            addResponseContractMetadata(metadata, request.getResponseJsonSchema(), responseValidationModelTier);
             if (request.isDeliver()) {
                 metadata.put(ContextAttributes.WEBHOOK_DELIVER, true);
                 metadata.put(ContextAttributes.WEBHOOK_DELIVER_CHANNEL, request.getChannel());
@@ -214,16 +232,31 @@ public class WebhookController {
                         modelTier);
             }
 
-            channelAdapter.registerPendingRun(chatId, runId, request.getCallbackUrl(), modelTier, deliveryId);
+            CompletableFuture<String> responseFuture = channelAdapter.registerPendingRun(
+                    chatId,
+                    runId,
+                    request.getCallbackUrl(),
+                    modelTier,
+                    deliveryId);
 
             Message message = buildMessage(chatId, safeMessage, metadata, TraceNamingSupport.WEBHOOK_AGENT);
             eventPublisher.publishEvent(new AgentLoop.InboundMessageEvent(message));
 
             log.info("[Webhook] Agent run accepted: runId={}, chatId={}, name={}",
                     runId, chatId, request.getName());
+            if (request.isSyncResponse()) {
+                return buildSynchronousResponse(
+                        responseFuture,
+                        runId,
+                        chatId,
+                        timeout,
+                        request.getResponseJsonSchema(),
+                        responseValidationModelTier,
+                        modelTier);
+            }
             return ResponseEntity.status(HttpStatus.ACCEPTED)
                     .body(WebhookResponse.accepted(runId, chatId));
-        });
+        }).subscribeOn(Schedulers.boundedElastic());
     }
 
     // ==================== /{name} (custom mapping) ====================
@@ -234,7 +267,7 @@ public class WebhookController {
      * or agent flow.
      */
     @PostMapping("/{name}")
-    public Mono<ResponseEntity<WebhookResponse>> customHook(
+    public Mono<ResponseEntity<?>> customHook(
             @PathVariable String name,
             @RequestBody(required = false) byte[] body,
             @RequestHeader HttpHeaders headers) {
@@ -268,13 +301,13 @@ public class WebhookController {
             if (ACTION_AGENT.equals(mapping.getAction())) {
                 try {
                     return dispatchAsAgent(mapping, safeText, config);
-                } catch (IllegalArgumentException e) {
+                } catch (IllegalArgumentException | WebhookResponseSchemaService.SchemaProcessingException e) {
                     return badRequest(e.getMessage());
                 }
             }
 
             return dispatchAsWake(mapping, safeText);
-        });
+        }).subscribeOn(Schedulers.boundedElastic());
     }
 
     // ==================== internal helpers ====================
@@ -290,12 +323,19 @@ public class WebhookController {
         return ResponseEntity.ok(WebhookResponse.accepted(chatId));
     }
 
-    private ResponseEntity<WebhookResponse> dispatchAsAgent(
+    private ResponseEntity<?> dispatchAsAgent(
             UserPreferences.HookMapping mapping, String text, UserPreferences.WebhookConfig config) {
 
         String runId = UUID.randomUUID().toString();
         String chatId = "hook:" + mapping.getName() + ":" + UUID.randomUUID();
         String modelTier = normalizeOptionalModelTier(mapping.getModel(), "Webhook mapping model");
+        String responseValidationModelTier = normalizeOptionalModelTier(
+                mapping.getResponseValidationModelTier(),
+                "Webhook mapping responseValidationModelTier");
+        validateSynchronousResponseContract(
+                mapping.isSyncResponse(),
+                mapping.getResponseJsonSchema(),
+                "Webhook mapping responseJsonSchema");
 
         Map<String, Object> metadata = new HashMap<>();
         metadata.put("webhook.runId", runId);
@@ -304,21 +344,108 @@ public class WebhookController {
         if (modelTier != null) {
             metadata.put("webhook.modelTier", modelTier);
         }
+        addResponseContractMetadata(metadata, mapping.getResponseJsonSchema(), responseValidationModelTier);
         if (mapping.isDeliver()) {
             metadata.put(ContextAttributes.WEBHOOK_DELIVER, true);
             metadata.put(ContextAttributes.WEBHOOK_DELIVER_CHANNEL, mapping.getChannel());
             metadata.put(ContextAttributes.WEBHOOK_DELIVER_TO, mapping.getTo());
         }
 
-        channelAdapter.registerPendingRun(chatId, runId, null, modelTier, null);
+        CompletableFuture<String> responseFuture = channelAdapter.registerPendingRun(chatId, runId, null, modelTier,
+                null);
 
         Message message = buildMessage(chatId, text, metadata, TraceNamingSupport.WEBHOOK_AGENT);
         eventPublisher.publishEvent(new AgentLoop.InboundMessageEvent(message));
 
         log.info("[Webhook] Custom agent accepted: mapping={}, runId={}, chatId={}",
                 mapping.getName(), runId, chatId);
+        if (mapping.isSyncResponse()) {
+            return buildSynchronousResponse(
+                    responseFuture,
+                    runId,
+                    chatId,
+                    config.getDefaultTimeoutSeconds(),
+                    mapping.getResponseJsonSchema(),
+                    responseValidationModelTier,
+                    modelTier);
+        }
         return ResponseEntity.status(HttpStatus.ACCEPTED)
                 .body(WebhookResponse.accepted(runId, chatId));
+    }
+
+    private void addResponseContractMetadata(Map<String, Object> metadata, Map<String, Object> responseJsonSchema,
+            String responseValidationModelTier) {
+        if (WebhookResponseSchemaService.hasSchema(responseJsonSchema)) {
+            metadata.put(ContextAttributes.WEBHOOK_RESPONSE_JSON_SCHEMA, responseJsonSchema);
+            metadata.put(ContextAttributes.WEBHOOK_RESPONSE_JSON_SCHEMA_TEXT,
+                    responseSchemaService.renderSchema(responseJsonSchema));
+        }
+        if (responseValidationModelTier != null && !responseValidationModelTier.isBlank()) {
+            metadata.put(ContextAttributes.WEBHOOK_RESPONSE_VALIDATION_MODEL_TIER, responseValidationModelTier);
+        }
+    }
+
+    private void validateSynchronousResponseContract(boolean syncResponse, Map<String, Object> responseJsonSchema,
+            String fieldName) {
+        if (!WebhookResponseSchemaService.hasSchema(responseJsonSchema)) {
+            return;
+        }
+        if (!syncResponse) {
+            throw new IllegalArgumentException(fieldName + " requires syncResponse=true");
+        }
+        responseSchemaService.validateSchemaDefinition(responseJsonSchema);
+    }
+
+    private ResponseEntity<?> buildSynchronousResponse(CompletableFuture<String> responseFuture, String runId,
+            String chatId, int timeoutSeconds, Map<String, Object> responseJsonSchema,
+            String responseValidationModelTier, String fallbackModelTier) {
+        long startedNanos = System.nanoTime();
+        try {
+            String response = responseFuture.get(timeoutSeconds, TimeUnit.SECONDS);
+            if (!WebhookResponseSchemaService.hasSchema(responseJsonSchema)) {
+                return ResponseEntity.ok(WebhookResponse.completed(runId, chatId, response, null));
+            }
+
+            WebhookResponseSchemaService.SchemaResult result = responseSchemaService.validateAndRepair(
+                    response,
+                    responseJsonSchema,
+                    responseValidationModelTier,
+                    fallbackModelTier,
+                    remainingBudget(timeoutSeconds, startedNanos));
+            return ResponseEntity.ok()
+                    .header("X-Golemcore-Run-Id", runId)
+                    .header("X-Golemcore-Chat-Id", chatId)
+                    .header("X-Golemcore-Schema-Repair-Attempts", String.valueOf(result.repairAttempts()))
+                    .body(result.payload());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            channelAdapter.cancelPendingRun(chatId);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(WebhookResponse.error("Synchronous webhook response was interrupted"));
+        } catch (TimeoutException e) {
+            channelAdapter.cancelPendingRun(chatId);
+            return ResponseEntity.status(HttpStatus.GATEWAY_TIMEOUT)
+                    .body(WebhookResponse.error("Synchronous webhook response timed out"));
+        } catch (CancellationException | ExecutionException e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(WebhookResponse.error("Synchronous webhook response failed: " + e.getMessage()));
+        } catch (WebhookResponseSchemaService.SchemaTimeoutException e) {
+            return ResponseEntity.status(HttpStatus.GATEWAY_TIMEOUT)
+                    .body(WebhookResponse.error("Synchronous webhook response timed out"));
+        } catch (WebhookResponseSchemaService.SchemaProcessingException e) {
+            return ResponseEntity.status(HttpStatusCode.valueOf(422))
+                    .body(WebhookResponse.error(e.getMessage()));
+        }
+    }
+
+    private Duration remainingBudget(int timeoutSeconds, long startedNanos) {
+        Duration timeout = Duration.ofSeconds(timeoutSeconds);
+        Duration elapsed = Duration.ofNanos(Math.max(0L, System.nanoTime() - startedNanos));
+        Duration remaining = timeout.minus(elapsed);
+        if (remaining.isNegative() || remaining.isZero()) {
+            throw new WebhookResponseSchemaService.SchemaTimeoutException("Synchronous webhook response timed out");
+        }
+        return remaining;
     }
 
     private Message buildMessage(String chatId, String content, Map<String, Object> metadata, String traceName) {

--- a/src/main/java/me/golemcore/bot/adapter/inbound/webhook/WebhookResponseSchemaService.java
+++ b/src/main/java/me/golemcore/bot/adapter/inbound/webhook/WebhookResponseSchemaService.java
@@ -1,0 +1,323 @@
+/*
+ * Copyright 2026 Aleksei Kuleshov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contact: alex@kuleshov.tech
+ */
+
+package me.golemcore.bot.adapter.inbound.webhook;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SchemaLocation;
+import com.networknt.schema.SpecVersion;
+import com.networknt.schema.ValidationMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import me.golemcore.bot.domain.model.LlmRequest;
+import me.golemcore.bot.domain.model.LlmResponse;
+import me.golemcore.bot.domain.model.Message;
+import me.golemcore.bot.domain.service.ModelSelectionService;
+import me.golemcore.bot.port.outbound.LlmPort;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class WebhookResponseSchemaService {
+
+    private static final int MAX_SCHEMA_REPAIR_ATTEMPTS = 3;
+    private static final int MAX_REPORTED_SCHEMA_ERRORS = 8;
+    private static final Duration REPAIR_TIMEOUT = Duration.ofSeconds(30);
+    private static final String DEFAULT_VALIDATION_TIER = "balanced";
+    private static final SchemaLocation DRAFT_7_META_SCHEMA = SchemaLocation
+            .of("https://json-schema.org/draft-07/schema");
+
+    private final ObjectMapper objectMapper;
+    private final ModelSelectionService modelSelectionService;
+    private final LlmPort llmPort;
+
+    private final JsonSchemaFactory schemaFactory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V7);
+    private final JsonSchema schemaDefinitionSchema = schemaFactory.getSchema(DRAFT_7_META_SCHEMA);
+
+    public static boolean hasSchema(Map<String, Object> schema) {
+        return schema != null && !schema.isEmpty();
+    }
+
+    public void validateSchemaDefinition(Map<String, Object> schema) {
+        if (hasSchema(schema)) {
+            buildSchema(schema);
+        }
+    }
+
+    public String renderSchema(Map<String, Object> schema) {
+        return writeJson(schema);
+    }
+
+    public SchemaResult validateAndRepair(String rawResponse, Map<String, Object> schema,
+            String validationModelTier, String fallbackModelTier) {
+        return validateAndRepair(rawResponse, schema, validationModelTier, fallbackModelTier,
+                REPAIR_TIMEOUT.multipliedBy(MAX_SCHEMA_REPAIR_ATTEMPTS));
+    }
+
+    public SchemaResult validateAndRepair(String rawResponse, Map<String, Object> schema,
+            String validationModelTier, String fallbackModelTier, Duration repairBudget) {
+        if (!hasSchema(schema)) {
+            return new SchemaResult(rawResponse, 0);
+        }
+
+        JsonSchema jsonSchema = buildSchema(schema);
+        String schemaText = writeJson(schema);
+        String candidate = rawResponse;
+        ValidationAttempt validation = validateCandidate(jsonSchema, candidate);
+        if (validation.valid()) {
+            return new SchemaResult(validation.payload(), 0);
+        }
+
+        String repairTier = resolveRepairTier(validationModelTier, fallbackModelTier);
+        long repairStartedNanos = System.nanoTime();
+        for (int attempt = 1; attempt <= MAX_SCHEMA_REPAIR_ATTEMPTS; attempt++) {
+            Duration attemptTimeout = nextRepairAttemptTimeout(repairBudget, repairStartedNanos);
+            candidate = repairCandidate(candidate, schemaText, validation.errors(), repairTier, attemptTimeout);
+            validation = validateCandidate(jsonSchema, candidate);
+            if (validation.valid()) {
+                return new SchemaResult(validation.payload(), attempt);
+            }
+            log.warn("[Webhook] Response schema repair attempt {} failed: {}", attempt, validation.errors());
+        }
+
+        throw new SchemaProcessingException(
+                "Synchronous webhook response did not match responseJsonSchema after "
+                        + MAX_SCHEMA_REPAIR_ATTEMPTS + " repair attempts: " + String.join("; ", validation.errors()));
+    }
+
+    private JsonSchema buildSchema(Map<String, Object> schema) {
+        JsonNode schemaNode = objectMapper.valueToTree(schema);
+        validateSchemaDefinition(schemaNode);
+        try {
+            return schemaFactory.getSchema(schemaNode);
+        } catch (RuntimeException e) {
+            throw new SchemaProcessingException("Invalid responseJsonSchema: " + e.getMessage(), e);
+        }
+    }
+
+    private void validateSchemaDefinition(JsonNode schemaNode) {
+        Set<ValidationMessage> validationMessages = schemaDefinitionSchema.validate(schemaNode);
+        if (!validationMessages.isEmpty()) {
+            List<String> errors = validationMessages.stream()
+                    .map(ValidationMessage::getMessage)
+                    .limit(MAX_REPORTED_SCHEMA_ERRORS)
+                    .toList();
+            throw new SchemaProcessingException("Invalid responseJsonSchema: " + String.join("; ", errors));
+        }
+    }
+
+    private ValidationAttempt validateCandidate(JsonSchema jsonSchema, String candidate) {
+        JsonNode payload = parseCandidate(candidate);
+        if (payload == null) {
+            return new ValidationAttempt(null, false, List.of("response is not valid JSON"));
+        }
+
+        Set<ValidationMessage> validationMessages = jsonSchema.validate(payload);
+        if (validationMessages.isEmpty()) {
+            return new ValidationAttempt(payload, true, List.of());
+        }
+
+        List<String> errors = validationMessages.stream()
+                .map(ValidationMessage::getMessage)
+                .limit(MAX_REPORTED_SCHEMA_ERRORS)
+                .toList();
+        return new ValidationAttempt(payload, false, errors);
+    }
+
+    private JsonNode parseCandidate(String candidate) {
+        String trimmed = candidate != null ? candidate.trim() : "";
+        if (trimmed.isBlank()) {
+            return null;
+        }
+        JsonNode parsed = tryParse(trimmed);
+        if (parsed != null) {
+            return parsed;
+        }
+        return tryParse(extractJsonPayload(trimmed));
+    }
+
+    private JsonNode tryParse(String candidate) {
+        if (candidate == null || candidate.isBlank()) {
+            return null;
+        }
+        try {
+            return objectMapper.readTree(candidate);
+        } catch (JsonProcessingException e) {
+            return null;
+        }
+    }
+
+    private String extractJsonPayload(String candidate) {
+        String unfenced = stripMarkdownFence(candidate);
+        int objectStart = unfenced.indexOf('{');
+        int arrayStart = unfenced.indexOf('[');
+        int start = resolvePayloadStart(objectStart, arrayStart);
+        if (start < 0) {
+            return unfenced;
+        }
+
+        char opening = unfenced.charAt(start);
+        char closing = opening == '{' ? '}' : ']';
+        int end = unfenced.lastIndexOf(closing);
+        if (end < start) {
+            return unfenced;
+        }
+        return unfenced.substring(start, end + 1);
+    }
+
+    private int resolvePayloadStart(int objectStart, int arrayStart) {
+        if (objectStart < 0) {
+            return arrayStart;
+        }
+        if (arrayStart < 0) {
+            return objectStart;
+        }
+        return Math.min(objectStart, arrayStart);
+    }
+
+    private String stripMarkdownFence(String candidate) {
+        String trimmed = candidate.trim();
+        if (!trimmed.startsWith("```")) {
+            return trimmed;
+        }
+        int firstLineBreak = trimmed.indexOf('\n');
+        int closingFence = trimmed.lastIndexOf("```");
+        if (firstLineBreak < 0 || closingFence <= firstLineBreak) {
+            return trimmed;
+        }
+        return trimmed.substring(firstLineBreak + 1, closingFence).trim();
+    }
+
+    private Duration nextRepairAttemptTimeout(Duration repairBudget, long repairStartedNanos) {
+        Duration effectiveBudget = repairBudget != null ? repairBudget : REPAIR_TIMEOUT;
+        Duration elapsed = Duration.ofNanos(Math.max(0L, System.nanoTime() - repairStartedNanos));
+        Duration remaining = effectiveBudget.minus(elapsed);
+        if (remaining.isNegative() || remaining.isZero()) {
+            throw new SchemaTimeoutException("Response schema repair timed out");
+        }
+        return remaining.compareTo(REPAIR_TIMEOUT) < 0 ? remaining : REPAIR_TIMEOUT;
+    }
+
+    private String repairCandidate(String candidate, String schemaText, List<String> errors, String repairTier,
+            Duration attemptTimeout) {
+        ModelSelectionService.ModelSelection selection = modelSelectionService.resolveForTier(repairTier);
+        LlmRequest request = LlmRequest.builder()
+                .model(selection.model())
+                .reasoningEffort(selection.reasoning())
+                .temperature(0.0)
+                .systemPrompt("""
+                        You convert assistant output into strict JSON.
+                        Return only JSON. Do not include markdown fences or commentary.
+                        The JSON must satisfy the provided JSON Schema exactly.
+                        """)
+                .messages(List.of(Message.builder()
+                        .role("user")
+                        .content(buildRepairPrompt(candidate, schemaText, errors))
+                        .timestamp(Instant.now())
+                        .build()))
+                .modelTier(repairTier)
+                .build();
+        try {
+            long timeoutMillis = Math.max(1L, attemptTimeout.toMillis());
+            LlmResponse response = llmPort.chat(request).get(timeoutMillis, TimeUnit.MILLISECONDS);
+            if (response == null || response.getContent() == null || response.getContent().isBlank()) {
+                throw new SchemaProcessingException("Response schema repair returned an empty response");
+            }
+            return response.getContent();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new SchemaProcessingException("Response schema repair was interrupted", e);
+        } catch (TimeoutException e) {
+            throw new SchemaTimeoutException("Response schema repair timed out", e);
+        } catch (ExecutionException e) {
+            throw new SchemaProcessingException("Response schema repair failed: " + e.getMessage(), e);
+        }
+    }
+
+    private String buildRepairPrompt(String candidate, String schemaText, List<String> errors) {
+        return ("JSON Schema:%n%s%n%n"
+                + "Validation errors:%n%s%n%n"
+                + "Assistant output to reformat:%n%s%n%n"
+                + "Return only corrected JSON.")
+                .formatted(schemaText, String.join(System.lineSeparator(), errors), candidate != null ? candidate : "");
+    }
+
+    private String resolveRepairTier(String validationModelTier, String fallbackModelTier) {
+        if (validationModelTier != null && !validationModelTier.isBlank()) {
+            return validationModelTier;
+        }
+        if (fallbackModelTier != null && !fallbackModelTier.isBlank()) {
+            return fallbackModelTier;
+        }
+        return DEFAULT_VALIDATION_TIER;
+    }
+
+    private String writeJson(Object value) {
+        try {
+            return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(value);
+        } catch (JsonProcessingException e) {
+            throw new SchemaProcessingException("Failed to render responseJsonSchema", e);
+        }
+    }
+
+    public record SchemaResult(Object payload, int repairAttempts) {
+    }
+
+    private record ValidationAttempt(JsonNode payload, boolean valid, List<String> errors) {
+    }
+
+    public static class SchemaProcessingException extends RuntimeException {
+
+        private static final long serialVersionUID = 1L;
+
+        public SchemaProcessingException(String message) {
+            super(message);
+        }
+
+        public SchemaProcessingException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+
+    public static final class SchemaTimeoutException extends SchemaProcessingException {
+
+        private static final long serialVersionUID = 1L;
+
+        public SchemaTimeoutException(String message) {
+            super(message);
+        }
+
+        public SchemaTimeoutException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+}

--- a/src/main/java/me/golemcore/bot/adapter/inbound/webhook/dto/AgentRequest.java
+++ b/src/main/java/me/golemcore/bot/adapter/inbound/webhook/dto/AgentRequest.java
@@ -65,6 +65,16 @@ public class AgentRequest {
     /** URL to POST the agent response to when processing completes. */
     private String callbackUrl;
 
+    /** Wait for the agent response and return it in the HTTP response body. */
+    @Builder.Default
+    private boolean syncResponse = false;
+
+    /** Optional JSON Schema that the synchronous response must satisfy. */
+    private Map<String, Object> responseJsonSchema;
+
+    /** Optional explicit tier for response schema repair calls. */
+    private String responseValidationModelTier;
+
     /** Maximum execution time in seconds. */
     @Builder.Default
     private int timeoutSeconds = 300;

--- a/src/main/java/me/golemcore/bot/adapter/inbound/webhook/dto/WebhookResponse.java
+++ b/src/main/java/me/golemcore/bot/adapter/inbound/webhook/dto/WebhookResponse.java
@@ -48,6 +48,12 @@ public class WebhookResponse {
     @JsonProperty("error")
     private String errorMessage;
 
+    /** Agent response text for synchronous runs without a custom JSON schema. */
+    private Object response;
+
+    /** Number of LLM repair attempts used to satisfy the configured JSON Schema. */
+    private Integer schemaValidationAttempts;
+
     public static WebhookResponse accepted(String chatId) {
         return WebhookResponse.builder()
                 .status("accepted")
@@ -60,6 +66,17 @@ public class WebhookResponse {
                 .status("accepted")
                 .runId(runId)
                 .chatId(chatId)
+                .build();
+    }
+
+    public static WebhookResponse completed(String runId, String chatId, Object response,
+            Integer schemaValidationAttempts) {
+        return WebhookResponse.builder()
+                .status("completed")
+                .runId(runId)
+                .chatId(chatId)
+                .response(response)
+                .schemaValidationAttempts(schemaValidationAttempts)
                 .build();
     }
 

--- a/src/main/java/me/golemcore/bot/application/settings/RuntimeSettingsValidator.java
+++ b/src/main/java/me/golemcore/bot/application/settings/RuntimeSettingsValidator.java
@@ -462,7 +462,17 @@ public class RuntimeSettingsValidator {
                 continue;
             }
             mapping.setModel(normalizeOptionalSelectableTier(mapping.getModel(), "webhooks.mapping.model"));
+            mapping.setResponseValidationModelTier(normalizeOptionalSelectableTier(
+                    mapping.getResponseValidationModelTier(),
+                    "webhooks.mapping.responseValidationModelTier"));
+            if (hasResponseJsonSchema(mapping.getResponseJsonSchema()) && !mapping.isSyncResponse()) {
+                throw new IllegalArgumentException("webhooks.mapping.responseJsonSchema requires syncResponse=true");
+            }
         }
+    }
+
+    private boolean hasResponseJsonSchema(Map<String, Object> responseJsonSchema) {
+        return responseJsonSchema != null && !responseJsonSchema.isEmpty();
     }
 
     public RuntimeConfig.ToolsConfig ensureToolsConfig(RuntimeConfig config) {

--- a/src/main/java/me/golemcore/bot/domain/context/layer/WebhookResponseSchemaLayer.java
+++ b/src/main/java/me/golemcore/bot/domain/context/layer/WebhookResponseSchemaLayer.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 Aleksei Kuleshov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contact: alex@kuleshov.tech
+ */
+
+package me.golemcore.bot.domain.context.layer;
+
+import me.golemcore.bot.domain.context.ContextLayer;
+import me.golemcore.bot.domain.context.ContextLayerResult;
+import me.golemcore.bot.domain.model.AgentContext;
+import me.golemcore.bot.domain.model.ContextAttributes;
+import me.golemcore.bot.domain.model.Message;
+
+public class WebhookResponseSchemaLayer implements ContextLayer {
+
+    @Override
+    public String getName() {
+        return "webhook_response_schema";
+    }
+
+    @Override
+    public int getOrder() {
+        return 76;
+    }
+
+    @Override
+    public boolean appliesTo(AgentContext context) {
+        return readSchemaText(context) != null;
+    }
+
+    @Override
+    public ContextLayerResult assemble(AgentContext context) {
+        String schemaText = readSchemaText(context);
+        if (schemaText == null) {
+            return ContextLayerResult.empty(getName());
+        }
+
+        String content = ("# Webhook Response JSON Contract%n"
+                + "The caller requires the final response to be valid JSON matching this JSON Schema.%n"
+                + "Return only the JSON payload. Do not include markdown fences, prose, or fields not allowed by the schema.%n%n"
+                + "```json%n%s%n```")
+                .formatted(schemaText);
+
+        return ContextLayerResult.builder()
+                .layerName(getName())
+                .content(content)
+                .estimatedTokens((int) Math.ceil(content.length() / 3.5))
+                .build();
+    }
+
+    private String readSchemaText(AgentContext context) {
+        if (context == null || context.getMessages() == null || context.getMessages().isEmpty()) {
+            return null;
+        }
+        Message last = context.getMessages().get(context.getMessages().size() - 1);
+        if (last.getMetadata() == null) {
+            return null;
+        }
+        Object schemaText = last.getMetadata().get(ContextAttributes.WEBHOOK_RESPONSE_JSON_SCHEMA_TEXT);
+        if (schemaText instanceof String text && !text.isBlank()) {
+            return text;
+        }
+        return null;
+    }
+}

--- a/src/main/java/me/golemcore/bot/domain/model/ContextAttributes.java
+++ b/src/main/java/me/golemcore/bot/domain/model/ContextAttributes.java
@@ -223,6 +223,15 @@ public final class ContextAttributes {
     /** String ? webhook delivery target chat identifier. */
     public static final String WEBHOOK_DELIVER_TO = "webhook.deliver.to";
 
+    /** Map<String,Object> ? JSON Schema required for webhook response payloads. */
+    public static final String WEBHOOK_RESPONSE_JSON_SCHEMA = "webhook.response.jsonSchema";
+
+    /** String ? rendered JSON Schema text for webhook prompt assembly. */
+    public static final String WEBHOOK_RESPONSE_JSON_SCHEMA_TEXT = "webhook.response.jsonSchemaText";
+
+    /** String ? model tier used for webhook response schema repair calls. */
+    public static final String WEBHOOK_RESPONSE_VALIDATION_MODEL_TIER = "webhook.response.validationModelTier";
+
     /**
      * String ? transport chat id used for outbound delivery (for example Telegram
      * chat id when logical session key differs).

--- a/src/main/java/me/golemcore/bot/domain/model/UserPreferences.java
+++ b/src/main/java/me/golemcore/bot/domain/model/UserPreferences.java
@@ -157,5 +157,15 @@ public class UserPreferences {
 
         /** Target chat ID on the delivery channel. */
         private String to;
+
+        /** Wait for the agent response and return it in the webhook HTTP response. */
+        @Builder.Default
+        private boolean syncResponse = false;
+
+        /** Optional JSON Schema that the synchronous response must satisfy. */
+        private Map<String, Object> responseJsonSchema;
+
+        /** Optional explicit tier for response schema repair calls. */
+        private String responseValidationModelTier;
     }
 }

--- a/src/main/java/me/golemcore/bot/infrastructure/config/ContextLayerConfiguration.java
+++ b/src/main/java/me/golemcore/bot/infrastructure/config/ContextLayerConfiguration.java
@@ -15,6 +15,7 @@ import me.golemcore.bot.domain.context.layer.RagLayer;
 import me.golemcore.bot.domain.context.layer.SkillLayer;
 import me.golemcore.bot.domain.context.layer.TierAwarenessLayer;
 import me.golemcore.bot.domain.context.layer.ToolLayer;
+import me.golemcore.bot.domain.context.layer.WebhookResponseSchemaLayer;
 import me.golemcore.bot.domain.context.layer.WorkspaceInstructionsLayer;
 import me.golemcore.bot.domain.context.resolution.SkillResolver;
 import me.golemcore.bot.domain.context.resolution.TierResolver;
@@ -107,6 +108,11 @@ public class ContextLayerConfiguration {
     @Bean
     HiveLayer hiveLayer() {
         return new HiveLayer();
+    }
+
+    @Bean
+    WebhookResponseSchemaLayer webhookResponseSchemaLayer() {
+        return new WebhookResponseSchemaLayer();
     }
 
     @Bean

--- a/src/test/java/me/golemcore/bot/adapter/inbound/webhook/WebhookControllerTest.java
+++ b/src/test/java/me/golemcore/bot/adapter/inbound/webhook/WebhookControllerTest.java
@@ -20,8 +20,10 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -47,6 +49,7 @@ class WebhookControllerTest {
     private WebhookChannelAdapter channelAdapter;
     private WebhookPayloadTransformer transformer;
     private WebhookDeliveryTracker deliveryTracker;
+    private WebhookResponseSchemaService responseSchemaService;
     private ApplicationEventPublisher eventPublisher;
     private InputSanitizer inputSanitizer;
     private WebhookController controller;
@@ -58,12 +61,13 @@ class WebhookControllerTest {
         channelAdapter = mock(WebhookChannelAdapter.class);
         transformer = mock(WebhookPayloadTransformer.class);
         deliveryTracker = mock(WebhookDeliveryTracker.class);
+        responseSchemaService = mock(WebhookResponseSchemaService.class);
         eventPublisher = mock(ApplicationEventPublisher.class);
         inputSanitizer = new InputSanitizer();
 
         controller = new WebhookController(
                 preferencesService, authenticator, channelAdapter,
-                transformer, deliveryTracker, eventPublisher, inputSanitizer);
+                transformer, deliveryTracker, responseSchemaService, eventPublisher, inputSanitizer);
 
         when(preferencesService.getPreferences()).thenReturn(buildEnabledPrefs());
         when(authenticator.authenticateBearer(any())).thenReturn(true);
@@ -180,13 +184,13 @@ class WebhookControllerTest {
                 .model("smart")
                 .build();
 
-        ResponseEntity<WebhookResponse> response = controller.agent(toJsonBytes(request), new HttpHeaders()).block();
+        ResponseEntity<?> response = controller.agent(toJsonBytes(request), new HttpHeaders()).block();
 
         assertNotNull(response);
         assertEquals(HttpStatus.ACCEPTED, response.getStatusCode());
-        assertNotNull(response.getBody().getRunId());
-        assertNotNull(response.getBody().getChatId());
-        assertEquals("accepted", response.getBody().getStatus());
+        assertNotNull(webhookBody(response).getRunId());
+        assertNotNull(webhookBody(response).getChatId());
+        assertEquals("accepted", webhookBody(response).getStatus());
     }
 
     @Test
@@ -196,17 +200,17 @@ class WebhookControllerTest {
                 .chatId("my-session")
                 .build();
 
-        ResponseEntity<WebhookResponse> response = controller.agent(toJsonBytes(request), new HttpHeaders()).block();
+        ResponseEntity<?> response = controller.agent(toJsonBytes(request), new HttpHeaders()).block();
 
         assertNotNull(response);
-        assertEquals("my-session", response.getBody().getChatId());
+        assertEquals("my-session", webhookBody(response).getChatId());
     }
 
     @Test
     void agentShouldReturnBadRequestWhenMessageMissing() {
         AgentRequest request = AgentRequest.builder().message(null).build();
 
-        ResponseEntity<WebhookResponse> response = controller.agent(toJsonBytes(request), new HttpHeaders()).block();
+        ResponseEntity<?> response = controller.agent(toJsonBytes(request), new HttpHeaders()).block();
 
         assertNotNull(response);
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
@@ -229,6 +233,120 @@ class WebhookControllerTest {
                 eq("https://example.com/callback"), eq("coding"));
         verify(channelAdapter).registerPendingRun(anyString(), anyString(),
                 eq("https://example.com/callback"), eq("coding"), eq("delivery-1"));
+    }
+
+    @Test
+    void agentShouldReturnSynchronousResponseWhenRequested() {
+        AgentRequest request = AgentRequest.builder()
+                .message("Answer directly")
+                .syncResponse(true)
+                .build();
+        when(channelAdapter.registerPendingRun(anyString(), anyString(), any(), any(), any()))
+                .thenReturn(CompletableFuture.completedFuture("Direct answer"));
+
+        ResponseEntity<?> response = controller.agent(toJsonBytes(request), new HttpHeaders()).block();
+
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals("completed", webhookBody(response).getStatus());
+        assertEquals("Direct answer", webhookBody(response).getResponse());
+    }
+
+    @Test
+    void agentShouldReturnSchemaPayloadForSynchronousJsonSchema() {
+        Map<String, Object> schema = aliceResponseSchema();
+        Map<String, Object> payload = Map.of(
+                "version", "1.0",
+                "response", Map.of("text", "Ready", "tts", "Ready", "end_session", true));
+        AgentRequest request = AgentRequest.builder()
+                .message("Answer in Alice format")
+                .model("coding")
+                .syncResponse(true)
+                .responseJsonSchema(schema)
+                .responseValidationModelTier("smart")
+                .build();
+        when(channelAdapter.registerPendingRun(anyString(), anyString(), any(), any(), any()))
+                .thenReturn(CompletableFuture.completedFuture("Ready"));
+        when(responseSchemaService.renderSchema(schema)).thenReturn("{\"type\":\"object\"}");
+        when(responseSchemaService.validateAndRepair(eq("Ready"), eq(schema), eq("smart"), eq("coding"), any()))
+                .thenReturn(new WebhookResponseSchemaService.SchemaResult(payload, 1));
+
+        ResponseEntity<?> response = controller.agent(toJsonBytes(request), new HttpHeaders()).block();
+
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(payload, response.getBody());
+        assertEquals(List.of("1"), response.getHeaders().get("X-Golemcore-Schema-Repair-Attempts"));
+        verify(responseSchemaService).validateSchemaDefinition(schema);
+        ArgumentCaptor<Duration> repairBudgetCaptor = ArgumentCaptor.forClass(Duration.class);
+        verify(responseSchemaService).validateAndRepair(eq("Ready"), eq(schema), eq("smart"), eq("coding"),
+                repairBudgetCaptor.capture());
+        assertTrue(repairBudgetCaptor.getValue().compareTo(Duration.ZERO) > 0);
+        assertTrue(repairBudgetCaptor.getValue().compareTo(Duration.ofSeconds(300)) <= 0);
+
+        ArgumentCaptor<AgentLoop.InboundMessageEvent> captor = ArgumentCaptor
+                .forClass(AgentLoop.InboundMessageEvent.class);
+        verify(eventPublisher).publishEvent(captor.capture());
+        Message message = captor.getValue().message();
+        assertEquals(schema, message.getMetadata().get(ContextAttributes.WEBHOOK_RESPONSE_JSON_SCHEMA));
+        assertEquals("{\"type\":\"object\"}",
+                message.getMetadata().get(ContextAttributes.WEBHOOK_RESPONSE_JSON_SCHEMA_TEXT));
+        assertEquals("smart", message.getMetadata().get(ContextAttributes.WEBHOOK_RESPONSE_VALIDATION_MODEL_TIER));
+    }
+
+    @Test
+    void agentShouldRejectInvalidResponseSchemaBeforeDispatch() {
+        Map<String, Object> schema = Map.of("type", "invalid");
+        AgentRequest request = AgentRequest.builder()
+                .message("Answer in JSON")
+                .syncResponse(true)
+                .responseJsonSchema(schema)
+                .build();
+        doThrow(new WebhookResponseSchemaService.SchemaProcessingException("Invalid responseJsonSchema"))
+                .when(responseSchemaService).validateSchemaDefinition(schema);
+
+        ResponseEntity<?> response = controller.agent(toJsonBytes(request), new HttpHeaders()).block();
+
+        assertNotNull(response);
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals("Invalid responseJsonSchema", webhookBody(response).getErrorMessage());
+        verify(channelAdapter, never()).registerPendingRun(anyString(), anyString(), any(), any(), any());
+    }
+
+    @Test
+    void agentShouldRejectResponseSchemaWithoutSynchronousResponse() {
+        AgentRequest request = AgentRequest.builder()
+                .message("Answer in JSON")
+                .responseJsonSchema(aliceResponseSchema())
+                .build();
+
+        ResponseEntity<?> response = controller.agent(toJsonBytes(request), new HttpHeaders()).block();
+
+        assertNotNull(response);
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals("'responseJsonSchema' requires syncResponse=true", webhookBody(response).getErrorMessage());
+        verify(channelAdapter, never()).registerPendingRun(anyString(), anyString(), any(), any(), any());
+    }
+
+    @Test
+    void agentShouldReturnGatewayTimeoutWhenSchemaRepairBudgetExpires() {
+        Map<String, Object> schema = aliceResponseSchema();
+        AgentRequest request = AgentRequest.builder()
+                .message("Answer in Alice format")
+                .syncResponse(true)
+                .responseJsonSchema(schema)
+                .build();
+        when(channelAdapter.registerPendingRun(anyString(), anyString(), any(), any(), any()))
+                .thenReturn(CompletableFuture.completedFuture("Ready"));
+        when(responseSchemaService.renderSchema(schema)).thenReturn("{\"type\":\"object\"}");
+        when(responseSchemaService.validateAndRepair(eq("Ready"), eq(schema), any(), any(), any()))
+                .thenThrow(new WebhookResponseSchemaService.SchemaTimeoutException("Response schema repair timed out"));
+
+        ResponseEntity<?> response = controller.agent(toJsonBytes(request), new HttpHeaders()).block();
+
+        assertNotNull(response);
+        assertEquals(HttpStatus.GATEWAY_TIMEOUT, response.getStatusCode());
+        assertEquals("Synchronous webhook response timed out", webhookBody(response).getErrorMessage());
     }
 
     @Test
@@ -283,7 +401,7 @@ class WebhookControllerTest {
         when(deliveryTracker.registerPendingDelivery(anyString(), anyString(), anyString(), anyString()))
                 .thenReturn("delivery-special");
 
-        ResponseEntity<WebhookResponse> response = controller.agent(toJsonBytes(request), new HttpHeaders()).block();
+        ResponseEntity<?> response = controller.agent(toJsonBytes(request), new HttpHeaders()).block();
 
         assertNotNull(response);
         assertEquals(HttpStatus.ACCEPTED, response.getStatusCode());
@@ -298,11 +416,11 @@ class WebhookControllerTest {
                 .model("turbo")
                 .build();
 
-        ResponseEntity<WebhookResponse> response = controller.agent(toJsonBytes(request), new HttpHeaders()).block();
+        ResponseEntity<?> response = controller.agent(toJsonBytes(request), new HttpHeaders()).block();
 
         assertNotNull(response);
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
-        assertEquals("'model' must be a known tier id", response.getBody().getErrorMessage());
+        assertEquals("'model' must be a known tier id", webhookBody(response).getErrorMessage());
         verify(channelAdapter, never()).registerPendingRun(anyString(), anyString(), any(), any(), any());
     }
 
@@ -315,12 +433,12 @@ class WebhookControllerTest {
         doThrow(new IllegalArgumentException("callbackUrl must be a valid http(s) URL"))
                 .when(deliveryTracker).validateCallbackUrl("ftp://example.com/callback");
 
-        ResponseEntity<WebhookResponse> response = controller.agent(toJsonBytes(request), new HttpHeaders()).block();
+        ResponseEntity<?> response = controller.agent(toJsonBytes(request), new HttpHeaders()).block();
 
         assertNotNull(response);
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
-        assertEquals("error", response.getBody().getStatus());
-        assertEquals("callbackUrl must be a valid http(s) URL", response.getBody().getErrorMessage());
+        assertEquals("error", webhookBody(response).getStatus());
+        assertEquals("callbackUrl must be a valid http(s) URL", webhookBody(response).getErrorMessage());
 
         verify(channelAdapter, never()).registerPendingRun(anyString(), anyString(), anyString(), anyString(),
                 anyString());
@@ -341,7 +459,7 @@ class WebhookControllerTest {
                 .thenReturn("Push to myapp");
 
         byte[] body = "{}".getBytes();
-        ResponseEntity<WebhookResponse> response = controller.customHook("github-push", body, new HttpHeaders())
+        ResponseEntity<?> response = controller.customHook("github-push", body, new HttpHeaders())
                 .block();
 
         assertNotNull(response);
@@ -351,7 +469,7 @@ class WebhookControllerTest {
     @Test
     void customHookShouldReturn404ForUnknownMapping() {
         byte[] body = "{}".getBytes();
-        ResponseEntity<WebhookResponse> response = controller.customHook("unknown", body, new HttpHeaders()).block();
+        ResponseEntity<?> response = controller.customHook("unknown", body, new HttpHeaders()).block();
 
         assertNotNull(response);
         assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
@@ -369,7 +487,7 @@ class WebhookControllerTest {
         when(authenticator.authenticate(any(), any(), any())).thenReturn(false);
 
         byte[] body = "{}".getBytes();
-        ResponseEntity<WebhookResponse> response = controller.customHook("auth-fail", body, new HttpHeaders()).block();
+        ResponseEntity<?> response = controller.customHook("auth-fail", body, new HttpHeaders()).block();
 
         assertNotNull(response);
         assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
@@ -394,7 +512,7 @@ class WebhookControllerTest {
         when(authenticator.authenticate(any(), any(), any())).thenReturn(true);
 
         byte[] body = "this payload is way too large for the limit".getBytes();
-        ResponseEntity<WebhookResponse> response = controller.customHook("big", body, new HttpHeaders()).block();
+        ResponseEntity<?> response = controller.customHook("big", body, new HttpHeaders()).block();
 
         assertNotNull(response);
         assertEquals(HttpStatusCode.valueOf(413), response.getStatusCode());
@@ -413,12 +531,36 @@ class WebhookControllerTest {
         when(transformer.transform(any(), any())).thenReturn("Process: deploy");
 
         byte[] body = "{\"event\":\"deploy\"}".getBytes();
-        ResponseEntity<WebhookResponse> response = controller.customHook("agent-hook", body, new HttpHeaders())
+        ResponseEntity<?> response = controller.customHook("agent-hook", body, new HttpHeaders())
                 .block();
 
         assertNotNull(response);
         assertEquals(HttpStatus.ACCEPTED, response.getStatusCode());
-        assertNotNull(response.getBody().getRunId());
+        assertNotNull(webhookBody(response).getRunId());
+    }
+
+    @Test
+    void customHookAgentActionShouldReturnSynchronousResponseWhenConfigured() {
+        UserPreferences.HookMapping mapping = UserPreferences.HookMapping.builder()
+                .name("agent-hook")
+                .action("agent")
+                .messageTemplate("Process: {event}")
+                .syncResponse(true)
+                .build();
+        when(preferencesService.getPreferences()).thenReturn(buildPrefsWithMapping(mapping));
+        when(authenticator.authenticate(any(), any(), any())).thenReturn(true);
+        when(transformer.transform(any(), any())).thenReturn("Process: deploy");
+        when(channelAdapter.registerPendingRun(anyString(), anyString(), any(), any(), any()))
+                .thenReturn(CompletableFuture.completedFuture("Deployment done"));
+
+        byte[] body = "{\"event\":\"deploy\"}".getBytes();
+        ResponseEntity<?> response = controller.customHook("agent-hook", body, new HttpHeaders())
+                .block();
+
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals("completed", webhookBody(response).getStatus());
+        assertEquals("Deployment done", webhookBody(response).getResponse());
     }
 
     @Test
@@ -461,12 +603,12 @@ class WebhookControllerTest {
         when(transformer.transform(any(), any())).thenReturn("Process: deploy");
 
         byte[] body = "{\"event\":\"deploy\"}".getBytes();
-        ResponseEntity<WebhookResponse> response = controller.customHook("agent-hook", body, new HttpHeaders())
+        ResponseEntity<?> response = controller.customHook("agent-hook", body, new HttpHeaders())
                 .block();
 
         assertNotNull(response);
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
-        assertEquals("Webhook mapping model must be a known tier id", response.getBody().getErrorMessage());
+        assertEquals("Webhook mapping model must be a known tier id", webhookBody(response).getErrorMessage());
     }
 
     private UserPreferences buildEnabledPrefs() {
@@ -494,5 +636,18 @@ class WebhookControllerTest {
         } catch (Exception e) {
             throw new IllegalStateException("Failed to serialize test payload", e);
         }
+    }
+
+    private WebhookResponse webhookBody(ResponseEntity<?> response) {
+        return (WebhookResponse) response.getBody();
+    }
+
+    private Map<String, Object> aliceResponseSchema() {
+        return Map.of(
+                "type", "object",
+                "required", List.of("version", "response"),
+                "properties", Map.of(
+                        "version", Map.of("const", "1.0"),
+                        "response", Map.of("type", "object")));
     }
 }

--- a/src/test/java/me/golemcore/bot/adapter/inbound/webhook/WebhookHttpIntegrationTest.java
+++ b/src/test/java/me/golemcore/bot/adapter/inbound/webhook/WebhookHttpIntegrationTest.java
@@ -59,6 +59,7 @@ class WebhookHttpIntegrationTest {
                 mock(WebhookChannelAdapter.class),
                 new WebhookPayloadTransformer(),
                 mock(WebhookDeliveryTracker.class),
+                mock(WebhookResponseSchemaService.class),
                 mock(ApplicationEventPublisher.class),
                 new InputSanitizer());
 

--- a/src/test/java/me/golemcore/bot/adapter/inbound/webhook/WebhookResponseSchemaServiceTest.java
+++ b/src/test/java/me/golemcore/bot/adapter/inbound/webhook/WebhookResponseSchemaServiceTest.java
@@ -1,0 +1,315 @@
+package me.golemcore.bot.adapter.inbound.webhook;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import me.golemcore.bot.domain.model.LlmRequest;
+import me.golemcore.bot.domain.model.LlmResponse;
+import me.golemcore.bot.domain.service.ModelSelectionService;
+import me.golemcore.bot.port.outbound.LlmPort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class WebhookResponseSchemaServiceTest {
+
+    private ModelSelectionService modelSelectionService;
+    private LlmPort llmPort;
+    private WebhookResponseSchemaService service;
+
+    @BeforeEach
+    void setUp() {
+        modelSelectionService = mock(ModelSelectionService.class);
+        llmPort = mock(LlmPort.class);
+        service = new WebhookResponseSchemaService(new ObjectMapper(), modelSelectionService, llmPort);
+    }
+
+    @Test
+    void shouldAcceptValidJsonWithoutRepair() {
+        WebhookResponseSchemaService.SchemaResult result = service.validateAndRepair(
+                """
+                        {"version":"1.0","response":{"text":"Ready","tts":"Ready","end_session":true}}
+                        """,
+                aliceResponseSchema(),
+                "smart",
+                "coding");
+
+        JsonNode payload = assertInstanceOf(JsonNode.class, result.payload());
+        assertEquals("1.0", payload.path("version").asText());
+        assertEquals(0, result.repairAttempts());
+        verify(llmPort, never()).chat(any());
+    }
+
+    @Test
+    void shouldReturnRawResponseWhenNoSchemaConfigured() {
+        WebhookResponseSchemaService.SchemaResult result = service.validateAndRepair(
+                "plain response",
+                null,
+                null,
+                null);
+
+        assertEquals("plain response", result.payload());
+        assertEquals(0, result.repairAttempts());
+        verify(llmPort, never()).chat(any());
+    }
+
+    @Test
+    void shouldRenderAndValidateSchemaDefinition() {
+        service.validateSchemaDefinition(aliceResponseSchema());
+
+        String rendered = service.renderSchema(aliceResponseSchema());
+
+        assertTrue(rendered.contains("\"version\""));
+        verify(llmPort, never()).chat(any());
+    }
+
+    @Test
+    void shouldRepairInvalidJsonWithConfiguredTier() {
+        when(modelSelectionService.resolveForTier("smart"))
+                .thenReturn(new ModelSelectionService.ModelSelection("openai/gpt-test", "low"));
+        when(llmPort.chat(any()))
+                .thenReturn(CompletableFuture.completedFuture(LlmResponse.builder()
+                        .content("""
+                                {"version":"1.0","response":{"text":"Ready","tts":"Ready","end_session":true}}
+                                """)
+                        .build()));
+
+        WebhookResponseSchemaService.SchemaResult result = service.validateAndRepair(
+                "Ready",
+                aliceResponseSchema(),
+                "smart",
+                "coding");
+
+        JsonNode payload = assertInstanceOf(JsonNode.class, result.payload());
+        assertEquals("Ready", payload.path("response").path("text").asText());
+        assertEquals(1, result.repairAttempts());
+
+        ArgumentCaptor<LlmRequest> requestCaptor = ArgumentCaptor.forClass(LlmRequest.class);
+        verify(llmPort).chat(requestCaptor.capture());
+        assertEquals("openai/gpt-test", requestCaptor.getValue().getModel());
+        assertEquals("low", requestCaptor.getValue().getReasoningEffort());
+        assertEquals("smart", requestCaptor.getValue().getModelTier());
+    }
+
+    @Test
+    void shouldRepairSchemaValidationErrors() {
+        when(modelSelectionService.resolveForTier("smart"))
+                .thenReturn(new ModelSelectionService.ModelSelection("openai/gpt-test", "low"));
+        when(llmPort.chat(any()))
+                .thenReturn(CompletableFuture.completedFuture(LlmResponse.builder()
+                        .content("""
+                                {"version":"1.0","response":{"text":"Ready","tts":"Ready","end_session":true}}
+                                """)
+                        .build()));
+
+        WebhookResponseSchemaService.SchemaResult result = service.validateAndRepair(
+                """
+                        {"version":"1.0"}
+                        """,
+                aliceResponseSchema(),
+                "smart",
+                "coding");
+
+        JsonNode payload = assertInstanceOf(JsonNode.class, result.payload());
+        assertEquals("Ready", payload.path("response").path("tts").asText());
+        assertEquals(1, result.repairAttempts());
+    }
+
+    @Test
+    void shouldAcceptJsonFromMarkdownFence() {
+        WebhookResponseSchemaService.SchemaResult result = service.validateAndRepair(
+                """
+                        ```json
+                        {"version":"1.0","response":{"text":"Ready","tts":"Ready","end_session":true}}
+                        ```
+                        """,
+                aliceResponseSchema(),
+                null,
+                null);
+
+        JsonNode payload = assertInstanceOf(JsonNode.class, result.payload());
+        assertEquals("1.0", payload.path("version").asText());
+        verify(llmPort, never()).chat(any());
+    }
+
+    @Test
+    void shouldAcceptArrayPayloadExtractedFromProse() {
+        WebhookResponseSchemaService.SchemaResult result = service.validateAndRepair(
+                "Result: [\"ready\"] done",
+                Map.of("type", "array", "items", Map.of("type", "string")),
+                null,
+                null);
+
+        JsonNode payload = assertInstanceOf(JsonNode.class, result.payload());
+        assertEquals("ready", payload.get(0).asText());
+        verify(llmPort, never()).chat(any());
+    }
+
+    @Test
+    void shouldFailAfterThreeUnsuccessfulRepairAttempts() {
+        when(modelSelectionService.resolveForTier("smart"))
+                .thenReturn(new ModelSelectionService.ModelSelection("openai/gpt-test", "low"));
+        when(llmPort.chat(any()))
+                .thenReturn(CompletableFuture.completedFuture(LlmResponse.builder()
+                        .content("""
+                                {"version":"wrong"}
+                                """)
+                        .build()));
+
+        WebhookResponseSchemaService.SchemaProcessingException exception = assertThrows(
+                WebhookResponseSchemaService.SchemaProcessingException.class,
+                () -> service.validateAndRepair("Ready", aliceResponseSchema(), "smart", null));
+
+        assertTrue(exception.getMessage().contains("repair attempts"));
+        verify(llmPort, times(3)).chat(any());
+    }
+
+    @Test
+    void shouldRejectRepairWhenBudgetIsExhausted() {
+        WebhookResponseSchemaService.SchemaTimeoutException exception = assertThrows(
+                WebhookResponseSchemaService.SchemaTimeoutException.class,
+                () -> service.validateAndRepair("Ready", aliceResponseSchema(), "smart", null, Duration.ZERO));
+
+        assertTrue(exception.getMessage().contains("timed out"));
+        verify(llmPort, never()).chat(any());
+    }
+
+    @Test
+    void shouldRejectEmptyRepairResponse() {
+        when(modelSelectionService.resolveForTier("smart"))
+                .thenReturn(new ModelSelectionService.ModelSelection("openai/gpt-test", "low"));
+        when(llmPort.chat(any()))
+                .thenReturn(CompletableFuture.completedFuture(LlmResponse.builder()
+                        .content(" ")
+                        .build()));
+
+        WebhookResponseSchemaService.SchemaProcessingException exception = assertThrows(
+                WebhookResponseSchemaService.SchemaProcessingException.class,
+                () -> service.validateAndRepair("Ready", aliceResponseSchema(), "smart", null));
+
+        assertTrue(exception.getMessage().contains("empty response"));
+    }
+
+    @Test
+    void shouldUseFallbackTierWhenValidationTierIsBlank() {
+        when(modelSelectionService.resolveForTier("coding"))
+                .thenReturn(new ModelSelectionService.ModelSelection("openai/gpt-coding", "medium"));
+        when(llmPort.chat(any()))
+                .thenReturn(CompletableFuture.completedFuture(LlmResponse.builder()
+                        .content("""
+                                {"version":"1.0","response":{"text":"Ready","tts":"Ready","end_session":true}}
+                                """)
+                        .build()));
+
+        service.validateAndRepair("Ready", aliceResponseSchema(), " ", "coding");
+
+        ArgumentCaptor<LlmRequest> requestCaptor = ArgumentCaptor.forClass(LlmRequest.class);
+        verify(llmPort).chat(requestCaptor.capture());
+        assertEquals("coding", requestCaptor.getValue().getModelTier());
+    }
+
+    @Test
+    void shouldUseBalancedTierWhenNoTierIsConfigured() {
+        when(modelSelectionService.resolveForTier("balanced"))
+                .thenReturn(new ModelSelectionService.ModelSelection("openai/gpt-balanced", "low"));
+        when(llmPort.chat(any()))
+                .thenReturn(CompletableFuture.completedFuture(LlmResponse.builder()
+                        .content("""
+                                {"version":"1.0","response":{"text":"Ready","tts":"Ready","end_session":true}}
+                                """)
+                        .build()));
+
+        service.validateAndRepair("Ready", aliceResponseSchema(), null, null);
+
+        ArgumentCaptor<LlmRequest> requestCaptor = ArgumentCaptor.forClass(LlmRequest.class);
+        verify(llmPort).chat(requestCaptor.capture());
+        assertEquals("balanced", requestCaptor.getValue().getModelTier());
+    }
+
+    @Test
+    void shouldReportRepairExecutionFailure() {
+        when(modelSelectionService.resolveForTier("smart"))
+                .thenReturn(new ModelSelectionService.ModelSelection("openai/gpt-test", "low"));
+        when(llmPort.chat(any()))
+                .thenReturn(CompletableFuture.failedFuture(new IllegalStateException("downstream unavailable")));
+
+        WebhookResponseSchemaService.SchemaProcessingException exception = assertThrows(
+                WebhookResponseSchemaService.SchemaProcessingException.class,
+                () -> service.validateAndRepair("Ready", aliceResponseSchema(), "smart", null));
+
+        assertTrue(exception.getMessage().contains("repair failed"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldPreserveInterruptedFlagWhenRepairIsInterrupted() throws Exception {
+        CompletableFuture<LlmResponse> responseFuture = mock(CompletableFuture.class);
+        when(responseFuture.get(anyLong(), any()))
+                .thenThrow(new InterruptedException("stop"));
+        when(modelSelectionService.resolveForTier("smart"))
+                .thenReturn(new ModelSelectionService.ModelSelection("openai/gpt-test", "low"));
+        when(llmPort.chat(any())).thenReturn(responseFuture);
+
+        WebhookResponseSchemaService.SchemaProcessingException exception = assertThrows(
+                WebhookResponseSchemaService.SchemaProcessingException.class,
+                () -> service.validateAndRepair("Ready", aliceResponseSchema(), "smart", null));
+
+        assertTrue(exception.getMessage().contains("interrupted"));
+        assertTrue(Thread.currentThread().isInterrupted());
+        Thread.interrupted();
+    }
+
+    @Test
+    void shouldRejectInvalidSchemaDefinition() {
+        WebhookResponseSchemaService.SchemaProcessingException exception = assertThrows(
+                WebhookResponseSchemaService.SchemaProcessingException.class,
+                () -> service.validateSchemaDefinition(Map.of("type", "invalid")));
+
+        assertTrue(exception.getMessage().contains("Invalid responseJsonSchema"));
+        verify(llmPort, never()).chat(any());
+    }
+
+    @Test
+    void shouldRejectSelfReferentialSchemaRendering() {
+        Map<String, Object> schema = new HashMap<>();
+        schema.put("self", schema);
+
+        WebhookResponseSchemaService.SchemaProcessingException exception = assertThrows(
+                WebhookResponseSchemaService.SchemaProcessingException.class,
+                () -> service.renderSchema(schema));
+
+        assertTrue(exception.getMessage().contains("Failed to render responseJsonSchema"));
+    }
+
+    private Map<String, Object> aliceResponseSchema() {
+        return Map.of(
+                "type", "object",
+                "required", List.of("version", "response"),
+                "properties", Map.of(
+                        "version", Map.of("const", "1.0"),
+                        "response", Map.of(
+                                "type", "object",
+                                "required", List.of("text", "tts", "end_session"),
+                                "properties", Map.of(
+                                        "text", Map.of("type", "string"),
+                                        "tts", Map.of("type", "string"),
+                                        "end_session", Map.of("type", "boolean")))));
+    }
+}

--- a/src/test/java/me/golemcore/bot/application/settings/RuntimeSettingsValidatorTest.java
+++ b/src/test/java/me/golemcore/bot/application/settings/RuntimeSettingsValidatorTest.java
@@ -273,12 +273,30 @@ class RuntimeSettingsValidatorTest {
                 .mappings(List.of(UserPreferences.HookMapping.builder()
                         .name("build")
                         .model("default")
+                        .responseValidationModelTier("SMART")
+                        .syncResponse(true)
                         .build()))
                 .build();
 
         validator.validateWebhookConfig(webhookConfig);
 
         assertNull(webhookConfig.getMappings().getFirst().getModel());
+        assertEquals("smart", webhookConfig.getMappings().getFirst().getResponseValidationModelTier());
+    }
+
+    @Test
+    void shouldRejectWebhookResponseSchemaWithoutSynchronousResponse() {
+        UserPreferences.WebhookConfig webhookConfig = UserPreferences.WebhookConfig.builder()
+                .mappings(List.of(UserPreferences.HookMapping.builder()
+                        .name("build")
+                        .responseJsonSchema(Map.of("type", "object"))
+                        .build()))
+                .build();
+
+        IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
+                () -> validator.validateWebhookConfig(webhookConfig));
+
+        assertEquals("webhooks.mapping.responseJsonSchema requires syncResponse=true", error.getMessage());
     }
 
     @Test

--- a/src/test/java/me/golemcore/bot/domain/context/layer/WebhookResponseSchemaLayerTest.java
+++ b/src/test/java/me/golemcore/bot/domain/context/layer/WebhookResponseSchemaLayerTest.java
@@ -1,0 +1,73 @@
+package me.golemcore.bot.domain.context.layer;
+
+import me.golemcore.bot.domain.context.ContextLayerResult;
+import me.golemcore.bot.domain.model.AgentContext;
+import me.golemcore.bot.domain.model.ContextAttributes;
+import me.golemcore.bot.domain.model.Message;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class WebhookResponseSchemaLayerTest {
+
+    private final WebhookResponseSchemaLayer layer = new WebhookResponseSchemaLayer();
+
+    @Test
+    void shouldApplyWhenWebhookMessageCarriesResponseSchema() {
+        AgentContext context = AgentContext.builder()
+                .messages(List.of(Message.builder()
+                        .role("user")
+                        .metadata(Map.of(ContextAttributes.WEBHOOK_RESPONSE_JSON_SCHEMA_TEXT, schemaText()))
+                        .build()))
+                .build();
+
+        ContextLayerResult result = layer.assemble(context);
+
+        assertTrue(layer.appliesTo(context));
+        assertTrue(result.hasContent());
+        assertTrue(result.getContent().contains("Webhook Response JSON Contract"));
+        assertTrue(result.getContent().contains("\"version\""));
+    }
+
+    @Test
+    void shouldSkipWhenNoResponseSchemaIsPresent() {
+        AgentContext context = AgentContext.builder()
+                .messages(List.of(Message.builder().role("user").build()))
+                .build();
+
+        assertFalse(layer.appliesTo(context));
+    }
+
+    @Test
+    void shouldSkipWhenContextHasNoUsableSchemaText() {
+        AgentContext emptyContext = AgentContext.builder()
+                .messages(List.of())
+                .build();
+        AgentContext blankSchemaContext = AgentContext.builder()
+                .messages(List.of(Message.builder()
+                        .role("user")
+                        .metadata(Map.of(ContextAttributes.WEBHOOK_RESPONSE_JSON_SCHEMA_TEXT, " "))
+                        .build()))
+                .build();
+
+        assertFalse(layer.appliesTo(null));
+        assertFalse(layer.appliesTo(emptyContext));
+        assertFalse(layer.appliesTo(blankSchemaContext));
+    }
+
+    private String schemaText() {
+        return """
+                {
+                  "type" : "object",
+                  "properties" : {
+                    "version" : {
+                      "const" : "1.0"
+                    }
+                  }
+                }
+                """;
+    }
+}

--- a/src/test/java/me/golemcore/bot/infrastructure/config/CoreLayerConfigurationTest.java
+++ b/src/test/java/me/golemcore/bot/infrastructure/config/CoreLayerConfigurationTest.java
@@ -111,6 +111,7 @@ class CoreLayerConfigurationTest {
                 contextLayerConfiguration.autoModeLayer(mock(me.golemcore.bot.domain.service.AutoModeService.class)));
         assertNotNull(contextLayerConfiguration.planModeLayer(mock(PlanService.class)));
         assertNotNull(contextLayerConfiguration.hiveLayer());
+        assertNotNull(contextLayerConfiguration.webhookResponseSchemaLayer());
         assertNotNull(contextLayerConfiguration.contextAssembler(
                 mock(me.golemcore.bot.domain.context.resolution.SkillResolver.class),
                 mock(me.golemcore.bot.domain.context.resolution.TierResolver.class),


### PR DESCRIPTION
## Summary
- Add synchronous webhook responses with optional JSON Schema contracts.
- Validate schema-backed responses and repair invalid output with up to 3 LLM formatting attempts using a configurable validation tier.
- Add schema prompt context, dashboard controls, docs, and backend guards requiring `syncResponse=true` when a response schema is configured.

## Validation
- `npm run lint`
- `./mvnw -Dtest=WebhookControllerTest,WebhookResponseSchemaServiceTest,RuntimeSettingsValidatorTest test -DskipGitHooks=true -Dmaven.gitcommitid.skip=true`
- `./mvnw -Dtest=WebhookResponseSchemaServiceTest,WebhookControllerTest,WebhookResponseSchemaLayerTest,HexagonalArchitectureContractTest test -DskipGitHooks=true -Dmaven.gitcommitid.skip=true`
- `./mvnw -Dtest=WebhookResponseSchemaServiceTest,WebhookResponseSchemaLayerTest test -DskipGitHooks=true -Dmaven.gitcommitid.skip=true`
- `./mvnw -P strict -DskipTests test-compile spotbugs:check pmd:check -DskipGitHooks=true -Dmaven.gitcommitid.skip=true`
- `./mvnw -P strict verify -DskipGitHooks=true -Dmaven.gitcommitid.skip=true`
- `python3 .github/scripts/check-only-english.py`
- GitHub checks passed on `8eda74e9`; Sonar new-code coverage is 86.6% (required >= 80%).