### PR TITLE
feat(webhook): honor sync schema model settings

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -12,6 +12,7 @@
         "@tanstack/react-query": "^5.62.0",
         "@uiw/codemirror-extensions-langs": "^4.25.4",
         "@uiw/react-codemirror": "^4.25.4",
+        "ajv": "^8.18.0",
         "axios": "^1.15.0",
         "class-variance-authority": "^0.7.1",
         "react": "^18.3.1",
@@ -1305,6 +1306,22 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
       "version": "14.0.0",
       "dev": true,
@@ -1315,6 +1332,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "node_modules/@eslint/js": {
       "version": "9.39.2",
@@ -3032,14 +3055,14 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "dev": true,
-      "license": "MIT",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -4007,6 +4030,22 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/eslint/node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "dev": true,
@@ -4017,6 +4056,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "node_modules/espree": {
       "version": "10.4.0",
@@ -4149,13 +4194,29 @@
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ]
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -4764,9 +4825,9 @@
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "dev": true,
-      "license": "MIT"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -6520,6 +6581,14 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -7260,8 +7329,9 @@
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
       }

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -17,6 +17,7 @@
     "@tanstack/react-query": "^5.62.0",
     "@uiw/codemirror-extensions-langs": "^4.25.4",
     "@uiw/react-codemirror": "^4.25.4",
+    "ajv": "^8.18.0",
     "axios": "^1.15.0",
     "class-variance-authority": "^0.7.1",
     "react": "^18.3.1",

--- a/dashboard/src/api/webhooks.test.ts
+++ b/dashboard/src/api/webhooks.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createDefaultWebhookConfig,
+  createEmptyWebhookMapping,
+  JSON_SCHEMA_DRAFT_2020_12_DOCS_URL,
+  type HookMapping,
+  validateWebhookConfig,
+  type WebhookConfig,
+} from './webhooks';
+
+function createConfig(mapping: Partial<HookMapping>): WebhookConfig {
+  return {
+    ...createDefaultWebhookConfig(),
+    mappings: [{
+      ...createEmptyWebhookMapping(),
+      name: 'sync-hook',
+      action: 'agent',
+      authMode: 'bearer',
+      syncResponse: true,
+      ...mapping,
+    }],
+  };
+}
+
+describe('webhook response JSON Schema validation', () => {
+  it('points users to the official Draft 2020-12 documentation', () => {
+    expect(JSON_SCHEMA_DRAFT_2020_12_DOCS_URL).toBe('https://json-schema.org/draft/2020-12');
+  });
+
+  it('accepts a valid synchronous response schema', () => {
+    const config = createConfig({
+      responseJsonSchema: JSON.stringify({
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        type: 'object',
+        required: ['version'],
+        additionalProperties: false,
+        properties: {
+          version: { type: 'string', const: '1.0' },
+          response: true,
+        },
+        allOf: [
+          { type: 'object' },
+        ],
+        $defs: {
+          localizedText: { type: 'string' },
+        },
+      }),
+    });
+
+    expect(validateWebhookConfig(config)).toEqual({ valid: true, issues: [] });
+  });
+
+  it('rejects response schema when synchronous response is disabled', () => {
+    const result = validateWebhookConfig(createConfig({
+      syncResponse: false,
+      responseJsonSchema: '{"type":"object"}',
+    }));
+
+    expect(result.valid).toBe(false);
+    expect(result.issues).toContain('Mapping #1: synchronous response is required when response JSON Schema is configured.');
+  });
+
+  it('rejects malformed response schema JSON', () => {
+    const result = validateWebhookConfig(createConfig({
+      responseJsonSchema: '{"type":',
+    }));
+
+    expect(result.valid).toBe(false);
+    expect(result.issues).toContain('Mapping #1: response JSON Schema must be valid JSON.');
+  });
+
+  it('rejects non-object and invalid schema type values', () => {
+    const nonObject = validateWebhookConfig(createConfig({
+      responseJsonSchema: 'true',
+    }));
+    const invalidType = validateWebhookConfig(createConfig({
+      responseJsonSchema: '{"type":"invalid"}',
+    }));
+
+    expect(nonObject.issues).toContain('Mapping #1: response JSON Schema must be a JSON object.');
+    expect(invalidType.valid).toBe(false);
+    expect(invalidType.issues.some((issue) => issue.includes('Draft 2020-12'))).toBe(true);
+    expect(invalidType.issues.some((issue) => issue.includes('/type'))).toBe(true);
+  });
+
+  it('rejects invalid nested schema shapes before saving', () => {
+    const result = validateWebhookConfig(createConfig({
+      responseJsonSchema: JSON.stringify({
+        type: 'object',
+        required: ['response', 42],
+        properties: {
+          response: { type: 'invalid' },
+        },
+        items: 'wrong',
+        oneOf: { type: 'object' },
+      }),
+    }));
+
+    expect(result.valid).toBe(false);
+    expect(result.issues.some((issue) => issue.includes('/required'))).toBe(true);
+    expect(result.issues.some((issue) => issue.includes('/properties/response/type'))).toBe(true);
+    expect(result.issues.some((issue) => issue.includes('/items'))).toBe(true);
+    expect(result.issues.some((issue) => issue.includes('/oneOf'))).toBe(true);
+  });
+
+  it('rejects invalid Draft 2020-12 keyword values before saving', () => {
+    const result = validateWebhookConfig(createConfig({
+      responseJsonSchema: JSON.stringify({
+        type: 'string',
+        minLength: 'bad',
+      }),
+    }));
+
+    expect(result.valid).toBe(false);
+    expect(result.issues.some((issue) => issue.includes('minLength'))).toBe(true);
+    expect(result.issues.some((issue) => issue.includes('Draft 2020-12'))).toBe(true);
+  });
+});

--- a/dashboard/src/api/webhooks.test.ts
+++ b/dashboard/src/api/webhooks.test.ts
@@ -27,6 +27,10 @@ describe('webhook response JSON Schema validation', () => {
     expect(JSON_SCHEMA_DRAFT_2020_12_DOCS_URL).toBe('https://json-schema.org/draft/2020-12');
   });
 
+  it('defaults webhook memory preset to disabled', () => {
+    expect(createDefaultWebhookConfig().memoryPreset).toBe('disabled');
+  });
+
   it('accepts a valid synchronous response schema', () => {
     const config = createConfig({
       responseJsonSchema: JSON.stringify({
@@ -81,6 +85,15 @@ describe('webhook response JSON Schema validation', () => {
     expect(invalidType.valid).toBe(false);
     expect(invalidType.issues.some((issue) => issue.includes('Draft 2020-12'))).toBe(true);
     expect(invalidType.issues.some((issue) => issue.includes('/type'))).toBe(true);
+  });
+
+  it('rejects empty response schema objects', () => {
+    const result = validateWebhookConfig(createConfig({
+      responseJsonSchema: '{}',
+    }));
+
+    expect(result.valid).toBe(false);
+    expect(result.issues).toContain('Mapping #1: response JSON Schema must not be empty.');
   });
 
   it('rejects invalid nested schema shapes before saving', () => {

--- a/dashboard/src/api/webhooks.ts
+++ b/dashboard/src/api/webhooks.ts
@@ -16,6 +16,9 @@ export interface HookMapping {
   deliver: boolean;
   channel: string | null;
   to: string | null;
+  syncResponse: boolean;
+  responseJsonSchema: string | null;
+  responseValidationModelTier: string | null;
 }
 
 export type HookMappingDraft = HookMapping;
@@ -115,6 +118,9 @@ function normalizeMapping(raw: unknown): HookMapping {
     deliver: Boolean(record.deliver),
     channel: toNullableString(record.channel),
     to: toNullableString(record.to),
+    syncResponse: Boolean(record.syncResponse),
+    responseJsonSchema: toSchemaEditorValue(record.responseJsonSchema),
+    responseValidationModelTier: toNullableString(record.responseValidationModelTier),
   };
 }
 
@@ -131,6 +137,9 @@ function toBackendMapping(mapping: HookMapping): UnknownRecord {
     deliver: mapping.deliver,
     channel: toNullableString(mapping.channel),
     to: toNullableString(mapping.to),
+    syncResponse: mapping.syncResponse,
+    responseJsonSchema: toBackendJsonSchema(mapping.responseJsonSchema),
+    responseValidationModelTier: toNullableString(mapping.responseValidationModelTier),
   };
 }
 
@@ -184,6 +193,9 @@ export function createEmptyWebhookMapping(): HookMappingDraft {
     deliver: false,
     channel: null,
     to: null,
+    syncResponse: false,
+    responseJsonSchema: null,
+    responseValidationModelTier: null,
   };
 }
 
@@ -264,6 +276,26 @@ function validateMappingDelivery(mapping: HookMapping, index: number, issues: st
   }
 }
 
+function validateMappingResponseSchema(mapping: HookMapping, index: number, issues: string[]): void {
+  if (mapping.action !== 'agent') {
+    return;
+  }
+
+  if (mapping.responseJsonSchema == null || mapping.responseJsonSchema.trim().length === 0) {
+    return;
+  }
+
+  const prefix = `Mapping #${index + 1}`;
+  if (!mapping.syncResponse) {
+    issues.push(`${prefix}: synchronous response is required when response JSON Schema is configured.`);
+  }
+  try {
+    JSON.parse(mapping.responseJsonSchema);
+  } catch {
+    issues.push(`${prefix}: response JSON Schema must be valid JSON.`);
+  }
+}
+
 export function validateWebhookConfig(config: WebhookConfig): WebhookValidationResult {
   const issues: string[] = [];
   const seenNames = new Set<string>();
@@ -274,12 +306,34 @@ export function validateWebhookConfig(config: WebhookConfig): WebhookValidationR
     validateMappingName(mapping, index, seenNames, issues);
     validateMappingAuth(mapping, index, issues);
     validateMappingDelivery(mapping, index, issues);
+    validateMappingResponseSchema(mapping, index, issues);
   });
 
   return {
     valid: issues.length === 0,
     issues,
   };
+}
+
+function toSchemaEditorValue(value: unknown): string | null {
+  if (typeof value === 'string') {
+    return toNullableTemplate(value);
+  }
+  if (value == null) {
+    return null;
+  }
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return null;
+  }
+}
+
+function toBackendJsonSchema(value: string | null | undefined): unknown {
+  if (value == null || value.trim().length === 0) {
+    return null;
+  }
+  return JSON.parse(value);
 }
 
 export async function getWebhookConfig(): Promise<WebhookConfig> {

--- a/dashboard/src/api/webhooks.ts
+++ b/dashboard/src/api/webhooks.ts
@@ -31,11 +31,13 @@ export interface WebhookConfig {
   tokenPresent?: boolean;
   maxPayloadSize: number;
   defaultTimeoutSeconds: number;
+  memoryPreset: string;
   mappings: HookMapping[];
 }
 
 const DEFAULT_MAX_PAYLOAD_SIZE = 65536;
 const DEFAULT_TIMEOUT_SECONDS = 300;
+const DEFAULT_MEMORY_PRESET = 'disabled';
 const HOOK_NAME_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
 const MAX_JSON_SCHEMA_VALIDATION_ISSUES = 8;
 const JSON_SCHEMA_VALIDATOR = new Ajv2020({
@@ -168,6 +170,7 @@ function parseWebhookConfig(raw: unknown): WebhookConfig {
     tokenPresent: hasSecretValue(tokenRaw),
     maxPayloadSize: toNumberOrDefault(record.maxPayloadSize, DEFAULT_MAX_PAYLOAD_SIZE),
     defaultTimeoutSeconds: toNumberOrDefault(record.defaultTimeoutSeconds, DEFAULT_TIMEOUT_SECONDS),
+    memoryPreset: toNullableString(record.memoryPreset) ?? DEFAULT_MEMORY_PRESET,
     mappings: mappingsRaw.map((item) => normalizeMapping(item)),
   };
 }
@@ -178,6 +181,7 @@ function toBackendWebhookConfig(config: WebhookConfig): UnknownRecord {
     token: toSecretPayload(config.token),
     maxPayloadSize: config.maxPayloadSize,
     defaultTimeoutSeconds: config.defaultTimeoutSeconds,
+    memoryPreset: toNullableString(config.memoryPreset) ?? DEFAULT_MEMORY_PRESET,
     mappings: config.mappings.map((mapping) => toBackendMapping(mapping)),
   };
 }
@@ -189,6 +193,7 @@ export function createDefaultWebhookConfig(): WebhookConfig {
     tokenPresent: false,
     maxPayloadSize: DEFAULT_MAX_PAYLOAD_SIZE,
     defaultTimeoutSeconds: DEFAULT_TIMEOUT_SECONDS,
+    memoryPreset: DEFAULT_MEMORY_PRESET,
     mappings: [],
   };
 }
@@ -314,6 +319,10 @@ function validateMappingResponseSchema(mapping: HookMapping, index: number, issu
 function validateJsonSchemaDocument(schema: unknown, prefix: string, issues: string[]): void {
   if (!isPlainObject(schema)) {
     issues.push(`${prefix}: response JSON Schema must be a JSON object.`);
+    return;
+  }
+  if (Object.keys(schema).length === 0) {
+    issues.push(`${prefix}: response JSON Schema must not be empty.`);
     return;
   }
 

--- a/dashboard/src/api/webhooks.ts
+++ b/dashboard/src/api/webhooks.ts
@@ -1,3 +1,5 @@
+import type { ErrorObject } from 'ajv';
+import Ajv2020 from 'ajv/dist/2020';
 import client from './client';
 
 export type HookAction = 'wake' | 'agent';
@@ -35,6 +37,14 @@ export interface WebhookConfig {
 const DEFAULT_MAX_PAYLOAD_SIZE = 65536;
 const DEFAULT_TIMEOUT_SECONDS = 300;
 const HOOK_NAME_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
+const MAX_JSON_SCHEMA_VALIDATION_ISSUES = 8;
+const JSON_SCHEMA_VALIDATOR = new Ajv2020({
+  allErrors: true,
+  strictSchema: true,
+  validateSchema: true,
+});
+
+export const JSON_SCHEMA_DRAFT_2020_12_DOCS_URL = 'https://json-schema.org/draft/2020-12';
 
 type UnknownRecord = Record<string, unknown>;
 
@@ -125,6 +135,8 @@ function normalizeMapping(raw: unknown): HookMapping {
 }
 
 function toBackendMapping(mapping: HookMapping): UnknownRecord {
+  const responseJsonSchema = toBackendJsonSchema(mapping.responseJsonSchema);
+
   return {
     name: mapping.name.trim(),
     action: mapping.action,
@@ -138,8 +150,10 @@ function toBackendMapping(mapping: HookMapping): UnknownRecord {
     channel: toNullableString(mapping.channel),
     to: toNullableString(mapping.to),
     syncResponse: mapping.syncResponse,
-    responseJsonSchema: toBackendJsonSchema(mapping.responseJsonSchema),
-    responseValidationModelTier: toNullableString(mapping.responseValidationModelTier),
+    responseJsonSchema,
+    responseValidationModelTier: responseJsonSchema == null
+      ? null
+      : toNullableString(mapping.responseValidationModelTier),
   };
 }
 
@@ -290,10 +304,73 @@ function validateMappingResponseSchema(mapping: HookMapping, index: number, issu
     issues.push(`${prefix}: synchronous response is required when response JSON Schema is configured.`);
   }
   try {
-    JSON.parse(mapping.responseJsonSchema);
+    const parsedSchema = JSON.parse(mapping.responseJsonSchema) as unknown;
+    validateJsonSchemaDocument(parsedSchema, prefix, issues);
   } catch {
     issues.push(`${prefix}: response JSON Schema must be valid JSON.`);
   }
+}
+
+function validateJsonSchemaDocument(schema: unknown, prefix: string, issues: string[]): void {
+  if (!isPlainObject(schema)) {
+    issues.push(`${prefix}: response JSON Schema must be a JSON object.`);
+    return;
+  }
+
+  validateJsonSchemaWithDraft202012(schema, prefix, issues);
+}
+
+function isPlainObject(value: unknown): value is UnknownRecord {
+  return value != null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function validateJsonSchemaWithDraft202012(schema: UnknownRecord, prefix: string, issues: string[]): void {
+  try {
+    if (JSON_SCHEMA_VALIDATOR.validateSchema(schema)) {
+      return;
+    }
+  } catch (error: unknown) {
+    issues.push(
+      `${prefix}: response JSON Schema is not a valid Draft 2020-12 schema (${formatSchemaException(error)}).`,
+    );
+    return;
+  }
+
+  const schemaErrors = JSON_SCHEMA_VALIDATOR.errors ?? [];
+  if (schemaErrors.length === 0) {
+    issues.push(`${prefix}: response JSON Schema is not a valid Draft 2020-12 schema.`);
+    return;
+  }
+  uniqueSchemaErrors(schemaErrors).slice(0, MAX_JSON_SCHEMA_VALIDATION_ISSUES).forEach((error) => {
+    issues.push(
+      `${prefix}: response JSON Schema is not a valid Draft 2020-12 schema (${formatSchemaError(error)}).`,
+    );
+  });
+}
+
+function uniqueSchemaErrors(errors: ErrorObject[]): ErrorObject[] {
+  const seen = new Set<string>();
+  return errors.filter((error) => {
+    const key = `${error.instancePath}:${error.schemaPath}:${error.message ?? ''}`;
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+}
+
+function formatSchemaError(error: ErrorObject): string {
+  const location = error.instancePath.length > 0 ? error.instancePath : error.schemaPath;
+  const message = error.message ?? 'is invalid';
+  return `${location} ${message}`;
+}
+
+function formatSchemaException(error: unknown): string {
+  if (error instanceof Error && error.message.length > 0) {
+    return error.message;
+  }
+  return 'schema validation failed';
 }
 
 export function validateWebhookConfig(config: WebhookConfig): WebhookValidationResult {

--- a/dashboard/src/components/webhooks/HookMappingAgentSection.test.tsx
+++ b/dashboard/src/components/webhooks/HookMappingAgentSection.test.tsx
@@ -41,11 +41,11 @@ function renderSection(mapping: HookMappingDraft): RenderResult {
   return { container, root };
 }
 
-function schemaRepairTierSelect(container: HTMLElement): HTMLSelectElement {
+function schemaResponseTierSelect(container: HTMLElement): HTMLSelectElement {
   const selects = Array.from(container.querySelectorAll('select'));
   const select = selects[2];
   if (!(select instanceof HTMLSelectElement)) {
-    throw new Error('Schema repair tier select not found');
+    throw new Error('Schema response tier select not found');
   }
   return select;
 }
@@ -70,7 +70,7 @@ describe('HookAgentSection', () => {
     expect(html).toContain('JSON Schema Draft 2020-12');
   });
 
-  it('keeps schema repair tier disabled until a response JSON Schema is configured', () => {
+  it('keeps schema response tier disabled until a response JSON Schema is configured', () => {
     const withoutSchema = renderSection({
       ...createEmptyWebhookMapping(),
       name: 'sync-hook',
@@ -79,7 +79,7 @@ describe('HookAgentSection', () => {
       responseValidationModelTier: 'special5',
     });
 
-    expect(schemaRepairTierSelect(withoutSchema.container).disabled).toBe(true);
+    expect(schemaResponseTierSelect(withoutSchema.container).disabled).toBe(true);
 
     act(() => {
       withoutSchema.root.unmount();
@@ -94,7 +94,7 @@ describe('HookAgentSection', () => {
       responseJsonSchema: '{"type":"object"}',
     });
 
-    expect(schemaRepairTierSelect(withSchema.container).disabled).toBe(false);
+    expect(schemaResponseTierSelect(withSchema.container).disabled).toBe(false);
 
     act(() => {
       withSchema.root.unmount();

--- a/dashboard/src/components/webhooks/HookMappingAgentSection.test.tsx
+++ b/dashboard/src/components/webhooks/HookMappingAgentSection.test.tsx
@@ -1,0 +1,104 @@
+/* @vitest-environment jsdom */
+
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import {
+  createEmptyWebhookMapping,
+  JSON_SCHEMA_DRAFT_2020_12_DOCS_URL,
+  type HookMappingDraft,
+} from '../../api/webhooks';
+import { HookAgentSection } from './HookMappingAgentSection';
+
+declare global {
+  var IS_REACT_ACT_ENVIRONMENT: boolean | undefined;
+}
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+interface RenderResult {
+  container: HTMLDivElement;
+  root: Root;
+}
+
+function renderSection(mapping: HookMappingDraft): RenderResult {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(
+      <HookAgentSection
+        mapping={mapping}
+        onChange={() => undefined}
+        availableChannels={[]}
+        channelsLoading={false}
+      />,
+    );
+  });
+
+  return { container, root };
+}
+
+function schemaRepairTierSelect(container: HTMLElement): HTMLSelectElement {
+  const selects = Array.from(container.querySelectorAll('select'));
+  const select = selects[2];
+  if (!(select instanceof HTMLSelectElement)) {
+    throw new Error('Schema repair tier select not found');
+  }
+  return select;
+}
+
+describe('HookAgentSection', () => {
+  it('renders the official JSON Schema Draft 2020-12 documentation link', () => {
+    const html = renderToStaticMarkup(
+      <HookAgentSection
+        mapping={{
+          ...createEmptyWebhookMapping(),
+          name: 'sync-hook',
+          action: 'agent',
+          syncResponse: true,
+        }}
+        onChange={() => undefined}
+        availableChannels={[]}
+        channelsLoading={false}
+      />,
+    );
+
+    expect(html).toContain(JSON_SCHEMA_DRAFT_2020_12_DOCS_URL);
+    expect(html).toContain('JSON Schema Draft 2020-12');
+  });
+
+  it('keeps schema repair tier disabled until a response JSON Schema is configured', () => {
+    const withoutSchema = renderSection({
+      ...createEmptyWebhookMapping(),
+      name: 'sync-hook',
+      action: 'agent',
+      syncResponse: true,
+      responseValidationModelTier: 'special5',
+    });
+
+    expect(schemaRepairTierSelect(withoutSchema.container).disabled).toBe(true);
+
+    act(() => {
+      withoutSchema.root.unmount();
+    });
+    withoutSchema.container.remove();
+
+    const withSchema = renderSection({
+      ...createEmptyWebhookMapping(),
+      name: 'sync-hook',
+      action: 'agent',
+      syncResponse: true,
+      responseJsonSchema: '{"type":"object"}',
+    });
+
+    expect(schemaRepairTierSelect(withSchema.container).disabled).toBe(false);
+
+    act(() => {
+      withSchema.root.unmount();
+    });
+    withSchema.container.remove();
+  });
+});

--- a/dashboard/src/components/webhooks/HookMappingAgentSection.tsx
+++ b/dashboard/src/components/webhooks/HookMappingAgentSection.tsx
@@ -125,8 +125,8 @@ export function HookAgentSection({
         <div className={cn('mt-5 grid gap-4 lg:grid-cols-[minmax(12rem,16rem)_minmax(0,1fr)]', !mapping.syncResponse && 'opacity-75')}>
           <div>
             <HookMappingFieldHeading
-              label="Schema Repair Tier"
-              help="Optional tier used only to reformat responses that do not match the JSON Schema. Use Model Tier for the primary answer model."
+              label="Schema Response Tier"
+              help="Optional tier used for schema-constrained responses and repair attempts."
             />
             <Select
               value={mapping.responseValidationModelTier ?? ''}

--- a/dashboard/src/components/webhooks/HookMappingAgentSection.tsx
+++ b/dashboard/src/components/webhooks/HookMappingAgentSection.tsx
@@ -5,8 +5,9 @@ import { cn } from '../../lib/utils';
 import { getExplicitModelTierOptions } from '../../lib/modelTiers';
 import HelpTip from '../common/HelpTip';
 import { Badge } from '../ui/badge';
-import { Input, Select } from '../ui/field';
+import { Input, Select, Textarea } from '../ui/field';
 import { HookMappingFieldHeading } from './HookMappingFieldHeading';
+import { SynchronousResponseHeader } from './SynchronousResponseHeader';
 import {
   controlClassName,
   fieldHelpClassName,
@@ -114,8 +115,66 @@ export function HookAgentSection({
           />
         </div>
       </div>
+
+      <div className={cn(surfaceClassName, 'xl:col-span-2')}>
+        <SynchronousResponseHeader
+          syncResponse={mapping.syncResponse}
+          onToggle={(syncResponse) => onChange(nextMappingWithSynchronousResponse(mapping, syncResponse))}
+        />
+        <div className={cn('mt-5 grid gap-4 lg:grid-cols-[minmax(12rem,16rem)_minmax(0,1fr)]', !mapping.syncResponse && 'opacity-75')}>
+          <div>
+            <HookMappingFieldHeading
+              label="Schema Repair Tier"
+              help="Optional tier used to reformat responses that do not match the JSON Schema."
+            />
+            <Select
+              value={mapping.responseValidationModelTier ?? ''}
+              disabled={!mapping.syncResponse}
+              onChange={(event) => onChange({ ...mapping, responseValidationModelTier: toNullableString(event.target.value) })}
+              className={controlClassName}
+            >
+              <option value="">Default</option>
+              {getExplicitModelTierOptions().map((option) => (
+                <option key={option.value} value={option.value}>{option.label}</option>
+              ))}
+            </Select>
+            <p className={fieldHelpClassName}>
+              Leave empty to reuse the hook model tier or the balanced tier.
+            </p>
+          </div>
+          <div>
+            <HookMappingFieldHeading
+              label="Response JSON Schema"
+              help="Optional schema for the synchronous HTTP response body. The final agent output is validated and repaired up to three times."
+            />
+            <Textarea
+              rows={7}
+              value={mapping.responseJsonSchema ?? ''}
+              disabled={!mapping.syncResponse}
+              onChange={(event) => onChange({ ...mapping, responseJsonSchema: toNullableString(event.target.value) })}
+              placeholder={'{\n  "type": "object",\n  "required": ["version", "response"],\n  "properties": {\n    "version": { "const": "1.0" },\n    "response": { "type": "object" }\n  }\n}'}
+              className="min-h-[12rem] rounded-2xl border-border/80 bg-background/80 font-mono text-sm shadow-none"
+            />
+          </div>
+        </div>
+      </div>
     </div>
   );
+}
+
+function nextMappingWithSynchronousResponse(
+  mapping: HookMappingDraft,
+  syncResponse: boolean,
+): HookMappingDraft {
+  if (syncResponse) {
+    return { ...mapping, syncResponse };
+  }
+  return {
+    ...mapping,
+    syncResponse,
+    responseJsonSchema: null,
+    responseValidationModelTier: null,
+  };
 }
 
 function DeliveryHeader({

--- a/dashboard/src/components/webhooks/HookMappingAgentSection.tsx
+++ b/dashboard/src/components/webhooks/HookMappingAgentSection.tsx
@@ -1,6 +1,6 @@
 import { type ReactElement, useEffect, useMemo, useRef } from 'react';
 import type { SystemChannelResponse } from '../../api/system';
-import type { HookMappingDraft } from '../../api/webhooks';
+import { JSON_SCHEMA_DRAFT_2020_12_DOCS_URL, type HookMappingDraft } from '../../api/webhooks';
 import { cn } from '../../lib/utils';
 import { getExplicitModelTierOptions } from '../../lib/modelTiers';
 import HelpTip from '../common/HelpTip';
@@ -46,6 +46,7 @@ export function HookAgentSection({
 }: HookAgentSectionProps): ReactElement | null {
   const telegramAutofillKeyRef = useRef<string | null>(null);
   const deliveryState = useDeliveryState(mapping, linkedTelegramUserId, availableChannels, channelsLoading);
+  const hasResponseJsonSchema = mapping.responseJsonSchema != null && mapping.responseJsonSchema.trim().length > 0;
 
   useEffect(() => {
     if (deliveryState.telegramAutofillKey == null) {
@@ -125,12 +126,15 @@ export function HookAgentSection({
           <div>
             <HookMappingFieldHeading
               label="Schema Repair Tier"
-              help="Optional tier used to reformat responses that do not match the JSON Schema."
+              help="Optional tier used only to reformat responses that do not match the JSON Schema. Use Model Tier for the primary answer model."
             />
             <Select
               value={mapping.responseValidationModelTier ?? ''}
-              disabled={!mapping.syncResponse}
-              onChange={(event) => onChange({ ...mapping, responseValidationModelTier: toNullableString(event.target.value) })}
+              disabled={!mapping.syncResponse || !hasResponseJsonSchema}
+              onChange={(event) => onChange({
+                ...mapping,
+                responseValidationModelTier: toNullableString(event.target.value),
+              })}
               className={controlClassName}
             >
               <option value="">Default</option>
@@ -145,21 +149,38 @@ export function HookAgentSection({
           <div>
             <HookMappingFieldHeading
               label="Response JSON Schema"
-              help="Optional schema for the synchronous HTTP response body. The final agent output is validated and repaired up to three times."
+              help="Optional Draft 2020-12 schema for the synchronous HTTP response body. The final agent output is validated and repaired up to three times."
             />
             <Textarea
               rows={7}
               value={mapping.responseJsonSchema ?? ''}
               disabled={!mapping.syncResponse}
-              onChange={(event) => onChange({ ...mapping, responseJsonSchema: toNullableString(event.target.value) })}
+              onChange={(event) => onChange(nextMappingWithResponseJsonSchema(mapping, event.target.value))}
               placeholder={'{\n  "type": "object",\n  "required": ["version", "response"],\n  "properties": {\n    "version": { "const": "1.0" },\n    "response": { "type": "object" }\n  }\n}'}
               className="min-h-[12rem] rounded-2xl border-border/80 bg-background/80 font-mono text-sm shadow-none"
             />
+            <p className={fieldHelpClassName}>
+              Reference:{' '}
+              <a href={JSON_SCHEMA_DRAFT_2020_12_DOCS_URL} target="_blank" rel="noreferrer" className="font-semibold text-primary underline-offset-4 hover:underline">JSON Schema Draft 2020-12</a>
+              .
+            </p>
           </div>
         </div>
       </div>
     </div>
   );
+}
+
+function nextMappingWithResponseJsonSchema(mapping: HookMappingDraft, value: string): HookMappingDraft {
+  const responseJsonSchema = toNullableString(value);
+  if (responseJsonSchema != null) {
+    return { ...mapping, responseJsonSchema };
+  }
+  return {
+    ...mapping,
+    responseJsonSchema: null,
+    responseValidationModelTier: null,
+  };
 }
 
 function nextMappingWithSynchronousResponse(

--- a/dashboard/src/components/webhooks/HookMappingFormSections.tsx
+++ b/dashboard/src/components/webhooks/HookMappingFormSections.tsx
@@ -1,6 +1,6 @@
 import { type ReactElement, useState } from 'react';
 import { FiEye, FiEyeOff } from 'react-icons/fi';
-import type { HookMappingDraft } from '../../api/webhooks';
+import type { HookAction, HookMappingDraft } from '../../api/webhooks';
 import { cn } from '../../lib/utils';
 import { Badge } from '../ui/badge';
 import { Button } from '../ui/button';
@@ -77,7 +77,7 @@ export function HookIdentitySection({
           />
           <Select
             value={mapping.action}
-            onChange={(event) => onChange({ ...mapping, action: resolveHookAction(event.target.value) })}
+            onChange={(event) => onChange(nextMappingWithAction(mapping, resolveHookAction(event.target.value)))}
             className={controlClassName}
           >
             <option value="wake">Wake</option>
@@ -133,6 +133,19 @@ export function HookIdentitySection({
       </div>
     </div>
   );
+}
+
+function nextMappingWithAction(mapping: HookMappingDraft, action: HookAction): HookMappingDraft {
+  if (action === 'agent') {
+    return { ...mapping, action };
+  }
+  return {
+    ...mapping,
+    action,
+    syncResponse: false,
+    responseJsonSchema: null,
+    responseValidationModelTier: null,
+  };
 }
 
 interface HookSecuritySectionProps {

--- a/dashboard/src/components/webhooks/SynchronousResponseHeader.tsx
+++ b/dashboard/src/components/webhooks/SynchronousResponseHeader.tsx
@@ -1,0 +1,55 @@
+import type { ReactElement } from 'react';
+import { cn } from '../../lib/utils';
+import HelpTip from '../common/HelpTip';
+
+interface SynchronousResponseHeaderProps {
+  syncResponse: boolean;
+  onToggle: (syncResponse: boolean) => void;
+}
+
+export function SynchronousResponseHeader({
+  syncResponse,
+  onToggle,
+}: SynchronousResponseHeaderProps): ReactElement {
+  return (
+    <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+      <div className="space-y-1">
+        <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
+          <span>Synchronous HTTP Response</span>
+          <HelpTip text="Wait for the completed agent response and return it to the webhook caller." />
+        </div>
+        <p className="text-sm leading-6 text-muted-foreground">
+          Return the final agent output in the webhook HTTP response body.
+        </p>
+      </div>
+
+      <button
+        type="button"
+        role="switch"
+        aria-checked={syncResponse}
+        onClick={() => onToggle(!syncResponse)}
+        className={cn(
+          'inline-flex items-center gap-3 self-start rounded-lg border px-3 py-2 text-sm font-semibold transition-all',
+          syncResponse
+            ? 'border-primary/30 bg-primary/10 text-foreground shadow-soft'
+            : 'border-border/80 bg-background/80 text-muted-foreground',
+        )}
+      >
+        <span
+          className={cn(
+            'relative h-6 w-11 rounded-full transition-colors',
+            syncResponse ? 'bg-primary' : 'bg-muted',
+          )}
+        >
+          <span
+            className={cn(
+              'absolute left-0.5 top-0.5 h-5 w-5 rounded-full bg-white shadow transition-transform',
+              syncResponse ? 'translate-x-5' : 'translate-x-0',
+            )}
+          />
+        </span>
+        <span>{syncResponse ? 'Enabled' : 'Disabled'}</span>
+      </button>
+    </div>
+  );
+}

--- a/dashboard/src/components/webhooks/WebhookRuntimeCard.tsx
+++ b/dashboard/src/components/webhooks/WebhookRuntimeCard.tsx
@@ -1,6 +1,7 @@
 import type { ReactElement } from 'react';
 import { Button, Card, Col, Form, InputGroup, Row } from 'react-bootstrap';
 import { FiEye, FiEyeOff } from 'react-icons/fi';
+import type { MemoryPreset } from '../../api/settingsTypes';
 import type { WebhookConfig } from '../../api/webhooks';
 
 const DEFAULT_MAX_PAYLOAD_SIZE = 65536;
@@ -10,6 +11,8 @@ interface WebhookRuntimeCardProps {
   form: WebhookConfig;
   onChange: (next: WebhookConfig) => void;
   showToken: boolean;
+  memoryPresets: MemoryPreset[];
+  memoryPresetsLoading: boolean;
   onToggleShowToken: () => void;
 }
 
@@ -36,9 +39,14 @@ export function WebhookRuntimeCard({
   form,
   onChange,
   showToken,
+  memoryPresets,
+  memoryPresetsLoading,
   onToggleShowToken,
 }: WebhookRuntimeCardProps): ReactElement {
   const tokenToggleLabel = showToken ? 'Hide bearer token' : 'Show bearer token';
+  const memoryPresetOptions: Array<Pick<MemoryPreset, 'id' | 'label'>> = memoryPresets.length > 0
+    ? memoryPresets
+    : [{ id: 'disabled', label: 'Memory Disabled' }];
 
   return (
     <Card className="settings-card h-100">
@@ -87,7 +95,7 @@ export function WebhookRuntimeCard({
             </Form.Group>
           </Col>
 
-          <Col md={3}>
+          <Col md={2}>
             <Form.Group>
               <Form.Label className="small fw-medium">Max Payload (bytes)</Form.Label>
               <Form.Control
@@ -102,7 +110,7 @@ export function WebhookRuntimeCard({
             </Form.Group>
           </Col>
 
-          <Col md={3}>
+          <Col md={2}>
             <Form.Group>
               <Form.Label className="small fw-medium">Default Timeout (sec)</Form.Label>
               <Form.Control
@@ -114,6 +122,22 @@ export function WebhookRuntimeCard({
                   defaultTimeoutSeconds: toNumber(event.target.value, DEFAULT_TIMEOUT_SECONDS),
                 })}
               />
+            </Form.Group>
+          </Col>
+
+          <Col md={2}>
+            <Form.Group>
+              <Form.Label className="small fw-medium">Memory Preset</Form.Label>
+              <Form.Select
+                size="sm"
+                value={form.memoryPreset}
+                disabled={memoryPresetsLoading}
+                onChange={(event) => onChange({ ...form, memoryPreset: event.target.value })}
+              >
+                {memoryPresetOptions.map((preset) => (
+                  <option key={preset.id} value={preset.id}>{preset.label}</option>
+                ))}
+              </Form.Select>
             </Form.Group>
           </Col>
         </Row>

--- a/dashboard/src/components/webhooks/hookTemplateExamples.ts
+++ b/dashboard/src/components/webhooks/hookTemplateExamples.ts
@@ -9,7 +9,7 @@ export const HOOK_TEMPLATE_PATH_HINT =
 export const HOOK_TEMPLATE_EXAMPLES: HookTemplateExample[] = [
   {
     path: '{request.command}',
-    description: 'Raw Alice request body: reads the spoken command directly.',
+    description: 'Direct request body: reads the command field from the request object.',
   },
   {
     path: '{payload.request.command}',

--- a/dashboard/src/pages/WebhooksPage.tsx
+++ b/dashboard/src/pages/WebhooksPage.tsx
@@ -25,7 +25,7 @@ import {
   type WebhookConfig,
   validateWebhookConfig,
 } from '../api/webhooks';
-import { useRuntimeConfig } from '../hooks/useSettings';
+import { useMemoryPresets, useRuntimeConfig } from '../hooks/useSettings';
 import { useSystemChannels } from '../hooks/useSystem';
 import { useUpdateWebhookConfig, useWebhookConfig } from '../hooks/useWebhooks';
 import { filterAndSortChannels, resolveLinkedTelegramUserId } from '../utils/channelUtils';
@@ -67,6 +67,7 @@ function ErrorState({ onRetry }: ErrorStateProps): ReactElement {
 export default function WebhooksPage(): ReactElement {
   const webhookConfigQuery = useWebhookConfig();
   const runtimeConfigQuery = useRuntimeConfig();
+  const memoryPresetsQuery = useMemoryPresets();
   const systemChannelsQuery = useSystemChannels();
   const updateWebhookConfigMutation = useUpdateWebhookConfig();
 
@@ -153,6 +154,8 @@ export default function WebhooksPage(): ReactElement {
             form={form}
             onChange={setForm}
             showToken={showWebhookToken}
+            memoryPresets={memoryPresetsQuery.data ?? []}
+            memoryPresetsLoading={memoryPresetsQuery.isLoading}
             onToggleShowToken={() => setShowWebhookToken((current) => !current)}
           />
         </Col>

--- a/docs/WEBHOOKS.md
+++ b/docs/WEBHOOKS.md
@@ -40,6 +40,7 @@ Or edit `settings.json` directly:
     "token": "my-secret-token",
     "maxPayloadSize": 65536,
     "defaultTimeoutSeconds": 300,
+    "memoryPreset": "disabled",
     "mappings": []
   }
 }
@@ -131,10 +132,11 @@ Full agent turn. Runs a complete agent pipeline (LLM + tools) in an isolated ses
 | `name` | string | No | — | Human-readable label for logging |
 | `chatId` | string | No | `"hook:<uuid>"` | Session identifier |
 | `model` | string | No | — | Model tier (`balanced`, `smart`, `coding`, `deep`) |
+| `memoryPreset` | string | No | `disabled` | Memory preset for webhook turns; use another preset to opt in to memory |
 | `callbackUrl` | string | No | — | URL to POST results to when done |
 | `syncResponse` | boolean | No | `false` | Wait for the agent result and return it in the HTTP response |
 | `responseJsonSchema` | object | No | — | JSON Schema for the synchronous HTTP response body |
-| `responseValidationModelTier` | string | No | — | Model tier used for response schema repair calls |
+| `responseValidationModelTier` | string | No | — | Model tier used for schema-constrained response and repair calls |
 | `deliver` | boolean | No | `false` | Route response to a messaging channel |
 | `channel` | string | No | — | Target channel type (e.g. `"telegram"`) |
 | `to` | string | No | — | Target chat ID on delivery channel |
@@ -178,18 +180,13 @@ On failure:
 
 **Synchronous response**:
 
-Set `syncResponse=true` to wait for the completed agent output and return `200 OK` from the original HTTP call:
+Set `syncResponse=true` to wait for the completed agent output and return `200 OK` from the original HTTP call. Without `responseJsonSchema`, the response body is `text/plain` and the `X-Golemcore-Run-Id` / `X-Golemcore-Chat-Id` headers identify the run:
 
-```json
-{
-  "status": "completed",
-  "runId": "550e8400-e29b-41d4-a716-446655440000",
-  "chatId": "hook:...",
-  "response": "Here is the summary..."
-}
+```text
+Here is the summary...
 ```
 
-If `responseJsonSchema` is provided, the schema describes the top-level HTTP response body. The bot adds schema instructions to the system prompt, validates the final agent output, and makes up to three repair calls when the output does not match the schema. The repair calls use `responseValidationModelTier` when set, otherwise the hook model tier or `balanced`.
+If `responseJsonSchema` is provided, it must be a non-empty Draft 2020-12 JSON Schema for the top-level HTTP response body. The bot adds schema instructions to the system prompt, uses `responseValidationModelTier` as the schema-constrained response tier when set, validates the final agent output, and makes up to three repair calls when the output does not match the schema. Repair calls use `responseValidationModelTier` when set, otherwise the hook model tier or `balanced`.
 
 Example Alice-style response contract:
 
@@ -324,7 +321,7 @@ Custom mappings transform raw JSON payloads from external services into structur
 | `model` | string | — | Model tier override (for agent action) |
 | `syncResponse` | boolean | `false` | Return the final agent result in the HTTP response |
 | `responseJsonSchema` | object | — | JSON Schema for the synchronous HTTP response body |
-| `responseValidationModelTier` | string | — | Model tier used for schema repair calls |
+| `responseValidationModelTier` | string | — | Model tier used for schema-constrained response and repair calls |
 | `deliver` | boolean | `false` | Route response to a messaging channel |
 | `channel` | string | — | Target channel type for delivery |
 | `to` | string | — | Target chat ID for delivery |
@@ -485,6 +482,7 @@ All webhook configuration is stored in `UserPreferences` (not application.proper
     "token": null,
     "maxPayloadSize": 65536,
     "defaultTimeoutSeconds": 300,
+    "memoryPreset": "disabled",
     "mappings": []
   }
 }
@@ -496,6 +494,7 @@ All webhook configuration is stored in `UserPreferences` (not application.proper
 | `token` | string | `null` | Shared secret for Bearer authentication |
 | `maxPayloadSize` | int | `65536` | Max payload size in bytes (64KB) |
 | `defaultTimeoutSeconds` | int | `300` | Default timeout for `/agent` runs |
+| `memoryPreset` | string | `disabled` | Memory preset for webhook turns; use another preset to opt in to memory |
 | `mappings` | array | `[]` | Custom hook mappings (see above) |
 
 ### Delivery Tracking Config

--- a/docs/WEBHOOKS.md
+++ b/docs/WEBHOOKS.md
@@ -132,6 +132,9 @@ Full agent turn. Runs a complete agent pipeline (LLM + tools) in an isolated ses
 | `chatId` | string | No | `"hook:<uuid>"` | Session identifier |
 | `model` | string | No | — | Model tier (`balanced`, `smart`, `coding`, `deep`) |
 | `callbackUrl` | string | No | — | URL to POST results to when done |
+| `syncResponse` | boolean | No | `false` | Wait for the agent result and return it in the HTTP response |
+| `responseJsonSchema` | object | No | — | JSON Schema for the synchronous HTTP response body |
+| `responseValidationModelTier` | string | No | — | Model tier used for response schema repair calls |
 | `deliver` | boolean | No | `false` | Route response to a messaging channel |
 | `channel` | string | No | — | Target channel type (e.g. `"telegram"`) |
 | `to` | string | No | — | Target chat ID on delivery channel |
@@ -172,6 +175,65 @@ On failure:
   "durationMs": 300000
 }
 ```
+
+**Synchronous response**:
+
+Set `syncResponse=true` to wait for the completed agent output and return `200 OK` from the original HTTP call:
+
+```json
+{
+  "status": "completed",
+  "runId": "550e8400-e29b-41d4-a716-446655440000",
+  "chatId": "hook:...",
+  "response": "Here is the summary..."
+}
+```
+
+If `responseJsonSchema` is provided, the schema describes the top-level HTTP response body. The bot adds schema instructions to the system prompt, validates the final agent output, and makes up to three repair calls when the output does not match the schema. The repair calls use `responseValidationModelTier` when set, otherwise the hook model tier or `balanced`.
+
+Example Alice-style response contract:
+
+```json
+{
+  "message": "Answer the user in Alice skill format",
+  "syncResponse": true,
+  "model": "smart",
+  "responseValidationModelTier": "balanced",
+  "responseJsonSchema": {
+    "type": "object",
+    "required": ["version", "response"],
+    "additionalProperties": false,
+    "properties": {
+      "version": { "const": "1.0" },
+      "response": {
+        "type": "object",
+        "required": ["text", "tts", "end_session"],
+        "additionalProperties": false,
+        "properties": {
+          "text": { "type": "string" },
+          "tts": { "type": "string" },
+          "end_session": { "type": "boolean" }
+        }
+      }
+    }
+  }
+}
+```
+
+For schema-backed synchronous runs, the successful HTTP body is the validated JSON payload itself:
+
+```json
+{
+  "version": "1.0",
+  "response": {
+    "text": "Response text",
+    "tts": "Text for speech",
+    "end_session": true
+  }
+}
+```
+
+When `callbackUrl` is also set, callback delivery remains independent and contains the raw completed agent text. The JSON Schema contract applies to the original synchronous HTTP response body.
 
 **Use cases:**
 - Automated code review on PR open
@@ -260,6 +322,9 @@ Custom mappings transform raw JSON payloads from external services into structur
 | `hmacPrefix` | string | — | Prefix to strip from signature (e.g. `"sha256="`) |
 | `messageTemplate` | string | — | Template with `{json.path}` placeholders |
 | `model` | string | — | Model tier override (for agent action) |
+| `syncResponse` | boolean | `false` | Return the final agent result in the HTTP response |
+| `responseJsonSchema` | object | — | JSON Schema for the synchronous HTTP response body |
+| `responseValidationModelTier` | string | — | Model tier used for schema repair calls |
 | `deliver` | boolean | `false` | Route response to a messaging channel |
 | `channel` | string | — | Target channel type for delivery |
 | `to` | string | — | Target chat ID for delivery |

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
         <totp.version>1.7.1</totp.version>
         <protobuf.version>4.34.1</protobuf.version>
         <protobuf.maven.plugin.version>0.6.1</protobuf.maven.plugin.version>
+        <json.schema.validator.version>1.5.6</json.schema.validator.version>
 
         <spotbugs.version>4.9.8.3</spotbugs.version>
         <pmd.version>3.28.0</pmd.version>
@@ -207,6 +208,11 @@
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.networknt</groupId>
+            <artifactId>json-schema-validator</artifactId>
+            <version>${json.schema.validator.version}</version>
         </dependency>
 
         <!-- Protocol Buffers -->

--- a/src/main/java/me/golemcore/bot/adapter/inbound/command/CommandRouter.java
+++ b/src/main/java/me/golemcore/bot/adapter/inbound/command/CommandRouter.java
@@ -161,7 +161,7 @@ public class CommandRouter implements CommandPort {
             case "reset" -> handleReset(sessionId, sessionIdentity);
             case "compact" -> handleCompact(sessionId, args);
             case CMD_HELP -> handleHelp();
-            case "tier" -> modelSelectionCommandHandler.handleTier(args);
+            case "tier" -> modelSelectionCommandHandler.handleTier(args, sessionId);
             case "model" -> modelSelectionCommandHandler.handleModel(args);
             case "sessions" -> handleSessions(channelType);
             case "auto" -> automationCommandHandler.handleAuto(args, channelType, autoSessionChatId, transportChatId);

--- a/src/main/java/me/golemcore/bot/adapter/inbound/command/ModelSelectionCommandHandler.java
+++ b/src/main/java/me/golemcore/bot/adapter/inbound/command/ModelSelectionCommandHandler.java
@@ -22,15 +22,20 @@ class ModelSelectionCommandHandler {
     private final UserPreferencesService preferencesService;
 
     CommandPort.CommandResult handleTier(List<String> args) {
+        return handleTier(args, null);
+    }
+
+    CommandPort.CommandResult handleTier(List<String> args, String sessionId) {
         if (args.isEmpty()) {
             return renderTierOutcome(
-                    modelSelectionCommandService.handleTier(new ModelSelectionCommandService.ShowTierStatus()));
+                    modelSelectionCommandService
+                            .handleTier(new ModelSelectionCommandService.ShowTierStatus(sessionId)));
         }
 
         String tier = ModelTierCatalog.normalizeTierId(args.get(0));
         boolean force = args.size() > 1 && "force".equalsIgnoreCase(args.get(1));
         return renderTierOutcome(modelSelectionCommandService.handleTier(
-                new ModelSelectionCommandService.SetTierSelection(tier, force)));
+                new ModelSelectionCommandService.SetTierSelection(tier, force, sessionId)));
     }
 
     CommandPort.CommandResult handleModel(List<String> args) {

--- a/src/main/java/me/golemcore/bot/adapter/inbound/web/WebSocketChatHandler.java
+++ b/src/main/java/me/golemcore/bot/adapter/inbound/web/WebSocketChatHandler.java
@@ -57,7 +57,7 @@ public class WebSocketChatHandler implements WebSocketHandler {
     public Mono<Void> handle(WebSocketSession session) {
         String token = extractToken(session);
         if (token == null || !jwtTokenProvider.validateToken(token) || !jwtTokenProvider.isAccessToken(token)) {
-            log.warn("[WebSocket] Connection rejected: invalid or missing JWT");
+            log.debug("[WebSocket] Connection rejected: invalid or missing JWT");
             return session.close();
         }
 

--- a/src/main/java/me/golemcore/bot/adapter/inbound/webhook/WebhookController.java
+++ b/src/main/java/me/golemcore/bot/adapter/inbound/webhook/WebhookController.java
@@ -25,12 +25,14 @@ import me.golemcore.bot.adapter.inbound.webhook.dto.WebhookResponse;
 import me.golemcore.bot.domain.loop.AgentLoop;
 import me.golemcore.bot.domain.model.AgentSession;
 import me.golemcore.bot.domain.model.ContextAttributes;
+import me.golemcore.bot.domain.model.MemoryPresetIds;
 import me.golemcore.bot.domain.model.Message;
 import me.golemcore.bot.domain.model.ModelTierCatalog;
 import me.golemcore.bot.domain.model.UserPreferences;
 import me.golemcore.bot.domain.model.trace.TraceContext;
 import me.golemcore.bot.domain.model.trace.TraceSpanKind;
 import me.golemcore.bot.domain.model.trace.TraceStatusCode;
+import me.golemcore.bot.domain.service.MemoryPresetService;
 import me.golemcore.bot.domain.service.TraceContextSupport;
 import me.golemcore.bot.domain.service.TraceNamingSupport;
 import me.golemcore.bot.domain.service.TraceService;
@@ -60,6 +62,7 @@ import java.time.Instant;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CancellationException;
@@ -105,6 +108,7 @@ public class WebhookController {
     private final WebhookPayloadTransformer transformer;
     private final WebhookDeliveryTracker deliveryTracker;
     private final WebhookResponseSchemaService responseSchemaService;
+    private final MemoryPresetService memoryPresetService;
     private final ApplicationEventPublisher eventPublisher;
     private final SessionPort sessionPort;
     private final TraceService traceService;
@@ -145,8 +149,18 @@ public class WebhookController {
             String chatId = request.getChatId() != null ? request.getChatId() : "webhook:default";
             String sanitizedText = inputSanitizer.sanitize(request.getText());
             String safeText = wrapExternal(sanitizedText);
+            String memoryPreset;
+            try {
+                memoryPreset = resolveWebhookMemoryPreset(null, config);
+            } catch (IllegalArgumentException e) {
+                return badRequest(e.getMessage());
+            }
 
-            Message message = buildMessage(chatId, safeText, request.getMetadata(), TraceNamingSupport.WEBHOOK_WAKE);
+            Map<String, Object> metadata = new HashMap<>(
+                    request.getMetadata() != null ? request.getMetadata() : Map.of());
+            addMemoryPresetMetadata(metadata, memoryPreset);
+
+            Message message = buildMessage(chatId, safeText, metadata, TraceNamingSupport.WEBHOOK_WAKE);
             eventPublisher.publishEvent(new AgentLoop.InboundMessageEvent(message));
 
             log.info("[Webhook] Wake event accepted for chatId={}", chatId);
@@ -197,6 +211,7 @@ public class WebhookController {
             String modelTier;
             String responseValidationModelTier;
             String effectiveModelTier;
+            String memoryPreset;
             try {
                 modelTier = normalizeOptionalModelTier(request.getModel(), "'model'");
                 responseValidationModelTier = normalizeResponseValidationModelTier(
@@ -211,6 +226,7 @@ public class WebhookController {
                         request.isSyncResponse(),
                         request.getResponseJsonSchema(),
                         "'responseJsonSchema'");
+                memoryPreset = resolveWebhookMemoryPreset(request.getMemoryPreset(), config);
             } catch (IllegalArgumentException e) {
                 return badRequest(e.getMessage());
             } catch (WebhookResponseSchemaService.SchemaProcessingException e) {
@@ -224,6 +240,7 @@ public class WebhookController {
                     request.getMetadata() != null ? request.getMetadata() : Map.of());
             metadata.put("webhook.runId", runId);
             metadata.put("webhook.timeoutSeconds", timeout);
+            addMemoryPresetMetadata(metadata, memoryPreset);
             if (effectiveModelTier != null) {
                 metadata.put(ContextAttributes.WEBHOOK_MODEL_TIER, effectiveModelTier);
             }
@@ -323,16 +340,23 @@ public class WebhookController {
                 }
             }
 
-            return dispatchAsWake(mapping, safeText);
+            try {
+                return dispatchAsWake(mapping, safeText, config);
+            } catch (IllegalArgumentException e) {
+                return badRequest(e.getMessage());
+            }
         }).subscribeOn(Schedulers.boundedElastic());
     }
 
     // ==================== internal helpers ====================
 
-    private ResponseEntity<WebhookResponse> dispatchAsWake(UserPreferences.HookMapping mapping, String text) {
+    private ResponseEntity<WebhookResponse> dispatchAsWake(
+            UserPreferences.HookMapping mapping, String text, UserPreferences.WebhookConfig config) {
         String chatId = "hook:" + mapping.getName();
 
-        Map<String, Object> metadata = Map.of("webhook.mapping", mapping.getName());
+        Map<String, Object> metadata = new HashMap<>();
+        metadata.put("webhook.mapping", mapping.getName());
+        addMemoryPresetMetadata(metadata, resolveWebhookMemoryPreset(null, config));
         Message message = buildMessage(chatId, text, metadata, TraceNamingSupport.WEBHOOK_WAKE);
         eventPublisher.publishEvent(new AgentLoop.InboundMessageEvent(message));
 
@@ -346,6 +370,7 @@ public class WebhookController {
         String runId = UUID.randomUUID().toString();
         String chatId = "hook:" + mapping.getName() + ":" + UUID.randomUUID();
         String modelTier = normalizeOptionalModelTier(mapping.getModel(), "Webhook mapping model");
+        String memoryPreset = resolveWebhookMemoryPreset(null, config);
         String responseValidationModelTier = normalizeResponseValidationModelTier(
                 mapping.getResponseJsonSchema(),
                 mapping.getResponseValidationModelTier(),
@@ -363,6 +388,7 @@ public class WebhookController {
         metadata.put("webhook.runId", runId);
         metadata.put("webhook.mapping", mapping.getName());
         metadata.put("webhook.timeoutSeconds", config.getDefaultTimeoutSeconds());
+        addMemoryPresetMetadata(metadata, memoryPreset);
         if (effectiveModelTier != null) {
             metadata.put(ContextAttributes.WEBHOOK_MODEL_TIER, effectiveModelTier);
         }
@@ -396,6 +422,10 @@ public class WebhookController {
                 .body(WebhookResponse.accepted(runId, chatId));
     }
 
+    private void addMemoryPresetMetadata(Map<String, Object> metadata, String memoryPreset) {
+        metadata.put(ContextAttributes.MEMORY_PRESET_ID, memoryPreset);
+    }
+
     private void addResponseContractMetadata(Map<String, Object> metadata, Map<String, Object> responseJsonSchema,
             String responseValidationModelTier) {
         if (!WebhookResponseSchemaService.hasSchema(responseJsonSchema)) {
@@ -411,6 +441,9 @@ public class WebhookController {
 
     private void validateSynchronousResponseContract(boolean syncResponse, Map<String, Object> responseJsonSchema,
             String fieldName) {
+        if (responseJsonSchema != null && responseJsonSchema.isEmpty()) {
+            throw new IllegalArgumentException(fieldName + " must not be empty");
+        }
         if (!WebhookResponseSchemaService.hasSchema(responseJsonSchema)) {
             return;
         }
@@ -557,6 +590,25 @@ public class WebhookController {
             return responseValidationModelTier;
         }
         return modelTier;
+    }
+
+    private String resolveWebhookMemoryPreset(String requestMemoryPreset, UserPreferences.WebhookConfig config) {
+        if (requestMemoryPreset != null && !requestMemoryPreset.isBlank()) {
+            return normalizeMemoryPreset(requestMemoryPreset, "'memoryPreset'");
+        }
+        String configuredPreset = config != null ? config.getMemoryPreset() : null;
+        return normalizeMemoryPreset(configuredPreset, "webhooks.memoryPreset");
+    }
+
+    private String normalizeMemoryPreset(String memoryPreset, String fieldName) {
+        if (memoryPreset == null || memoryPreset.isBlank()) {
+            return MemoryPresetIds.DISABLED;
+        }
+        String normalizedPreset = memoryPreset.trim().toLowerCase(Locale.ROOT);
+        if (memoryPresetService.findById(normalizedPreset).isEmpty()) {
+            throw new IllegalArgumentException(fieldName + " must be a known memory preset id");
+        }
+        return normalizedPreset;
     }
 
     private void putIfPresent(Map<String, Object> attributes, String key, String value) {

--- a/src/main/java/me/golemcore/bot/adapter/inbound/webhook/WebhookController.java
+++ b/src/main/java/me/golemcore/bot/adapter/inbound/webhook/WebhookController.java
@@ -23,14 +23,19 @@ import me.golemcore.bot.adapter.inbound.webhook.dto.AgentRequest;
 import me.golemcore.bot.adapter.inbound.webhook.dto.WakeRequest;
 import me.golemcore.bot.adapter.inbound.webhook.dto.WebhookResponse;
 import me.golemcore.bot.domain.loop.AgentLoop;
+import me.golemcore.bot.domain.model.AgentSession;
 import me.golemcore.bot.domain.model.ContextAttributes;
 import me.golemcore.bot.domain.model.Message;
 import me.golemcore.bot.domain.model.ModelTierCatalog;
 import me.golemcore.bot.domain.model.UserPreferences;
+import me.golemcore.bot.domain.model.trace.TraceContext;
 import me.golemcore.bot.domain.model.trace.TraceSpanKind;
+import me.golemcore.bot.domain.model.trace.TraceStatusCode;
 import me.golemcore.bot.domain.service.TraceContextSupport;
 import me.golemcore.bot.domain.service.TraceNamingSupport;
+import me.golemcore.bot.domain.service.TraceService;
 import me.golemcore.bot.domain.service.UserPreferencesService;
+import me.golemcore.bot.port.outbound.SessionPort;
 import me.golemcore.bot.security.InputSanitizer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -52,6 +57,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -99,6 +105,8 @@ public class WebhookController {
     private final WebhookDeliveryTracker deliveryTracker;
     private final WebhookResponseSchemaService responseSchemaService;
     private final ApplicationEventPublisher eventPublisher;
+    private final SessionPort sessionPort;
+    private final TraceService traceService;
     private final InputSanitizer inputSanitizer;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -209,7 +217,7 @@ public class WebhookController {
             metadata.put("webhook.runId", runId);
             metadata.put("webhook.timeoutSeconds", timeout);
             if (modelTier != null) {
-                metadata.put("webhook.modelTier", modelTier);
+                metadata.put(ContextAttributes.WEBHOOK_MODEL_TIER, modelTier);
             }
             addResponseContractMetadata(metadata, request.getResponseJsonSchema(), responseValidationModelTier);
             if (request.isDeliver()) {
@@ -252,7 +260,8 @@ public class WebhookController {
                         timeout,
                         request.getResponseJsonSchema(),
                         responseValidationModelTier,
-                        modelTier);
+                        modelTier,
+                        message);
             }
             return ResponseEntity.status(HttpStatus.ACCEPTED)
                     .body(WebhookResponse.accepted(runId, chatId));
@@ -342,7 +351,7 @@ public class WebhookController {
         metadata.put("webhook.mapping", mapping.getName());
         metadata.put("webhook.timeoutSeconds", config.getDefaultTimeoutSeconds());
         if (modelTier != null) {
-            metadata.put("webhook.modelTier", modelTier);
+            metadata.put(ContextAttributes.WEBHOOK_MODEL_TIER, modelTier);
         }
         addResponseContractMetadata(metadata, mapping.getResponseJsonSchema(), responseValidationModelTier);
         if (mapping.isDeliver()) {
@@ -367,7 +376,8 @@ public class WebhookController {
                     config.getDefaultTimeoutSeconds(),
                     mapping.getResponseJsonSchema(),
                     responseValidationModelTier,
-                    modelTier);
+                    modelTier,
+                    message);
         }
         return ResponseEntity.status(HttpStatus.ACCEPTED)
                 .body(WebhookResponse.accepted(runId, chatId));
@@ -398,20 +408,25 @@ public class WebhookController {
 
     private ResponseEntity<?> buildSynchronousResponse(CompletableFuture<String> responseFuture, String runId,
             String chatId, int timeoutSeconds, Map<String, Object> responseJsonSchema,
-            String responseValidationModelTier, String fallbackModelTier) {
+            String responseValidationModelTier, String fallbackModelTier, Message triggerMessage) {
         long startedNanos = System.nanoTime();
+        SchemaTraceSpan schemaTrace = null;
         try {
             String response = responseFuture.get(timeoutSeconds, TimeUnit.SECONDS);
             if (!WebhookResponseSchemaService.hasSchema(responseJsonSchema)) {
                 return ResponseEntity.ok(WebhookResponse.completed(runId, chatId, response, null));
             }
 
+            schemaTrace = startSchemaValidationTrace(
+                    triggerMessage, chatId, responseJsonSchema, responseValidationModelTier, fallbackModelTier);
             WebhookResponseSchemaService.SchemaResult result = responseSchemaService.validateAndRepair(
                     response,
                     responseJsonSchema,
                     responseValidationModelTier,
                     fallbackModelTier,
                     remainingBudget(timeoutSeconds, startedNanos));
+            finishSchemaValidationTrace(schemaTrace, TraceStatusCode.OK, null,
+                    Map.of("repair_attempts", result.repairAttempts()));
             return ResponseEntity.ok()
                     .header("X-Golemcore-Run-Id", runId)
                     .header("X-Golemcore-Chat-Id", chatId)
@@ -430,9 +445,13 @@ public class WebhookController {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                     .body(WebhookResponse.error("Synchronous webhook response failed: " + e.getMessage()));
         } catch (WebhookResponseSchemaService.SchemaTimeoutException e) {
+            finishSchemaValidationTrace(schemaTrace, TraceStatusCode.ERROR, e.getMessage(),
+                    Map.of("error_type", "timeout"));
             return ResponseEntity.status(HttpStatus.GATEWAY_TIMEOUT)
                     .body(WebhookResponse.error("Synchronous webhook response timed out"));
         } catch (WebhookResponseSchemaService.SchemaProcessingException e) {
+            finishSchemaValidationTrace(schemaTrace, TraceStatusCode.ERROR, e.getMessage(),
+                    Map.of("error_type", "schema_processing"));
             return ResponseEntity.status(HttpStatusCode.valueOf(422))
                     .body(WebhookResponse.error(e.getMessage()));
         }
@@ -446,6 +465,73 @@ public class WebhookController {
             throw new WebhookResponseSchemaService.SchemaTimeoutException("Synchronous webhook response timed out");
         }
         return remaining;
+    }
+
+    private SchemaTraceSpan startSchemaValidationTrace(Message triggerMessage, String chatId,
+            Map<String, Object> responseJsonSchema, String responseValidationModelTier, String fallbackModelTier) {
+        try {
+            TraceContext rootTrace = TraceContextSupport
+                    .readTraceContext(triggerMessage != null ? triggerMessage.getMetadata() : null);
+            if (rootTrace == null) {
+                return null;
+            }
+            AgentSession session = sessionPort.get(CHANNEL_TYPE + ":" + chatId).orElse(null);
+            if (session == null) {
+                return null;
+            }
+            Map<String, Object> attributes = new LinkedHashMap<>();
+            attributes.put("schema.present", true);
+            attributes.put("schema.top_level_keys", responseJsonSchema.size());
+            putIfPresent(attributes, "validation.model.tier",
+                    resolveEffectiveValidationTier(responseValidationModelTier, fallbackModelTier));
+            putIfPresent(attributes, "response.model.tier", fallbackModelTier);
+
+            TraceContext span = traceService.startSpan(session, rootTrace,
+                    "webhook.response.schema.validation", TraceSpanKind.INTERNAL, Instant.now(), attributes);
+            traceService.appendEvent(session, span, "schema.validation.started", Instant.now(), attributes);
+            return new SchemaTraceSpan(session, span);
+        } catch (RuntimeException e) {
+            log.debug("[Webhook] Failed to start schema validation trace: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    private void finishSchemaValidationTrace(SchemaTraceSpan schemaTrace, TraceStatusCode statusCode,
+            String statusMessage, Map<String, Object> attributes) {
+        if (schemaTrace == null) {
+            return;
+        }
+        try {
+            Map<String, Object> eventAttributes = new LinkedHashMap<>(attributes != null ? attributes : Map.of());
+            eventAttributes.put("success", TraceStatusCode.OK.equals(statusCode));
+            traceService.appendEvent(
+                    schemaTrace.session(),
+                    schemaTrace.span(),
+                    TraceStatusCode.OK.equals(statusCode) ? "schema.validation.finished" : "schema.validation.failed",
+                    Instant.now(),
+                    eventAttributes);
+            traceService.finishSpan(schemaTrace.session(), schemaTrace.span(), statusCode, statusMessage,
+                    Instant.now());
+            sessionPort.save(schemaTrace.session());
+        } catch (RuntimeException e) {
+            log.debug("[Webhook] Failed to finish schema validation trace: {}", e.getMessage());
+        }
+    }
+
+    private String resolveEffectiveValidationTier(String responseValidationModelTier, String fallbackModelTier) {
+        if (responseValidationModelTier != null && !responseValidationModelTier.isBlank()) {
+            return responseValidationModelTier;
+        }
+        if (fallbackModelTier != null && !fallbackModelTier.isBlank()) {
+            return fallbackModelTier;
+        }
+        return "balanced";
+    }
+
+    private void putIfPresent(Map<String, Object> attributes, String key, String value) {
+        if (value != null && !value.isBlank()) {
+            attributes.put(key, value);
+        }
     }
 
     private Message buildMessage(String chatId, String content, Map<String, Object> metadata, String traceName) {
@@ -523,5 +609,8 @@ public class WebhookController {
     private ResponseEntity<WebhookResponse> badRequest(String message) {
         return ResponseEntity.badRequest()
                 .body(WebhookResponse.error(message));
+    }
+
+    private record SchemaTraceSpan(AgentSession session, TraceContext span) {
     }
 }

--- a/src/main/java/me/golemcore/bot/adapter/inbound/webhook/WebhookController.java
+++ b/src/main/java/me/golemcore/bot/adapter/inbound/webhook/WebhookController.java
@@ -43,6 +43,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -197,8 +198,10 @@ public class WebhookController {
             String responseValidationModelTier;
             try {
                 modelTier = normalizeOptionalModelTier(request.getModel(), "'model'");
-                responseValidationModelTier = normalizeOptionalModelTier(
-                        request.getResponseValidationModelTier(), "'responseValidationModelTier'");
+                responseValidationModelTier = normalizeResponseValidationModelTier(
+                        request.getResponseJsonSchema(),
+                        request.getResponseValidationModelTier(),
+                        "'responseValidationModelTier'");
                 validateSynchronousResponseContract(
                         request.isSyncResponse(),
                         request.getResponseJsonSchema(),
@@ -338,7 +341,8 @@ public class WebhookController {
         String runId = UUID.randomUUID().toString();
         String chatId = "hook:" + mapping.getName() + ":" + UUID.randomUUID();
         String modelTier = normalizeOptionalModelTier(mapping.getModel(), "Webhook mapping model");
-        String responseValidationModelTier = normalizeOptionalModelTier(
+        String responseValidationModelTier = normalizeResponseValidationModelTier(
+                mapping.getResponseJsonSchema(),
                 mapping.getResponseValidationModelTier(),
                 "Webhook mapping responseValidationModelTier");
         validateSynchronousResponseContract(
@@ -385,11 +389,12 @@ public class WebhookController {
 
     private void addResponseContractMetadata(Map<String, Object> metadata, Map<String, Object> responseJsonSchema,
             String responseValidationModelTier) {
-        if (WebhookResponseSchemaService.hasSchema(responseJsonSchema)) {
-            metadata.put(ContextAttributes.WEBHOOK_RESPONSE_JSON_SCHEMA, responseJsonSchema);
-            metadata.put(ContextAttributes.WEBHOOK_RESPONSE_JSON_SCHEMA_TEXT,
-                    responseSchemaService.renderSchema(responseJsonSchema));
+        if (!WebhookResponseSchemaService.hasSchema(responseJsonSchema)) {
+            return;
         }
+        metadata.put(ContextAttributes.WEBHOOK_RESPONSE_JSON_SCHEMA, responseJsonSchema);
+        metadata.put(ContextAttributes.WEBHOOK_RESPONSE_JSON_SCHEMA_TEXT,
+                responseSchemaService.renderSchema(responseJsonSchema));
         if (responseValidationModelTier != null && !responseValidationModelTier.isBlank()) {
             metadata.put(ContextAttributes.WEBHOOK_RESPONSE_VALIDATION_MODEL_TIER, responseValidationModelTier);
         }
@@ -414,7 +419,7 @@ public class WebhookController {
         try {
             String response = responseFuture.get(timeoutSeconds, TimeUnit.SECONDS);
             if (!WebhookResponseSchemaService.hasSchema(responseJsonSchema)) {
-                return ResponseEntity.ok(WebhookResponse.completed(runId, chatId, response, null));
+                return buildPlainTextSynchronousResponse(runId, chatId, response);
             }
 
             schemaTrace = startSchemaValidationTrace(
@@ -465,6 +470,14 @@ public class WebhookController {
             throw new WebhookResponseSchemaService.SchemaTimeoutException("Synchronous webhook response timed out");
         }
         return remaining;
+    }
+
+    private ResponseEntity<String> buildPlainTextSynchronousResponse(String runId, String chatId, String response) {
+        return ResponseEntity.ok()
+                .contentType(MediaType.TEXT_PLAIN)
+                .header("X-Golemcore-Run-Id", runId)
+                .header("X-Golemcore-Chat-Id", chatId)
+                .body(response);
     }
 
     private SchemaTraceSpan startSchemaValidationTrace(Message triggerMessage, String chatId,
@@ -560,6 +573,14 @@ public class WebhookController {
             throw new IllegalArgumentException(fieldName + " must be a known tier id");
         }
         return normalizedTier;
+    }
+
+    private String normalizeResponseValidationModelTier(Map<String, Object> responseJsonSchema, String modelTier,
+            String fieldName) {
+        if (!WebhookResponseSchemaService.hasSchema(responseJsonSchema)) {
+            return null;
+        }
+        return normalizeOptionalModelTier(modelTier, fieldName);
     }
 
     private <T> T parseBody(byte[] body, Class<T> type) {

--- a/src/main/java/me/golemcore/bot/adapter/inbound/webhook/WebhookController.java
+++ b/src/main/java/me/golemcore/bot/adapter/inbound/webhook/WebhookController.java
@@ -196,12 +196,17 @@ public class WebhookController {
                     : config.getDefaultTimeoutSeconds();
             String modelTier;
             String responseValidationModelTier;
+            String effectiveModelTier;
             try {
                 modelTier = normalizeOptionalModelTier(request.getModel(), "'model'");
                 responseValidationModelTier = normalizeResponseValidationModelTier(
                         request.getResponseJsonSchema(),
                         request.getResponseValidationModelTier(),
                         "'responseValidationModelTier'");
+                effectiveModelTier = resolveEffectiveWebhookModelTier(
+                        modelTier,
+                        request.getResponseJsonSchema(),
+                        responseValidationModelTier);
                 validateSynchronousResponseContract(
                         request.isSyncResponse(),
                         request.getResponseJsonSchema(),
@@ -219,8 +224,8 @@ public class WebhookController {
                     request.getMetadata() != null ? request.getMetadata() : Map.of());
             metadata.put("webhook.runId", runId);
             metadata.put("webhook.timeoutSeconds", timeout);
-            if (modelTier != null) {
-                metadata.put(ContextAttributes.WEBHOOK_MODEL_TIER, modelTier);
+            if (effectiveModelTier != null) {
+                metadata.put(ContextAttributes.WEBHOOK_MODEL_TIER, effectiveModelTier);
             }
             addResponseContractMetadata(metadata, request.getResponseJsonSchema(), responseValidationModelTier);
             if (request.isDeliver()) {
@@ -240,14 +245,14 @@ public class WebhookController {
                         runId,
                         chatId,
                         request.getCallbackUrl(),
-                        modelTier);
+                        effectiveModelTier);
             }
 
             CompletableFuture<String> responseFuture = channelAdapter.registerPendingRun(
                     chatId,
                     runId,
                     request.getCallbackUrl(),
-                    modelTier,
+                    effectiveModelTier,
                     deliveryId);
 
             Message message = buildMessage(chatId, safeMessage, metadata, TraceNamingSupport.WEBHOOK_AGENT);
@@ -263,7 +268,7 @@ public class WebhookController {
                         timeout,
                         request.getResponseJsonSchema(),
                         responseValidationModelTier,
-                        modelTier,
+                        effectiveModelTier,
                         message);
             }
             return ResponseEntity.status(HttpStatus.ACCEPTED)
@@ -345,6 +350,10 @@ public class WebhookController {
                 mapping.getResponseJsonSchema(),
                 mapping.getResponseValidationModelTier(),
                 "Webhook mapping responseValidationModelTier");
+        String effectiveModelTier = resolveEffectiveWebhookModelTier(
+                modelTier,
+                mapping.getResponseJsonSchema(),
+                responseValidationModelTier);
         validateSynchronousResponseContract(
                 mapping.isSyncResponse(),
                 mapping.getResponseJsonSchema(),
@@ -354,8 +363,8 @@ public class WebhookController {
         metadata.put("webhook.runId", runId);
         metadata.put("webhook.mapping", mapping.getName());
         metadata.put("webhook.timeoutSeconds", config.getDefaultTimeoutSeconds());
-        if (modelTier != null) {
-            metadata.put(ContextAttributes.WEBHOOK_MODEL_TIER, modelTier);
+        if (effectiveModelTier != null) {
+            metadata.put(ContextAttributes.WEBHOOK_MODEL_TIER, effectiveModelTier);
         }
         addResponseContractMetadata(metadata, mapping.getResponseJsonSchema(), responseValidationModelTier);
         if (mapping.isDeliver()) {
@@ -364,8 +373,8 @@ public class WebhookController {
             metadata.put(ContextAttributes.WEBHOOK_DELIVER_TO, mapping.getTo());
         }
 
-        CompletableFuture<String> responseFuture = channelAdapter.registerPendingRun(chatId, runId, null, modelTier,
-                null);
+        CompletableFuture<String> responseFuture = channelAdapter.registerPendingRun(chatId, runId, null,
+                effectiveModelTier, null);
 
         Message message = buildMessage(chatId, text, metadata, TraceNamingSupport.WEBHOOK_AGENT);
         eventPublisher.publishEvent(new AgentLoop.InboundMessageEvent(message));
@@ -380,7 +389,7 @@ public class WebhookController {
                     config.getDefaultTimeoutSeconds(),
                     mapping.getResponseJsonSchema(),
                     responseValidationModelTier,
-                    modelTier,
+                    effectiveModelTier,
                     message);
         }
         return ResponseEntity.status(HttpStatus.ACCEPTED)
@@ -539,6 +548,15 @@ public class WebhookController {
             return fallbackModelTier;
         }
         return "balanced";
+    }
+
+    private String resolveEffectiveWebhookModelTier(String modelTier, Map<String, Object> responseJsonSchema,
+            String responseValidationModelTier) {
+        if (WebhookResponseSchemaService.hasSchema(responseJsonSchema)
+                && responseValidationModelTier != null && !responseValidationModelTier.isBlank()) {
+            return responseValidationModelTier;
+        }
+        return modelTier;
     }
 
     private void putIfPresent(Map<String, Object> attributes, String key, String value) {

--- a/src/main/java/me/golemcore/bot/adapter/inbound/webhook/WebhookController.java
+++ b/src/main/java/me/golemcore/bot/adapter/inbound/webhook/WebhookController.java
@@ -46,13 +46,20 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Inbound HTTP webhook controller (OpenClaw-style, WebFlux).
@@ -90,6 +97,7 @@ public class WebhookController {
     private final WebhookChannelAdapter channelAdapter;
     private final WebhookPayloadTransformer transformer;
     private final WebhookDeliveryTracker deliveryTracker;
+    private final WebhookResponseSchemaService responseSchemaService;
     private final ApplicationEventPublisher eventPublisher;
     private final InputSanitizer inputSanitizer;
     private final ObjectMapper objectMapper = new ObjectMapper();
@@ -134,7 +142,7 @@ public class WebhookController {
 
             log.info("[Webhook] Wake event accepted for chatId={}", chatId);
             return ResponseEntity.ok(WebhookResponse.accepted(chatId));
-        });
+        }).subscribeOn(Schedulers.boundedElastic());
     }
 
     // ==================== /agent ====================
@@ -145,7 +153,7 @@ public class WebhookController {
      * adapter.
      */
     @PostMapping("/agent")
-    public Mono<ResponseEntity<WebhookResponse>> agent(
+    public Mono<ResponseEntity<?>> agent(
             @RequestBody(required = false) byte[] body,
             @RequestHeader HttpHeaders headers) {
 
@@ -178,9 +186,18 @@ public class WebhookController {
                     ? request.getTimeoutSeconds()
                     : config.getDefaultTimeoutSeconds();
             String modelTier;
+            String responseValidationModelTier;
             try {
                 modelTier = normalizeOptionalModelTier(request.getModel(), "'model'");
+                responseValidationModelTier = normalizeOptionalModelTier(
+                        request.getResponseValidationModelTier(), "'responseValidationModelTier'");
+                validateSynchronousResponseContract(
+                        request.isSyncResponse(),
+                        request.getResponseJsonSchema(),
+                        "'responseJsonSchema'");
             } catch (IllegalArgumentException e) {
+                return badRequest(e.getMessage());
+            } catch (WebhookResponseSchemaService.SchemaProcessingException e) {
                 return badRequest(e.getMessage());
             }
 
@@ -194,6 +211,7 @@ public class WebhookController {
             if (modelTier != null) {
                 metadata.put("webhook.modelTier", modelTier);
             }
+            addResponseContractMetadata(metadata, request.getResponseJsonSchema(), responseValidationModelTier);
             if (request.isDeliver()) {
                 metadata.put(ContextAttributes.WEBHOOK_DELIVER, true);
                 metadata.put(ContextAttributes.WEBHOOK_DELIVER_CHANNEL, request.getChannel());
@@ -214,16 +232,31 @@ public class WebhookController {
                         modelTier);
             }
 
-            channelAdapter.registerPendingRun(chatId, runId, request.getCallbackUrl(), modelTier, deliveryId);
+            CompletableFuture<String> responseFuture = channelAdapter.registerPendingRun(
+                    chatId,
+                    runId,
+                    request.getCallbackUrl(),
+                    modelTier,
+                    deliveryId);
 
             Message message = buildMessage(chatId, safeMessage, metadata, TraceNamingSupport.WEBHOOK_AGENT);
             eventPublisher.publishEvent(new AgentLoop.InboundMessageEvent(message));
 
             log.info("[Webhook] Agent run accepted: runId={}, chatId={}, name={}",
                     runId, chatId, request.getName());
+            if (request.isSyncResponse()) {
+                return buildSynchronousResponse(
+                        responseFuture,
+                        runId,
+                        chatId,
+                        timeout,
+                        request.getResponseJsonSchema(),
+                        responseValidationModelTier,
+                        modelTier);
+            }
             return ResponseEntity.status(HttpStatus.ACCEPTED)
                     .body(WebhookResponse.accepted(runId, chatId));
-        });
+        }).subscribeOn(Schedulers.boundedElastic());
     }
 
     // ==================== /{name} (custom mapping) ====================
@@ -234,7 +267,7 @@ public class WebhookController {
      * or agent flow.
      */
     @PostMapping("/{name}")
-    public Mono<ResponseEntity<WebhookResponse>> customHook(
+    public Mono<ResponseEntity<?>> customHook(
             @PathVariable String name,
             @RequestBody(required = false) byte[] body,
             @RequestHeader HttpHeaders headers) {
@@ -268,13 +301,13 @@ public class WebhookController {
             if (ACTION_AGENT.equals(mapping.getAction())) {
                 try {
                     return dispatchAsAgent(mapping, safeText, config);
-                } catch (IllegalArgumentException e) {
+                } catch (IllegalArgumentException | WebhookResponseSchemaService.SchemaProcessingException e) {
                     return badRequest(e.getMessage());
                 }
             }
 
             return dispatchAsWake(mapping, safeText);
-        });
+        }).subscribeOn(Schedulers.boundedElastic());
     }
 
     // ==================== internal helpers ====================
@@ -290,12 +323,19 @@ public class WebhookController {
         return ResponseEntity.ok(WebhookResponse.accepted(chatId));
     }
 
-    private ResponseEntity<WebhookResponse> dispatchAsAgent(
+    private ResponseEntity<?> dispatchAsAgent(
             UserPreferences.HookMapping mapping, String text, UserPreferences.WebhookConfig config) {
 
         String runId = UUID.randomUUID().toString();
         String chatId = "hook:" + mapping.getName() + ":" + UUID.randomUUID();
         String modelTier = normalizeOptionalModelTier(mapping.getModel(), "Webhook mapping model");
+        String responseValidationModelTier = normalizeOptionalModelTier(
+                mapping.getResponseValidationModelTier(),
+                "Webhook mapping responseValidationModelTier");
+        validateSynchronousResponseContract(
+                mapping.isSyncResponse(),
+                mapping.getResponseJsonSchema(),
+                "Webhook mapping responseJsonSchema");
 
         Map<String, Object> metadata = new HashMap<>();
         metadata.put("webhook.runId", runId);
@@ -304,21 +344,108 @@ public class WebhookController {
         if (modelTier != null) {
             metadata.put("webhook.modelTier", modelTier);
         }
+        addResponseContractMetadata(metadata, mapping.getResponseJsonSchema(), responseValidationModelTier);
         if (mapping.isDeliver()) {
             metadata.put(ContextAttributes.WEBHOOK_DELIVER, true);
             metadata.put(ContextAttributes.WEBHOOK_DELIVER_CHANNEL, mapping.getChannel());
             metadata.put(ContextAttributes.WEBHOOK_DELIVER_TO, mapping.getTo());
         }
 
-        channelAdapter.registerPendingRun(chatId, runId, null, modelTier, null);
+        CompletableFuture<String> responseFuture = channelAdapter.registerPendingRun(chatId, runId, null, modelTier,
+                null);
 
         Message message = buildMessage(chatId, text, metadata, TraceNamingSupport.WEBHOOK_AGENT);
         eventPublisher.publishEvent(new AgentLoop.InboundMessageEvent(message));
 
         log.info("[Webhook] Custom agent accepted: mapping={}, runId={}, chatId={}",
                 mapping.getName(), runId, chatId);
+        if (mapping.isSyncResponse()) {
+            return buildSynchronousResponse(
+                    responseFuture,
+                    runId,
+                    chatId,
+                    config.getDefaultTimeoutSeconds(),
+                    mapping.getResponseJsonSchema(),
+                    responseValidationModelTier,
+                    modelTier);
+        }
         return ResponseEntity.status(HttpStatus.ACCEPTED)
                 .body(WebhookResponse.accepted(runId, chatId));
+    }
+
+    private void addResponseContractMetadata(Map<String, Object> metadata, Map<String, Object> responseJsonSchema,
+            String responseValidationModelTier) {
+        if (WebhookResponseSchemaService.hasSchema(responseJsonSchema)) {
+            metadata.put(ContextAttributes.WEBHOOK_RESPONSE_JSON_SCHEMA, responseJsonSchema);
+            metadata.put(ContextAttributes.WEBHOOK_RESPONSE_JSON_SCHEMA_TEXT,
+                    responseSchemaService.renderSchema(responseJsonSchema));
+        }
+        if (responseValidationModelTier != null && !responseValidationModelTier.isBlank()) {
+            metadata.put(ContextAttributes.WEBHOOK_RESPONSE_VALIDATION_MODEL_TIER, responseValidationModelTier);
+        }
+    }
+
+    private void validateSynchronousResponseContract(boolean syncResponse, Map<String, Object> responseJsonSchema,
+            String fieldName) {
+        if (!WebhookResponseSchemaService.hasSchema(responseJsonSchema)) {
+            return;
+        }
+        if (!syncResponse) {
+            throw new IllegalArgumentException(fieldName + " requires syncResponse=true");
+        }
+        responseSchemaService.validateSchemaDefinition(responseJsonSchema);
+    }
+
+    private ResponseEntity<?> buildSynchronousResponse(CompletableFuture<String> responseFuture, String runId,
+            String chatId, int timeoutSeconds, Map<String, Object> responseJsonSchema,
+            String responseValidationModelTier, String fallbackModelTier) {
+        long startedNanos = System.nanoTime();
+        try {
+            String response = responseFuture.get(timeoutSeconds, TimeUnit.SECONDS);
+            if (!WebhookResponseSchemaService.hasSchema(responseJsonSchema)) {
+                return ResponseEntity.ok(WebhookResponse.completed(runId, chatId, response, null));
+            }
+
+            WebhookResponseSchemaService.SchemaResult result = responseSchemaService.validateAndRepair(
+                    response,
+                    responseJsonSchema,
+                    responseValidationModelTier,
+                    fallbackModelTier,
+                    remainingBudget(timeoutSeconds, startedNanos));
+            return ResponseEntity.ok()
+                    .header("X-Golemcore-Run-Id", runId)
+                    .header("X-Golemcore-Chat-Id", chatId)
+                    .header("X-Golemcore-Schema-Repair-Attempts", String.valueOf(result.repairAttempts()))
+                    .body(result.payload());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            channelAdapter.cancelPendingRun(chatId);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(WebhookResponse.error("Synchronous webhook response was interrupted"));
+        } catch (TimeoutException e) {
+            channelAdapter.cancelPendingRun(chatId);
+            return ResponseEntity.status(HttpStatus.GATEWAY_TIMEOUT)
+                    .body(WebhookResponse.error("Synchronous webhook response timed out"));
+        } catch (CancellationException | ExecutionException e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(WebhookResponse.error("Synchronous webhook response failed: " + e.getMessage()));
+        } catch (WebhookResponseSchemaService.SchemaTimeoutException e) {
+            return ResponseEntity.status(HttpStatus.GATEWAY_TIMEOUT)
+                    .body(WebhookResponse.error("Synchronous webhook response timed out"));
+        } catch (WebhookResponseSchemaService.SchemaProcessingException e) {
+            return ResponseEntity.status(HttpStatusCode.valueOf(422))
+                    .body(WebhookResponse.error(e.getMessage()));
+        }
+    }
+
+    private Duration remainingBudget(int timeoutSeconds, long startedNanos) {
+        Duration timeout = Duration.ofSeconds(timeoutSeconds);
+        Duration elapsed = Duration.ofNanos(Math.max(0L, System.nanoTime() - startedNanos));
+        Duration remaining = timeout.minus(elapsed);
+        if (remaining.isNegative() || remaining.isZero()) {
+            throw new WebhookResponseSchemaService.SchemaTimeoutException("Synchronous webhook response timed out");
+        }
+        return remaining;
     }
 
     private Message buildMessage(String chatId, String content, Map<String, Object> metadata, String traceName) {

--- a/src/main/java/me/golemcore/bot/adapter/inbound/webhook/WebhookResponseSchemaService.java
+++ b/src/main/java/me/golemcore/bot/adapter/inbound/webhook/WebhookResponseSchemaService.java
@@ -1,0 +1,323 @@
+/*
+ * Copyright 2026 Aleksei Kuleshov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contact: alex@kuleshov.tech
+ */
+
+package me.golemcore.bot.adapter.inbound.webhook;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SchemaLocation;
+import com.networknt.schema.SpecVersion;
+import com.networknt.schema.ValidationMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import me.golemcore.bot.domain.model.LlmRequest;
+import me.golemcore.bot.domain.model.LlmResponse;
+import me.golemcore.bot.domain.model.Message;
+import me.golemcore.bot.domain.service.ModelSelectionService;
+import me.golemcore.bot.port.outbound.LlmPort;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class WebhookResponseSchemaService {
+
+    private static final int MAX_SCHEMA_REPAIR_ATTEMPTS = 3;
+    private static final int MAX_REPORTED_SCHEMA_ERRORS = 8;
+    private static final Duration REPAIR_TIMEOUT = Duration.ofSeconds(30);
+    private static final String DEFAULT_VALIDATION_TIER = "balanced";
+    private static final SchemaLocation DRAFT_7_META_SCHEMA = SchemaLocation
+            .of("https://json-schema.org/draft-07/schema");
+
+    private final ObjectMapper objectMapper;
+    private final ModelSelectionService modelSelectionService;
+    private final LlmPort llmPort;
+
+    private final JsonSchemaFactory schemaFactory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V7);
+    private final JsonSchema schemaDefinitionSchema = schemaFactory.getSchema(DRAFT_7_META_SCHEMA);
+
+    public static boolean hasSchema(Map<String, Object> schema) {
+        return schema != null && !schema.isEmpty();
+    }
+
+    public void validateSchemaDefinition(Map<String, Object> schema) {
+        if (hasSchema(schema)) {
+            buildSchema(schema);
+        }
+    }
+
+    public String renderSchema(Map<String, Object> schema) {
+        return writeJson(schema);
+    }
+
+    public SchemaResult validateAndRepair(String rawResponse, Map<String, Object> schema,
+            String validationModelTier, String fallbackModelTier) {
+        return validateAndRepair(rawResponse, schema, validationModelTier, fallbackModelTier,
+                REPAIR_TIMEOUT.multipliedBy(MAX_SCHEMA_REPAIR_ATTEMPTS));
+    }
+
+    public SchemaResult validateAndRepair(String rawResponse, Map<String, Object> schema,
+            String validationModelTier, String fallbackModelTier, Duration repairBudget) {
+        if (!hasSchema(schema)) {
+            return new SchemaResult(rawResponse, 0);
+        }
+
+        JsonSchema jsonSchema = buildSchema(schema);
+        String schemaText = writeJson(schema);
+        String candidate = rawResponse;
+        ValidationAttempt validation = validateCandidate(jsonSchema, candidate);
+        if (validation.valid()) {
+            return new SchemaResult(validation.payload(), 0);
+        }
+
+        String repairTier = resolveRepairTier(validationModelTier, fallbackModelTier);
+        long repairStartedNanos = System.nanoTime();
+        for (int attempt = 1; attempt <= MAX_SCHEMA_REPAIR_ATTEMPTS; attempt++) {
+            Duration attemptTimeout = nextRepairAttemptTimeout(repairBudget, repairStartedNanos);
+            candidate = repairCandidate(candidate, schemaText, validation.errors(), repairTier, attemptTimeout);
+            validation = validateCandidate(jsonSchema, candidate);
+            if (validation.valid()) {
+                return new SchemaResult(validation.payload(), attempt);
+            }
+            log.warn("[Webhook] Response schema repair attempt {} failed: {}", attempt, validation.errors());
+        }
+
+        throw new SchemaProcessingException(
+                "Synchronous webhook response did not match responseJsonSchema after "
+                        + MAX_SCHEMA_REPAIR_ATTEMPTS + " repair attempts: " + String.join("; ", validation.errors()));
+    }
+
+    private JsonSchema buildSchema(Map<String, Object> schema) {
+        JsonNode schemaNode = objectMapper.valueToTree(schema);
+        validateSchemaDefinition(schemaNode);
+        try {
+            return schemaFactory.getSchema(schemaNode);
+        } catch (RuntimeException e) {
+            throw new SchemaProcessingException("Invalid responseJsonSchema: " + e.getMessage(), e);
+        }
+    }
+
+    private void validateSchemaDefinition(JsonNode schemaNode) {
+        Set<ValidationMessage> validationMessages = schemaDefinitionSchema.validate(schemaNode);
+        if (!validationMessages.isEmpty()) {
+            List<String> errors = validationMessages.stream()
+                    .map(ValidationMessage::getMessage)
+                    .limit(MAX_REPORTED_SCHEMA_ERRORS)
+                    .toList();
+            throw new SchemaProcessingException("Invalid responseJsonSchema: " + String.join("; ", errors));
+        }
+    }
+
+    private ValidationAttempt validateCandidate(JsonSchema jsonSchema, String candidate) {
+        JsonNode payload = parseCandidate(candidate);
+        if (payload == null) {
+            return new ValidationAttempt(null, false, List.of("response is not valid JSON"));
+        }
+
+        Set<ValidationMessage> validationMessages = jsonSchema.validate(payload);
+        if (validationMessages.isEmpty()) {
+            return new ValidationAttempt(payload, true, List.of());
+        }
+
+        List<String> errors = validationMessages.stream()
+                .map(ValidationMessage::getMessage)
+                .limit(MAX_REPORTED_SCHEMA_ERRORS)
+                .toList();
+        return new ValidationAttempt(payload, false, errors);
+    }
+
+    private JsonNode parseCandidate(String candidate) {
+        String trimmed = candidate != null ? candidate.trim() : "";
+        if (trimmed.isBlank()) {
+            return null;
+        }
+        JsonNode parsed = tryParse(trimmed);
+        if (parsed != null) {
+            return parsed;
+        }
+        return tryParse(extractJsonPayload(trimmed));
+    }
+
+    private JsonNode tryParse(String candidate) {
+        if (candidate == null || candidate.isBlank()) {
+            return null;
+        }
+        try {
+            return objectMapper.readTree(candidate);
+        } catch (JsonProcessingException e) {
+            return null;
+        }
+    }
+
+    private String extractJsonPayload(String candidate) {
+        String unfenced = stripMarkdownFence(candidate);
+        int objectStart = unfenced.indexOf('{');
+        int arrayStart = unfenced.indexOf('[');
+        int start = resolvePayloadStart(objectStart, arrayStart);
+        if (start < 0) {
+            return unfenced;
+        }
+
+        char opening = unfenced.charAt(start);
+        char closing = opening == '{' ? '}' : ']';
+        int end = unfenced.lastIndexOf(closing);
+        if (end < start) {
+            return unfenced;
+        }
+        return unfenced.substring(start, end + 1);
+    }
+
+    private int resolvePayloadStart(int objectStart, int arrayStart) {
+        if (objectStart < 0) {
+            return arrayStart;
+        }
+        if (arrayStart < 0) {
+            return objectStart;
+        }
+        return Math.min(objectStart, arrayStart);
+    }
+
+    private String stripMarkdownFence(String candidate) {
+        String trimmed = candidate.trim();
+        if (!trimmed.startsWith("```")) {
+            return trimmed;
+        }
+        int firstLineBreak = trimmed.indexOf('\n');
+        int closingFence = trimmed.lastIndexOf("```");
+        if (firstLineBreak < 0 || closingFence <= firstLineBreak) {
+            return trimmed;
+        }
+        return trimmed.substring(firstLineBreak + 1, closingFence).trim();
+    }
+
+    private Duration nextRepairAttemptTimeout(Duration repairBudget, long repairStartedNanos) {
+        Duration effectiveBudget = repairBudget != null ? repairBudget : REPAIR_TIMEOUT;
+        Duration elapsed = Duration.ofNanos(Math.max(0L, System.nanoTime() - repairStartedNanos));
+        Duration remaining = effectiveBudget.minus(elapsed);
+        if (remaining.isNegative() || remaining.isZero()) {
+            throw new SchemaTimeoutException("Response schema repair timed out");
+        }
+        return remaining.compareTo(REPAIR_TIMEOUT) < 0 ? remaining : REPAIR_TIMEOUT;
+    }
+
+    private String repairCandidate(String candidate, String schemaText, List<String> errors, String repairTier,
+            Duration attemptTimeout) {
+        ModelSelectionService.ModelSelection selection = modelSelectionService.resolveForTier(repairTier);
+        LlmRequest request = LlmRequest.builder()
+                .model(selection.model())
+                .reasoningEffort(selection.reasoning())
+                .temperature(0.0)
+                .systemPrompt("""
+                        You convert assistant output into strict JSON.
+                        Return only JSON. Do not include markdown fences or commentary.
+                        The JSON must satisfy the provided JSON Schema exactly.
+                        """)
+                .messages(List.of(Message.builder()
+                        .role("user")
+                        .content(buildRepairPrompt(candidate, schemaText, errors))
+                        .timestamp(Instant.now())
+                        .build()))
+                .modelTier(repairTier)
+                .build();
+        try {
+            long timeoutMillis = Math.max(1L, attemptTimeout.toMillis());
+            LlmResponse response = llmPort.chat(request).get(timeoutMillis, TimeUnit.MILLISECONDS);
+            if (response == null || response.getContent() == null || response.getContent().isBlank()) {
+                throw new SchemaProcessingException("Response schema repair returned an empty response");
+            }
+            return response.getContent();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new SchemaProcessingException("Response schema repair was interrupted", e);
+        } catch (TimeoutException e) {
+            throw new SchemaTimeoutException("Response schema repair timed out", e);
+        } catch (ExecutionException e) {
+            throw new SchemaProcessingException("Response schema repair failed: " + e.getMessage(), e);
+        }
+    }
+
+    private String buildRepairPrompt(String candidate, String schemaText, List<String> errors) {
+        return ("JSON Schema:%n%s%n%n"
+                + "Validation errors:%n%s%n%n"
+                + "Assistant output to reformat:%n%s%n%n"
+                + "Return only corrected JSON.")
+                .formatted(schemaText, String.join(System.lineSeparator(), errors), candidate != null ? candidate : "");
+    }
+
+    private String resolveRepairTier(String validationModelTier, String fallbackModelTier) {
+        if (validationModelTier != null && !validationModelTier.isBlank()) {
+            return validationModelTier;
+        }
+        if (fallbackModelTier != null && !fallbackModelTier.isBlank()) {
+            return fallbackModelTier;
+        }
+        return DEFAULT_VALIDATION_TIER;
+    }
+
+    private String writeJson(Object value) {
+        try {
+            return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(value);
+        } catch (JsonProcessingException e) {
+            throw new SchemaProcessingException("Failed to render responseJsonSchema", e);
+        }
+    }
+
+    public record SchemaResult(Object payload, int repairAttempts) {
+    }
+
+    private record ValidationAttempt(JsonNode payload, boolean valid, List<String> errors) {
+    }
+
+    public static class SchemaProcessingException extends RuntimeException {
+
+        private static final long serialVersionUID = 1L;
+
+        public SchemaProcessingException(String message) {
+            super(message);
+        }
+
+        public SchemaProcessingException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+
+    public static final class SchemaTimeoutException extends SchemaProcessingException {
+
+        private static final long serialVersionUID = 1L;
+
+        public SchemaTimeoutException(String message) {
+            super(message);
+        }
+
+        public SchemaTimeoutException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+}

--- a/src/main/java/me/golemcore/bot/adapter/inbound/webhook/WebhookResponseSchemaService.java
+++ b/src/main/java/me/golemcore/bot/adapter/inbound/webhook/WebhookResponseSchemaService.java
@@ -53,15 +53,15 @@ public class WebhookResponseSchemaService {
     private static final int MAX_REPORTED_SCHEMA_ERRORS = 8;
     private static final Duration REPAIR_TIMEOUT = Duration.ofSeconds(30);
     private static final String DEFAULT_VALIDATION_TIER = "balanced";
-    private static final SchemaLocation DRAFT_7_META_SCHEMA = SchemaLocation
-            .of("https://json-schema.org/draft-07/schema");
+    private static final SchemaLocation DRAFT_2020_12_META_SCHEMA = SchemaLocation
+            .of("https://json-schema.org/draft/2020-12/schema");
 
     private final ObjectMapper objectMapper;
     private final ModelSelectionService modelSelectionService;
     private final LlmPort llmPort;
 
-    private final JsonSchemaFactory schemaFactory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V7);
-    private final JsonSchema schemaDefinitionSchema = schemaFactory.getSchema(DRAFT_7_META_SCHEMA);
+    private final JsonSchemaFactory schemaFactory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012);
+    private final JsonSchema schemaDefinitionSchema = schemaFactory.getSchema(DRAFT_2020_12_META_SCHEMA);
 
     public static boolean hasSchema(Map<String, Object> schema) {
         return schema != null && !schema.isEmpty();
@@ -94,7 +94,7 @@ public class WebhookResponseSchemaService {
         String candidate = rawResponse;
         ValidationAttempt validation = validateCandidate(jsonSchema, candidate);
         if (validation.valid()) {
-            return new SchemaResult(validation.payload(), 0);
+            return new SchemaResult(toSerializablePayload(validation.payload()), 0);
         }
 
         String repairTier = resolveRepairTier(validationModelTier, fallbackModelTier);
@@ -104,7 +104,7 @@ public class WebhookResponseSchemaService {
             candidate = repairCandidate(candidate, schemaText, validation.errors(), repairTier, attemptTimeout);
             validation = validateCandidate(jsonSchema, candidate);
             if (validation.valid()) {
-                return new SchemaResult(validation.payload(), attempt);
+                return new SchemaResult(toSerializablePayload(validation.payload()), attempt);
             }
             log.warn("[Webhook] Response schema repair attempt {} failed: {}", attempt, validation.errors());
         }
@@ -151,6 +151,14 @@ public class WebhookResponseSchemaService {
                 .limit(MAX_REPORTED_SCHEMA_ERRORS)
                 .toList();
         return new ValidationAttempt(payload, false, errors);
+    }
+
+    private Object toSerializablePayload(JsonNode payload) {
+        try {
+            return objectMapper.treeToValue(payload, Object.class);
+        } catch (JsonProcessingException e) {
+            throw new SchemaProcessingException("Failed to materialize responseJsonSchema payload", e);
+        }
     }
 
     private JsonNode parseCandidate(String candidate) {

--- a/src/main/java/me/golemcore/bot/adapter/inbound/webhook/WebhookResponseSchemaService.java
+++ b/src/main/java/me/golemcore/bot/adapter/inbound/webhook/WebhookResponseSchemaService.java
@@ -68,9 +68,13 @@ public class WebhookResponseSchemaService {
     }
 
     public void validateSchemaDefinition(Map<String, Object> schema) {
-        if (hasSchema(schema)) {
-            buildSchema(schema);
+        if (schema == null) {
+            return;
         }
+        if (schema.isEmpty()) {
+            throw new SchemaProcessingException("Invalid responseJsonSchema: schema must not be empty");
+        }
+        buildSchema(schema);
     }
 
     public String renderSchema(Map<String, Object> schema) {
@@ -85,6 +89,9 @@ public class WebhookResponseSchemaService {
 
     public SchemaResult validateAndRepair(String rawResponse, Map<String, Object> schema,
             String validationModelTier, String fallbackModelTier, Duration repairBudget) {
+        if (schema != null && schema.isEmpty()) {
+            throw new SchemaProcessingException("Invalid responseJsonSchema: schema must not be empty");
+        }
         if (!hasSchema(schema)) {
             return new SchemaResult(rawResponse, 0);
         }

--- a/src/main/java/me/golemcore/bot/adapter/inbound/webhook/dto/AgentRequest.java
+++ b/src/main/java/me/golemcore/bot/adapter/inbound/webhook/dto/AgentRequest.java
@@ -65,6 +65,16 @@ public class AgentRequest {
     /** URL to POST the agent response to when processing completes. */
     private String callbackUrl;
 
+    /** Wait for the agent response and return it in the HTTP response body. */
+    @Builder.Default
+    private boolean syncResponse = false;
+
+    /** Optional JSON Schema that the synchronous response must satisfy. */
+    private Map<String, Object> responseJsonSchema;
+
+    /** Optional explicit tier for response schema repair calls. */
+    private String responseValidationModelTier;
+
     /** Maximum execution time in seconds. */
     @Builder.Default
     private int timeoutSeconds = 300;

--- a/src/main/java/me/golemcore/bot/adapter/inbound/webhook/dto/AgentRequest.java
+++ b/src/main/java/me/golemcore/bot/adapter/inbound/webhook/dto/AgentRequest.java
@@ -75,6 +75,9 @@ public class AgentRequest {
     /** Optional explicit tier for schema-constrained responses and repair calls. */
     private String responseValidationModelTier;
 
+    /** Optional memory preset override for this webhook run. */
+    private String memoryPreset;
+
     /** Maximum execution time in seconds. */
     @Builder.Default
     private int timeoutSeconds = 300;

--- a/src/main/java/me/golemcore/bot/adapter/inbound/webhook/dto/AgentRequest.java
+++ b/src/main/java/me/golemcore/bot/adapter/inbound/webhook/dto/AgentRequest.java
@@ -72,7 +72,7 @@ public class AgentRequest {
     /** Optional JSON Schema that the synchronous response must satisfy. */
     private Map<String, Object> responseJsonSchema;
 
-    /** Optional explicit tier for response schema repair calls. */
+    /** Optional explicit tier for schema-constrained responses and repair calls. */
     private String responseValidationModelTier;
 
     /** Maximum execution time in seconds. */

--- a/src/main/java/me/golemcore/bot/adapter/inbound/webhook/dto/WebhookResponse.java
+++ b/src/main/java/me/golemcore/bot/adapter/inbound/webhook/dto/WebhookResponse.java
@@ -48,6 +48,12 @@ public class WebhookResponse {
     @JsonProperty("error")
     private String errorMessage;
 
+    /** Agent response text for synchronous runs without a custom JSON schema. */
+    private Object response;
+
+    /** Number of LLM repair attempts used to satisfy the configured JSON Schema. */
+    private Integer schemaValidationAttempts;
+
     public static WebhookResponse accepted(String chatId) {
         return WebhookResponse.builder()
                 .status("accepted")
@@ -60,6 +66,17 @@ public class WebhookResponse {
                 .status("accepted")
                 .runId(runId)
                 .chatId(chatId)
+                .build();
+    }
+
+    public static WebhookResponse completed(String runId, String chatId, Object response,
+            Integer schemaValidationAttempts) {
+        return WebhookResponse.builder()
+                .status("completed")
+                .runId(runId)
+                .chatId(chatId)
+                .response(response)
+                .schemaValidationAttempts(schemaValidationAttempts)
                 .build();
     }
 

--- a/src/main/java/me/golemcore/bot/adapter/outbound/schema/NetworkntResponseJsonSchemaValidatorAdapter.java
+++ b/src/main/java/me/golemcore/bot/adapter/outbound/schema/NetworkntResponseJsonSchemaValidatorAdapter.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 Aleksei Kuleshov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contact: alex@kuleshov.tech
+ */
+
+package me.golemcore.bot.adapter.outbound.schema;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SchemaLocation;
+import com.networknt.schema.SpecVersion;
+import com.networknt.schema.ValidationMessage;
+import lombok.RequiredArgsConstructor;
+import me.golemcore.bot.port.outbound.ResponseJsonSchemaValidatorPort;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+public class NetworkntResponseJsonSchemaValidatorAdapter implements ResponseJsonSchemaValidatorPort {
+
+    private static final int MAX_REPORTED_SCHEMA_ERRORS = 8;
+    private static final SchemaLocation DRAFT_2020_12_META_SCHEMA = SchemaLocation
+            .of("https://json-schema.org/draft/2020-12/schema");
+
+    private final ObjectMapper objectMapper;
+
+    private final JsonSchemaFactory schemaFactory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012);
+    private final JsonSchema schemaDefinitionSchema = schemaFactory.getSchema(DRAFT_2020_12_META_SCHEMA);
+
+    @Override
+    public void validateResponseJsonSchema(Map<String, Object> responseJsonSchema) {
+        if (responseJsonSchema == null || responseJsonSchema.isEmpty()) {
+            return;
+        }
+
+        JsonNode schemaNode = objectMapper.valueToTree(responseJsonSchema);
+        Set<ValidationMessage> validationMessages = schemaDefinitionSchema.validate(schemaNode);
+        if (!validationMessages.isEmpty()) {
+            List<String> errors = validationMessages.stream()
+                    .map(ValidationMessage::getMessage)
+                    .limit(MAX_REPORTED_SCHEMA_ERRORS)
+                    .toList();
+            throw new IllegalArgumentException("Invalid responseJsonSchema: " + String.join("; ", errors));
+        }
+
+        try {
+            schemaFactory.getSchema(schemaNode);
+        } catch (RuntimeException e) {
+            throw new IllegalArgumentException("Invalid responseJsonSchema: " + e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/me/golemcore/bot/adapter/outbound/schema/NetworkntResponseJsonSchemaValidatorAdapter.java
+++ b/src/main/java/me/golemcore/bot/adapter/outbound/schema/NetworkntResponseJsonSchemaValidatorAdapter.java
@@ -48,8 +48,11 @@ public class NetworkntResponseJsonSchemaValidatorAdapter implements ResponseJson
 
     @Override
     public void validateResponseJsonSchema(Map<String, Object> responseJsonSchema) {
-        if (responseJsonSchema == null || responseJsonSchema.isEmpty()) {
+        if (responseJsonSchema == null) {
             return;
+        }
+        if (responseJsonSchema.isEmpty()) {
+            throw new IllegalArgumentException("Invalid responseJsonSchema: schema must not be empty");
         }
 
         JsonNode schemaNode = objectMapper.valueToTree(responseJsonSchema);

--- a/src/main/java/me/golemcore/bot/application/command/ModelSelectionCommandService.java
+++ b/src/main/java/me/golemcore/bot/application/command/ModelSelectionCommandService.java
@@ -1,16 +1,21 @@
 package me.golemcore.bot.application.command;
 
 import lombok.RequiredArgsConstructor;
+import me.golemcore.bot.domain.model.AgentSession;
 import me.golemcore.bot.domain.model.ModelTierCatalog;
 import me.golemcore.bot.domain.model.UserPreferences;
 import me.golemcore.bot.domain.service.ModelSelectionService;
 import me.golemcore.bot.domain.service.RuntimeConfigService;
+import me.golemcore.bot.domain.service.SessionModelSettingsSupport;
+import me.golemcore.bot.domain.service.StringValueSupport;
 import me.golemcore.bot.domain.service.UserPreferencesService;
+import me.golemcore.bot.port.outbound.SessionPort;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 public class ModelSelectionCommandService {
@@ -21,12 +26,12 @@ public class ModelSelectionCommandService {
     private final UserPreferencesService preferencesService;
     private final ModelSelectionService modelSelectionService;
     private final RuntimeConfigService runtimeConfigService;
+    private final SessionPort sessionPort;
 
     public TierOutcome handleTier(TierRequest request) {
-        if (request instanceof ShowTierStatus) {
-            UserPreferences preferences = preferencesService.getPreferences();
-            String tier = preferences.getModelTier() != null ? preferences.getModelTier() : "balanced";
-            return new CurrentTier(tier, preferences.isTierForce());
+        if (request instanceof ShowTierStatus showTierStatus) {
+            TierSettings tierSettings = resolveTierSettings(showTierStatus.sessionId());
+            return new CurrentTier(tierSettings.tier(), tierSettings.force());
         }
 
         if (!(request instanceof SetTierSelection setTier)) {
@@ -37,11 +42,17 @@ public class ModelSelectionCommandService {
             return new InvalidTier();
         }
 
-        UserPreferences preferences = preferencesService.getPreferences();
         boolean force = setTier.force();
-        preferences.setModelTier(tierArg);
-        preferences.setTierForce(force);
-        preferencesService.savePreferences(preferences);
+        Optional<AgentSession> session = resolveSession(setTier.sessionId());
+        if (session.isPresent()) {
+            SessionModelSettingsSupport.writeModelSettings(session.get(), tierArg, force);
+            sessionPort.save(session.get());
+        } else {
+            UserPreferences preferences = preferencesService.getPreferences();
+            preferences.setModelTier(tierArg);
+            preferences.setTierForce(force);
+            preferencesService.savePreferences(preferences);
+        }
         return new TierUpdated(tierArg, force);
     }
 
@@ -181,6 +192,41 @@ public class ModelSelectionCommandService {
         return preferences.getTierOverrides();
     }
 
+    private TierSettings resolveTierSettings(String sessionId) {
+        Optional<AgentSession> session = resolveSession(sessionId);
+        if (session.isPresent() && SessionModelSettingsSupport.hasModelSettings(session.get())) {
+            String tier = SessionModelSettingsSupport.readModelTier(session.get());
+            return new TierSettings(tier != null ? tier : "balanced",
+                    SessionModelSettingsSupport.readForce(session.get()));
+        }
+
+        UserPreferences preferences = preferencesService.getPreferences();
+        String tier = preferences.getModelTier() != null ? preferences.getModelTier() : "balanced";
+        return new TierSettings(tier, preferences.isTierForce());
+    }
+
+    private Optional<AgentSession> resolveSession(String sessionId) {
+        if (sessionPort == null || StringValueSupport.isBlank(sessionId)) {
+            return Optional.empty();
+        }
+
+        Optional<AgentSession> existing = sessionPort.get(sessionId);
+        if (existing != null && existing.isPresent()) {
+            return existing;
+        }
+
+        int separatorIndex = sessionId.indexOf(':');
+        if (separatorIndex <= 0 || separatorIndex + 1 >= sessionId.length()) {
+            return Optional.empty();
+        }
+        String channelType = sessionId.substring(0, separatorIndex);
+        String chatId = sessionId.substring(separatorIndex + 1);
+        return Optional.ofNullable(sessionPort.getOrCreate(channelType, chatId));
+    }
+
+    private record TierSettings(String tier, boolean force) {
+    }
+
     public sealed
 
     interface TierRequest
@@ -188,16 +234,26 @@ public class ModelSelectionCommandService {
     {
         }
 
-    public record ShowTierStatus() implements TierRequest {}
+    public record ShowTierStatus(String sessionId) implements TierRequest {
 
-    public record SetTierSelection(String tier, boolean force) implements TierRequest {}
+        public ShowTierStatus() {
+            this(null);
+        }
+    }
 
-    public sealed
+    public record SetTierSelection(String tier, boolean force, String sessionId) implements TierRequest {
 
-        interface TierOutcome
-        permits CurrentTier, TierUpdated, InvalidTier
-        {
-            }
+    public SetTierSelection(String tier, boolean force) {
+            this(tier, force, null);
+        }
+}
+
+public sealed
+
+interface TierOutcome
+permits CurrentTier, TierUpdated, InvalidTier
+{
+    }
 
     public record CurrentTier(String tier, boolean force) implements TierOutcome {}
 
@@ -207,10 +263,10 @@ public class ModelSelectionCommandService {
 
     public sealed
 
-            interface ModelRequest
-            permits ShowModelSelection, ListAvailableModels, SetModelOverride, SetReasoningLevel, ResetModelOverride
-            {
-                }
+    interface ModelRequest
+    permits ShowModelSelection, ListAvailableModels, SetModelOverride, SetReasoningLevel, ResetModelOverride
+    {
+        }
 
     public record ShowModelSelection() implements ModelRequest {}
 
@@ -224,12 +280,12 @@ public class ModelSelectionCommandService {
 
     public sealed
 
-                interface ModelOutcome
-            permits ModelSelectionOverview, AvailableModels, InvalidModelTier, ModelOverrideSet,
+        interface ModelOutcome
+        permits ModelSelectionOverview, AvailableModels, InvalidModelTier, ModelOverrideSet,
             ProviderNotConfigured, InvalidModel, MissingModelOverride, MissingReasoningSupport,
             InvalidReasoningLevel, ModelReasoningSet, ModelOverrideReset
-                {
-                    }
+        {
+    }
 
     public record ModelSelectionOverview(List<TierSelection> tiers) implements ModelOutcome {}
 

--- a/src/main/java/me/golemcore/bot/application/command/ModelSelectionCommandService.java
+++ b/src/main/java/me/golemcore/bot/application/command/ModelSelectionCommandService.java
@@ -211,7 +211,7 @@ public class ModelSelectionCommandService {
         }
 
         Optional<AgentSession> existing = sessionPort.get(sessionId);
-        if (existing != null && existing.isPresent()) {
+        if (existing.isPresent()) {
             return existing;
         }
 

--- a/src/main/java/me/golemcore/bot/application/settings/RuntimeSettingsValidator.java
+++ b/src/main/java/me/golemcore/bot/application/settings/RuntimeSettingsValidator.java
@@ -462,7 +462,17 @@ public class RuntimeSettingsValidator {
                 continue;
             }
             mapping.setModel(normalizeOptionalSelectableTier(mapping.getModel(), "webhooks.mapping.model"));
+            mapping.setResponseValidationModelTier(normalizeOptionalSelectableTier(
+                    mapping.getResponseValidationModelTier(),
+                    "webhooks.mapping.responseValidationModelTier"));
+            if (hasResponseJsonSchema(mapping.getResponseJsonSchema()) && !mapping.isSyncResponse()) {
+                throw new IllegalArgumentException("webhooks.mapping.responseJsonSchema requires syncResponse=true");
+            }
         }
+    }
+
+    private boolean hasResponseJsonSchema(Map<String, Object> responseJsonSchema) {
+        return responseJsonSchema != null && !responseJsonSchema.isEmpty();
     }
 
     public RuntimeConfig.ToolsConfig ensureToolsConfig(RuntimeConfig config) {

--- a/src/main/java/me/golemcore/bot/application/settings/RuntimeSettingsValidator.java
+++ b/src/main/java/me/golemcore/bot/application/settings/RuntimeSettingsValidator.java
@@ -1,8 +1,10 @@
 package me.golemcore.bot.application.settings;
 
+import me.golemcore.bot.domain.model.MemoryPresetIds;
 import me.golemcore.bot.domain.model.ModelTierCatalog;
 import me.golemcore.bot.domain.model.RuntimeConfig;
 import me.golemcore.bot.domain.model.UserPreferences;
+import me.golemcore.bot.domain.service.MemoryPresetService;
 import me.golemcore.bot.domain.service.ModelSelectionService;
 import me.golemcore.bot.port.outbound.ResponseJsonSchemaValidatorPort;
 import me.golemcore.bot.port.outbound.VoiceProviderCatalogPort;
@@ -71,18 +73,29 @@ public class RuntimeSettingsValidator {
     };
 
     private final ModelSelectionService modelSelectionService;
+    private final MemoryPresetService memoryPresetService;
     private final VoiceProviderCatalogPort voiceProviderCatalogPort;
     private final ResponseJsonSchemaValidatorPort responseJsonSchemaValidatorPort;
 
     public RuntimeSettingsValidator(ModelSelectionService modelSelectionService,
             VoiceProviderCatalogPort voiceProviderCatalogPort) {
-        this(modelSelectionService, voiceProviderCatalogPort, NOOP_RESPONSE_JSON_SCHEMA_VALIDATOR);
+        this(modelSelectionService, voiceProviderCatalogPort, NOOP_RESPONSE_JSON_SCHEMA_VALIDATOR,
+                new MemoryPresetService());
     }
 
     public RuntimeSettingsValidator(ModelSelectionService modelSelectionService,
             VoiceProviderCatalogPort voiceProviderCatalogPort,
             ResponseJsonSchemaValidatorPort responseJsonSchemaValidatorPort) {
+        this(modelSelectionService, voiceProviderCatalogPort, responseJsonSchemaValidatorPort,
+                new MemoryPresetService());
+    }
+
+    public RuntimeSettingsValidator(ModelSelectionService modelSelectionService,
+            VoiceProviderCatalogPort voiceProviderCatalogPort,
+            ResponseJsonSchemaValidatorPort responseJsonSchemaValidatorPort,
+            MemoryPresetService memoryPresetService) {
         this.modelSelectionService = modelSelectionService;
+        this.memoryPresetService = memoryPresetService != null ? memoryPresetService : new MemoryPresetService();
         this.voiceProviderCatalogPort = voiceProviderCatalogPort;
         this.responseJsonSchemaValidatorPort = responseJsonSchemaValidatorPort != null
                 ? responseJsonSchemaValidatorPort
@@ -467,7 +480,13 @@ public class RuntimeSettingsValidator {
     }
 
     public void validateWebhookConfig(UserPreferences.WebhookConfig webhookConfig) {
-        if (webhookConfig == null || webhookConfig.getMappings() == null) {
+        if (webhookConfig == null) {
+            return;
+        }
+        webhookConfig.setMemoryPreset(normalizeMemoryPreset(
+                webhookConfig.getMemoryPreset(),
+                "webhooks.memoryPreset"));
+        if (webhookConfig.getMappings() == null) {
             return;
         }
         for (UserPreferences.HookMapping mapping : webhookConfig.getMappings()) {
@@ -475,6 +494,9 @@ public class RuntimeSettingsValidator {
                 continue;
             }
             mapping.setModel(normalizeOptionalSelectableTier(mapping.getModel(), "webhooks.mapping.model"));
+            if (mapping.getResponseJsonSchema() != null && mapping.getResponseJsonSchema().isEmpty()) {
+                throw new IllegalArgumentException("webhooks.mapping.responseJsonSchema must not be empty");
+            }
             if (!hasResponseJsonSchema(mapping.getResponseJsonSchema())) {
                 mapping.setResponseValidationModelTier(null);
                 continue;
@@ -491,6 +513,17 @@ public class RuntimeSettingsValidator {
 
     private boolean hasResponseJsonSchema(Map<String, Object> responseJsonSchema) {
         return responseJsonSchema != null && !responseJsonSchema.isEmpty();
+    }
+
+    private String normalizeMemoryPreset(String memoryPreset, String fieldName) {
+        if (memoryPreset == null || memoryPreset.isBlank()) {
+            return MemoryPresetIds.DISABLED;
+        }
+        String normalizedPreset = memoryPreset.trim().toLowerCase(Locale.ROOT);
+        if (memoryPresetService.findById(normalizedPreset).isEmpty()) {
+            throw new IllegalArgumentException(fieldName + " must be a known memory preset id");
+        }
+        return normalizedPreset;
     }
 
     public RuntimeConfig.ToolsConfig ensureToolsConfig(RuntimeConfig config) {

--- a/src/main/java/me/golemcore/bot/application/settings/RuntimeSettingsValidator.java
+++ b/src/main/java/me/golemcore/bot/application/settings/RuntimeSettingsValidator.java
@@ -4,6 +4,7 @@ import me.golemcore.bot.domain.model.ModelTierCatalog;
 import me.golemcore.bot.domain.model.RuntimeConfig;
 import me.golemcore.bot.domain.model.UserPreferences;
 import me.golemcore.bot.domain.service.ModelSelectionService;
+import me.golemcore.bot.port.outbound.ResponseJsonSchemaValidatorPort;
 import me.golemcore.bot.port.outbound.VoiceProviderCatalogPort;
 
 import java.net.URI;
@@ -66,14 +67,26 @@ public class RuntimeSettingsValidator {
     private static final int LOCAL_EMBEDDING_RESTART_BACKOFF_MS_MIN = 1;
     private static final int LOCAL_EMBEDDING_RESTART_BACKOFF_MS_MAX = 60000;
     private static final Pattern SEMVER_PATTERN = Pattern.compile("v?\\d+(?:\\.\\d+){0,2}");
+    private static final ResponseJsonSchemaValidatorPort NOOP_RESPONSE_JSON_SCHEMA_VALIDATOR = schema -> {
+    };
 
     private final ModelSelectionService modelSelectionService;
     private final VoiceProviderCatalogPort voiceProviderCatalogPort;
+    private final ResponseJsonSchemaValidatorPort responseJsonSchemaValidatorPort;
 
     public RuntimeSettingsValidator(ModelSelectionService modelSelectionService,
             VoiceProviderCatalogPort voiceProviderCatalogPort) {
+        this(modelSelectionService, voiceProviderCatalogPort, NOOP_RESPONSE_JSON_SCHEMA_VALIDATOR);
+    }
+
+    public RuntimeSettingsValidator(ModelSelectionService modelSelectionService,
+            VoiceProviderCatalogPort voiceProviderCatalogPort,
+            ResponseJsonSchemaValidatorPort responseJsonSchemaValidatorPort) {
         this.modelSelectionService = modelSelectionService;
         this.voiceProviderCatalogPort = voiceProviderCatalogPort;
+        this.responseJsonSchemaValidatorPort = responseJsonSchemaValidatorPort != null
+                ? responseJsonSchemaValidatorPort
+                : NOOP_RESPONSE_JSON_SCHEMA_VALIDATOR;
     }
 
     public void validateRuntimeConfigUpdate(RuntimeConfig current, RuntimeConfig merged,
@@ -462,12 +475,17 @@ public class RuntimeSettingsValidator {
                 continue;
             }
             mapping.setModel(normalizeOptionalSelectableTier(mapping.getModel(), "webhooks.mapping.model"));
+            if (!hasResponseJsonSchema(mapping.getResponseJsonSchema())) {
+                mapping.setResponseValidationModelTier(null);
+                continue;
+            }
+            if (!mapping.isSyncResponse()) {
+                throw new IllegalArgumentException("webhooks.mapping.responseJsonSchema requires syncResponse=true");
+            }
+            responseJsonSchemaValidatorPort.validateResponseJsonSchema(mapping.getResponseJsonSchema());
             mapping.setResponseValidationModelTier(normalizeOptionalSelectableTier(
                     mapping.getResponseValidationModelTier(),
                     "webhooks.mapping.responseValidationModelTier"));
-            if (hasResponseJsonSchema(mapping.getResponseJsonSchema()) && !mapping.isSyncResponse()) {
-                throw new IllegalArgumentException("webhooks.mapping.responseJsonSchema requires syncResponse=true");
-            }
         }
     }
 

--- a/src/main/java/me/golemcore/bot/domain/context/layer/MemoryLayer.java
+++ b/src/main/java/me/golemcore/bot/domain/context/layer/MemoryLayer.java
@@ -26,8 +26,12 @@ import me.golemcore.bot.domain.context.ContextLayerResult;
 import me.golemcore.bot.domain.model.AgentContext;
 import me.golemcore.bot.domain.model.ContextAttributes;
 import me.golemcore.bot.domain.model.MemoryPack;
+import me.golemcore.bot.domain.model.MemoryPreset;
+import me.golemcore.bot.domain.model.MemoryPresetIds;
 import me.golemcore.bot.domain.model.MemoryQuery;
 import me.golemcore.bot.domain.model.Message;
+import me.golemcore.bot.domain.model.RuntimeConfig;
+import me.golemcore.bot.domain.service.MemoryPresetService;
 import me.golemcore.bot.domain.service.MemoryScopeSupport;
 import me.golemcore.bot.domain.service.RuntimeConfigService;
 
@@ -49,6 +53,7 @@ public class MemoryLayer implements ContextLayer {
 
     private final MemoryComponent memoryComponent;
     private final RuntimeConfigService runtimeConfigService;
+    private final MemoryPresetService memoryPresetService;
 
     @Override
     public String getName() {
@@ -62,11 +67,17 @@ public class MemoryLayer implements ContextLayer {
 
     @Override
     public boolean appliesTo(AgentContext context) {
-        return true;
+        return !isMemoryDisabled(context);
     }
 
     @Override
     public ContextLayerResult assemble(AgentContext context) {
+        if (isMemoryDisabled(context)) {
+            context.setMemoryContext("");
+            return ContextLayerResult.empty(getName());
+        }
+        RuntimeConfig.MemoryConfig memoryConfig = resolveMemoryPresetConfig(context);
+
         String userQuery = getLastUserMessageText(context);
         String sessionScope = MemoryScopeSupport.resolveScopeFromSessionOrGlobal(
                 context.getSession());
@@ -84,12 +95,12 @@ public class MemoryLayer implements ContextLayer {
                         : null)
                 .scope(sessionScope)
                 .scopeChain(scopeChain)
-                .softPromptBudgetTokens(runtimeConfigService.getMemorySoftPromptBudgetTokens())
-                .maxPromptBudgetTokens(runtimeConfigService.getMemoryMaxPromptBudgetTokens())
-                .workingTopK(runtimeConfigService.getMemoryWorkingTopK())
-                .episodicTopK(runtimeConfigService.getMemoryEpisodicTopK())
-                .semanticTopK(runtimeConfigService.getMemorySemanticTopK())
-                .proceduralTopK(runtimeConfigService.getMemoryProceduralTopK())
+                .softPromptBudgetTokens(resolveSoftPromptBudget(memoryConfig))
+                .maxPromptBudgetTokens(resolveMaxPromptBudget(memoryConfig))
+                .workingTopK(resolveWorkingTopK(memoryConfig))
+                .episodicTopK(resolveEpisodicTopK(memoryConfig))
+                .semanticTopK(resolveSemanticTopK(memoryConfig))
+                .proceduralTopK(resolveProceduralTopK(memoryConfig))
                 .build();
 
         String memoryContext = "";
@@ -131,5 +142,66 @@ public class MemoryLayer implements ContextLayer {
             }
         }
         return null;
+    }
+
+    private boolean isMemoryDisabled(AgentContext context) {
+        RuntimeConfig.MemoryConfig memoryConfig = resolveMemoryPresetConfig(context);
+        if (memoryConfig != null) {
+            return Boolean.FALSE.equals(memoryConfig.getEnabled());
+        }
+        String memoryPreset = context != null ? context.getAttribute(ContextAttributes.MEMORY_PRESET_ID) : null;
+        return memoryPreset != null && MemoryPresetIds.DISABLED.equalsIgnoreCase(memoryPreset.trim());
+    }
+
+    private RuntimeConfig.MemoryConfig resolveMemoryPresetConfig(AgentContext context) {
+        String memoryPreset = context != null ? context.getAttribute(ContextAttributes.MEMORY_PRESET_ID) : null;
+        if (memoryPreset == null || memoryPreset.isBlank()) {
+            return null;
+        }
+        return memoryPresetService.findById(memoryPreset)
+                .map(MemoryPreset::getMemory)
+                .orElse(null);
+    }
+
+    private int resolveSoftPromptBudget(RuntimeConfig.MemoryConfig memoryConfig) {
+        if (memoryConfig != null && memoryConfig.getSoftPromptBudgetTokens() != null) {
+            return memoryConfig.getSoftPromptBudgetTokens();
+        }
+        return runtimeConfigService.getMemorySoftPromptBudgetTokens();
+    }
+
+    private int resolveMaxPromptBudget(RuntimeConfig.MemoryConfig memoryConfig) {
+        if (memoryConfig != null && memoryConfig.getMaxPromptBudgetTokens() != null) {
+            return memoryConfig.getMaxPromptBudgetTokens();
+        }
+        return runtimeConfigService.getMemoryMaxPromptBudgetTokens();
+    }
+
+    private int resolveWorkingTopK(RuntimeConfig.MemoryConfig memoryConfig) {
+        if (memoryConfig != null && memoryConfig.getWorkingTopK() != null) {
+            return memoryConfig.getWorkingTopK();
+        }
+        return runtimeConfigService.getMemoryWorkingTopK();
+    }
+
+    private int resolveEpisodicTopK(RuntimeConfig.MemoryConfig memoryConfig) {
+        if (memoryConfig != null && memoryConfig.getEpisodicTopK() != null) {
+            return memoryConfig.getEpisodicTopK();
+        }
+        return runtimeConfigService.getMemoryEpisodicTopK();
+    }
+
+    private int resolveSemanticTopK(RuntimeConfig.MemoryConfig memoryConfig) {
+        if (memoryConfig != null && memoryConfig.getSemanticTopK() != null) {
+            return memoryConfig.getSemanticTopK();
+        }
+        return runtimeConfigService.getMemorySemanticTopK();
+    }
+
+    private int resolveProceduralTopK(RuntimeConfig.MemoryConfig memoryConfig) {
+        if (memoryConfig != null && memoryConfig.getProceduralTopK() != null) {
+            return memoryConfig.getProceduralTopK();
+        }
+        return runtimeConfigService.getMemoryProceduralTopK();
     }
 }

--- a/src/main/java/me/golemcore/bot/domain/context/layer/TierAwarenessLayer.java
+++ b/src/main/java/me/golemcore/bot/domain/context/layer/TierAwarenessLayer.java
@@ -23,6 +23,7 @@ import lombok.extern.slf4j.Slf4j;
 import me.golemcore.bot.domain.context.ContextLayer;
 import me.golemcore.bot.domain.context.ContextLayerResult;
 import me.golemcore.bot.domain.model.AgentContext;
+import me.golemcore.bot.domain.service.SessionModelSettingsSupport;
 import me.golemcore.bot.domain.service.UserPreferencesService;
 
 /**
@@ -51,6 +52,15 @@ public class TierAwarenessLayer implements ContextLayer {
 
     @Override
     public boolean appliesTo(AgentContext context) {
+        if (context == null) {
+            return false;
+        }
+        if (context.getSession() != null
+                && SessionModelSettingsSupport.hasModelSettings(context.getSession())) {
+            return !SessionModelSettingsSupport.readForce(context.getSession())
+                    && context.getActiveSkill() != null
+                    && context.getActiveSkill().getModelTier() != null;
+        }
         if (userPreferencesService.getPreferences().isTierForce()) {
             return false;
         }

--- a/src/main/java/me/golemcore/bot/domain/context/layer/ToolLayer.java
+++ b/src/main/java/me/golemcore/bot/domain/context/layer/ToolLayer.java
@@ -25,6 +25,7 @@ import me.golemcore.bot.domain.context.ContextLayer;
 import me.golemcore.bot.domain.context.ContextLayerResult;
 import me.golemcore.bot.domain.model.AgentContext;
 import me.golemcore.bot.domain.model.ContextAttributes;
+import me.golemcore.bot.domain.model.MemoryPresetIds;
 import me.golemcore.bot.domain.model.SessionIdentity;
 import me.golemcore.bot.domain.model.ToolDefinition;
 import me.golemcore.bot.domain.model.ToolNames;
@@ -157,10 +158,18 @@ public class ToolLayer implements ContextLayer {
                     : null;
             return delayedActionPolicyService.canScheduleActions(channelType);
         }
+        if (ToolNames.MEMORY.equals(toolName) && isMemoryPresetDisabled(context)) {
+            return false;
+        }
         if (isHiveSdlcTool(toolName)) {
             return hiveSessionActive;
         }
         return true;
+    }
+
+    private boolean isMemoryPresetDisabled(AgentContext context) {
+        String memoryPreset = context != null ? context.getAttribute(ContextAttributes.MEMORY_PRESET_ID) : null;
+        return memoryPreset != null && MemoryPresetIds.DISABLED.equalsIgnoreCase(memoryPreset.trim());
     }
 
     private boolean isHiveSdlcTool(String toolName) {

--- a/src/main/java/me/golemcore/bot/domain/context/layer/WebhookResponseSchemaLayer.java
+++ b/src/main/java/me/golemcore/bot/domain/context/layer/WebhookResponseSchemaLayer.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 Aleksei Kuleshov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contact: alex@kuleshov.tech
+ */
+
+package me.golemcore.bot.domain.context.layer;
+
+import me.golemcore.bot.domain.context.ContextLayer;
+import me.golemcore.bot.domain.context.ContextLayerResult;
+import me.golemcore.bot.domain.model.AgentContext;
+import me.golemcore.bot.domain.model.ContextAttributes;
+import me.golemcore.bot.domain.model.Message;
+
+public class WebhookResponseSchemaLayer implements ContextLayer {
+
+    @Override
+    public String getName() {
+        return "webhook_response_schema";
+    }
+
+    @Override
+    public int getOrder() {
+        return 76;
+    }
+
+    @Override
+    public boolean appliesTo(AgentContext context) {
+        return readSchemaText(context) != null;
+    }
+
+    @Override
+    public ContextLayerResult assemble(AgentContext context) {
+        String schemaText = readSchemaText(context);
+        if (schemaText == null) {
+            return ContextLayerResult.empty(getName());
+        }
+
+        String content = ("# Webhook Response JSON Contract%n"
+                + "The caller requires the final response to be valid JSON matching this JSON Schema.%n"
+                + "Return only the JSON payload. Do not include markdown fences, prose, or fields not allowed by the schema.%n%n"
+                + "```json%n%s%n```")
+                .formatted(schemaText);
+
+        return ContextLayerResult.builder()
+                .layerName(getName())
+                .content(content)
+                .estimatedTokens((int) Math.ceil(content.length() / 3.5))
+                .build();
+    }
+
+    private String readSchemaText(AgentContext context) {
+        if (context == null || context.getMessages() == null || context.getMessages().isEmpty()) {
+            return null;
+        }
+        Message last = context.getMessages().get(context.getMessages().size() - 1);
+        if (last.getMetadata() == null) {
+            return null;
+        }
+        Object schemaText = last.getMetadata().get(ContextAttributes.WEBHOOK_RESPONSE_JSON_SCHEMA_TEXT);
+        if (schemaText instanceof String text && !text.isBlank()) {
+            return text;
+        }
+        return null;
+    }
+}

--- a/src/main/java/me/golemcore/bot/domain/context/resolution/TierResolver.java
+++ b/src/main/java/me/golemcore/bot/domain/context/resolution/TierResolver.java
@@ -41,8 +41,9 @@ import java.util.Optional;
  * Tier resolution follows a priority chain that balances user control, skill
  * recommendations, and system defaults:
  * <ol>
- * <li><b>Forced user preference</b> — user explicitly locked a tier via
- * preferences with {@code tierForce=true}</li>
+ * <li><b>Webhook request override</b> — inbound hook mapping/request tier</li>
+ * <li><b>Forced user/session preference</b> — user explicitly locked a tier via
+ * preferences or session settings with {@code tierForce=true}</li>
  * <li><b>Reflection override</b> — autonomous recovery runs may specify a
  * dedicated reflection tier</li>
  * <li><b>Active skill recommendation</b> — the skill's YAML frontmatter
@@ -101,14 +102,14 @@ public class TierResolver {
 
         TierPreference tierPreference = resolveTierPreference(context, prefs);
 
-        if (tierPreference.force() && tierPreference.tier() != null) {
-            applyModelTier(context, tierPreference.tier(), tierPreference.forcedSource());
-            return;
-        }
-
         String webhookTier = context.getAttribute(ContextAttributes.WEBHOOK_MODEL_TIER);
         if (webhookTier != null && !webhookTier.isBlank()) {
             applyModelTier(context, webhookTier, "webhook");
+            return;
+        }
+
+        if (tierPreference.force() && tierPreference.tier() != null) {
+            applyModelTier(context, tierPreference.tier(), tierPreference.forcedSource());
             return;
         }
 

--- a/src/main/java/me/golemcore/bot/domain/context/resolution/TierResolver.java
+++ b/src/main/java/me/golemcore/bot/domain/context/resolution/TierResolver.java
@@ -29,6 +29,7 @@ import me.golemcore.bot.domain.model.UserPreferences;
 import me.golemcore.bot.domain.service.AutoRunContextSupport;
 import me.golemcore.bot.domain.service.ModelSelectionService;
 import me.golemcore.bot.domain.service.RuntimeConfigService;
+import me.golemcore.bot.domain.service.SessionModelSettingsSupport;
 import me.golemcore.bot.domain.service.UserPreferencesService;
 
 import java.util.Optional;
@@ -98,28 +99,45 @@ public class TierResolver {
             return;
         }
 
-        boolean force = prefs.isTierForce();
-        String userTier = prefs.getModelTier();
+        TierPreference tierPreference = resolveTierPreference(context, prefs);
 
-        if (force && userTier != null) {
-            applyModelTier(context, userTier, "user_pref_forced");
+        if (tierPreference.force() && tierPreference.tier() != null) {
+            applyModelTier(context, tierPreference.tier(), tierPreference.forcedSource());
+            return;
+        }
+
+        String webhookTier = context.getAttribute(ContextAttributes.WEBHOOK_MODEL_TIER);
+        if (webhookTier != null && !webhookTier.isBlank()) {
+            applyModelTier(context, webhookTier, "webhook");
             return;
         }
 
         if (isAutoReflectionContext(context)) {
-            resolveReflectionTier(context, userTier);
+            resolveReflectionTier(context, tierPreference.tier(), tierPreference.source());
             return;
         }
 
         Skill activeSkill = context.getActiveSkill();
         if (activeSkill != null && activeSkill.getModelTier() != null) {
             applyModelTier(context, activeSkill.getModelTier(), "skill");
-        } else if (userTier != null) {
-            applyModelTier(context, userTier, "user_pref");
+        } else if (tierPreference.tier() != null) {
+            applyModelTier(context, tierPreference.tier(), tierPreference.source());
         }
     }
 
-    private void resolveReflectionTier(AgentContext context, String userTier) {
+    private TierPreference resolveTierPreference(AgentContext context, UserPreferences prefs) {
+        if (context.getSession() != null
+                && SessionModelSettingsSupport.hasModelSettings(context.getSession())) {
+            return new TierPreference(
+                    SessionModelSettingsSupport.readModelTier(context.getSession()),
+                    SessionModelSettingsSupport.readForce(context.getSession()),
+                    "session_pref",
+                    "session_pref_forced");
+        }
+        return new TierPreference(prefs.getModelTier(), prefs.isTierForce(), "user_pref", "user_pref_forced");
+    }
+
+    private void resolveReflectionTier(AgentContext context, String fallbackTier, String fallbackSource) {
         Skill activeSkill = resolveReflectionSkill(context);
         String configuredReflectionTier = resolveReflectionTierOverride(context);
         boolean priority = resolveReflectionTierPriority(context);
@@ -147,8 +165,8 @@ public class TierResolver {
             applyModelTier(context, activeSkill.getModelTier(), "skill");
             return;
         }
-        if (userTier != null) {
-            applyModelTier(context, userTier, "user_pref");
+        if (fallbackTier != null) {
+            applyModelTier(context, fallbackTier, fallbackSource);
         }
     }
 
@@ -270,5 +288,8 @@ public class TierResolver {
             return null;
         }
         return context.getMessages().get(context.getMessages().size() - 1);
+    }
+
+    private record TierPreference(String tier, boolean force, String source, String forcedSource) {
     }
 }

--- a/src/main/java/me/golemcore/bot/domain/loop/AgentLoop.java
+++ b/src/main/java/me/golemcore/bot/domain/loop/AgentLoop.java
@@ -351,6 +351,7 @@ public class AgentLoop {
         copyStringMetadataAttribute(message, context, ContextAttributes.ACTIVE_SKILL_NAME);
         copyStringMetadataAttribute(message, context, ContextAttributes.AUTO_RUN_ACTIVE_SKILL);
         copyStringMetadataAttribute(message, context, ContextAttributes.AUTO_REFLECTION_TIER);
+        copyStringMetadataAttribute(message, context, ContextAttributes.WEBHOOK_MODEL_TIER);
         copyStringMetadataAttribute(message, context, ContextAttributes.HIVE_CARD_ID);
         copyStringMetadataAttribute(message, context, ContextAttributes.HIVE_THREAD_ID);
         copyStringMetadataAttribute(message, context, ContextAttributes.HIVE_COMMAND_ID);
@@ -874,6 +875,7 @@ public class AgentLoop {
             putIfPresent(attributes, "reasoning", afterState.reasoning());
             putIfPresent(attributes, "source", afterState.source());
             emitTraceEvent(context, systemSpan, "tier.resolved", attributes);
+            emitWebhookResponseSchemaContextEvent(context, systemSpan);
         }
 
         if (!Objects.equals(beforeState.tier(), afterState.tier())
@@ -895,6 +897,30 @@ public class AgentLoop {
             return;
         }
         traceService.appendEvent(context.getSession(), spanContext, eventName, clock.instant(), attributes);
+    }
+
+    private void emitWebhookResponseSchemaContextEvent(AgentContext context, TraceContext systemSpan) {
+        Message lastMessage = lastContextMessage(context);
+        String schemaText = readMetadataString(lastMessage, ContextAttributes.WEBHOOK_RESPONSE_JSON_SCHEMA_TEXT);
+        if (schemaText == null || schemaText.isBlank()) {
+            return;
+        }
+        Map<String, Object> attributes = new LinkedHashMap<>();
+        attributes.put("schema.present", true);
+        attributes.put("schema.chars", schemaText.length());
+        attributes.put("prompt.injected", context.getSystemPrompt() != null
+                && context.getSystemPrompt().contains("Webhook Response JSON Contract"));
+        putIfPresent(attributes, "validation.model.tier",
+                readMetadataString(lastMessage, ContextAttributes.WEBHOOK_RESPONSE_VALIDATION_MODEL_TIER));
+        putIfPresent(attributes, "response.model.tier", context.getModelTier());
+        emitTraceEvent(context, systemSpan, "webhook.response.schema.instructions", attributes);
+    }
+
+    private Message lastContextMessage(AgentContext context) {
+        if (context == null || context.getMessages() == null || context.getMessages().isEmpty()) {
+            return null;
+        }
+        return context.getMessages().get(context.getMessages().size() - 1);
     }
 
     private String normalizeTierForTrace(String tier) {

--- a/src/main/java/me/golemcore/bot/domain/loop/AgentLoop.java
+++ b/src/main/java/me/golemcore/bot/domain/loop/AgentLoop.java
@@ -352,6 +352,7 @@ public class AgentLoop {
         copyStringMetadataAttribute(message, context, ContextAttributes.AUTO_RUN_ACTIVE_SKILL);
         copyStringMetadataAttribute(message, context, ContextAttributes.AUTO_REFLECTION_TIER);
         copyStringMetadataAttribute(message, context, ContextAttributes.WEBHOOK_MODEL_TIER);
+        copyStringMetadataAttribute(message, context, ContextAttributes.MEMORY_PRESET_ID);
         copyStringMetadataAttribute(message, context, ContextAttributes.HIVE_CARD_ID);
         copyStringMetadataAttribute(message, context, ContextAttributes.HIVE_THREAD_ID);
         copyStringMetadataAttribute(message, context, ContextAttributes.HIVE_COMMAND_ID);

--- a/src/main/java/me/golemcore/bot/domain/model/ContextAttributes.java
+++ b/src/main/java/me/golemcore/bot/domain/model/ContextAttributes.java
@@ -223,6 +223,15 @@ public final class ContextAttributes {
     /** String ? webhook delivery target chat identifier. */
     public static final String WEBHOOK_DELIVER_TO = "webhook.deliver.to";
 
+    /** Map<String,Object> ? JSON Schema required for webhook response payloads. */
+    public static final String WEBHOOK_RESPONSE_JSON_SCHEMA = "webhook.response.jsonSchema";
+
+    /** String ? rendered JSON Schema text for webhook prompt assembly. */
+    public static final String WEBHOOK_RESPONSE_JSON_SCHEMA_TEXT = "webhook.response.jsonSchemaText";
+
+    /** String ? model tier used for webhook response schema repair calls. */
+    public static final String WEBHOOK_RESPONSE_VALIDATION_MODEL_TIER = "webhook.response.validationModelTier";
+
     /**
      * String ? transport chat id used for outbound delivery (for example Telegram
      * chat id when logical session key differs).

--- a/src/main/java/me/golemcore/bot/domain/model/ContextAttributes.java
+++ b/src/main/java/me/golemcore/bot/domain/model/ContextAttributes.java
@@ -103,6 +103,12 @@ public final class ContextAttributes {
      */
     public static final String MODEL_TIER_REASONING = "model.tier.reasoning";
 
+    /** String - session-scoped default model tier for this conversation. */
+    public static final String SESSION_MODEL_TIER = "session.modelTier";
+
+    /** Boolean - session-scoped lock for the selected model tier. */
+    public static final String SESSION_MODEL_TIER_FORCE = "session.modelTier.force";
+
     /** Boolean — plan mode is active for the current session. */
     public static final String PLAN_MODE_ACTIVE = "plan.mode.active";
 
@@ -222,6 +228,9 @@ public final class ContextAttributes {
 
     /** String ? webhook delivery target chat identifier. */
     public static final String WEBHOOK_DELIVER_TO = "webhook.deliver.to";
+
+    /** String - explicit model tier requested by a webhook agent run. */
+    public static final String WEBHOOK_MODEL_TIER = "webhook.modelTier";
 
     /** Map<String,Object> ? JSON Schema required for webhook response payloads. */
     public static final String WEBHOOK_RESPONSE_JSON_SCHEMA = "webhook.response.jsonSchema";

--- a/src/main/java/me/golemcore/bot/domain/model/ContextAttributes.java
+++ b/src/main/java/me/golemcore/bot/domain/model/ContextAttributes.java
@@ -232,6 +232,9 @@ public final class ContextAttributes {
     /** String - explicit model tier requested by a webhook agent run. */
     public static final String WEBHOOK_MODEL_TIER = "webhook.modelTier";
 
+    /** String - memory preset id applied to the current turn. */
+    public static final String MEMORY_PRESET_ID = "memory.presetId";
+
     /** Map<String,Object> ? JSON Schema required for webhook response payloads. */
     public static final String WEBHOOK_RESPONSE_JSON_SCHEMA = "webhook.response.jsonSchema";
 

--- a/src/main/java/me/golemcore/bot/domain/model/MemoryPresetIds.java
+++ b/src/main/java/me/golemcore/bot/domain/model/MemoryPresetIds.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 Aleksei Kuleshov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contact: alex@kuleshov.tech
+ */
+
+package me.golemcore.bot.domain.model;
+
+/**
+ * Stable memory preset identifiers shared by settings and runtime policies.
+ */
+public final class MemoryPresetIds {
+
+    public static final String DISABLED = "disabled";
+
+    private MemoryPresetIds() {
+    }
+}

--- a/src/main/java/me/golemcore/bot/domain/model/ToolNames.java
+++ b/src/main/java/me/golemcore/bot/domain/model/ToolNames.java
@@ -13,6 +13,7 @@ public final class ToolNames {
     public static final String HIVE_REQUEST_REVIEW = "hive_request_review";
     public static final String HIVE_CREATE_FOLLOWUP_CARD = "hive_create_followup_card";
     public static final String SCHEDULE_SESSION_ACTION = "schedule_session_action";
+    public static final String MEMORY = "memory";
 
     private ToolNames() {
     }

--- a/src/main/java/me/golemcore/bot/domain/model/UserPreferences.java
+++ b/src/main/java/me/golemcore/bot/domain/model/UserPreferences.java
@@ -90,6 +90,8 @@ public class UserPreferences {
     @AllArgsConstructor
     @Builder
     public static class WebhookConfig {
+        public static final String DEFAULT_MEMORY_PRESET = MemoryPresetIds.DISABLED;
+
         /** Master switch for webhook endpoints. */
         @Builder.Default
         private boolean enabled = false;
@@ -104,6 +106,10 @@ public class UserPreferences {
         /** Default timeout for /agent runs (seconds). */
         @Builder.Default
         private int defaultTimeoutSeconds = 300;
+
+        /** Memory preset applied to webhook turns. Defaults to disabled. */
+        @Builder.Default
+        private String memoryPreset = DEFAULT_MEMORY_PRESET;
 
         /** Custom hook mappings for {@code POST /api/hooks/{name}}. */
         @Builder.Default

--- a/src/main/java/me/golemcore/bot/domain/model/UserPreferences.java
+++ b/src/main/java/me/golemcore/bot/domain/model/UserPreferences.java
@@ -157,5 +157,15 @@ public class UserPreferences {
 
         /** Target chat ID on the delivery channel. */
         private String to;
+
+        /** Wait for the agent response and return it in the webhook HTTP response. */
+        @Builder.Default
+        private boolean syncResponse = false;
+
+        /** Optional JSON Schema that the synchronous response must satisfy. */
+        private Map<String, Object> responseJsonSchema;
+
+        /** Optional explicit tier for response schema repair calls. */
+        private String responseValidationModelTier;
     }
 }

--- a/src/main/java/me/golemcore/bot/domain/model/UserPreferences.java
+++ b/src/main/java/me/golemcore/bot/domain/model/UserPreferences.java
@@ -165,7 +165,7 @@ public class UserPreferences {
         /** Optional JSON Schema that the synchronous response must satisfy. */
         private Map<String, Object> responseJsonSchema;
 
-        /** Optional explicit tier for response schema repair calls. */
+        /** Optional explicit tier for schema-constrained responses and repair calls. */
         private String responseValidationModelTier;
     }
 }

--- a/src/main/java/me/golemcore/bot/domain/service/MemoryPresetService.java
+++ b/src/main/java/me/golemcore/bot/domain/service/MemoryPresetService.java
@@ -19,6 +19,7 @@ package me.golemcore.bot.domain.service;
  */
 
 import me.golemcore.bot.domain.model.MemoryPreset;
+import me.golemcore.bot.domain.model.MemoryPresetIds;
 import me.golemcore.bot.domain.model.RuntimeConfig;
 import org.springframework.stereotype.Service;
 
@@ -184,7 +185,7 @@ public class MemoryPresetService {
                     "aggressive",
                     "detailed"),
             createPreset(
-                    "disabled",
+                    MemoryPresetIds.DISABLED,
                     "Memory Disabled",
                     "Memory is fully disabled for privacy-sensitive tasks and debugging without memory context.",
                     false,

--- a/src/main/java/me/golemcore/bot/domain/service/SessionModelSettingsSupport.java
+++ b/src/main/java/me/golemcore/bot/domain/service/SessionModelSettingsSupport.java
@@ -1,0 +1,117 @@
+package me.golemcore.bot.domain.service;
+
+/*
+ * Copyright 2026 Aleksei Kuleshov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contact: alex@kuleshov.tech
+ */
+
+import me.golemcore.bot.domain.model.AgentSession;
+import me.golemcore.bot.domain.model.ContextAttributes;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Helpers for session-scoped model tier settings.
+ */
+public final class SessionModelSettingsSupport {
+
+    private static final Set<String> MODEL_SETTINGS_INHERITANCE_EXCLUDED_CHANNELS = Set.of("judge", "webhook", "hive");
+
+    private SessionModelSettingsSupport() {
+    }
+
+    public static boolean shouldInheritModelSettings(String channelType) {
+        if (StringValueSupport.isBlank(channelType)) {
+            return false;
+        }
+        String normalizedChannel = channelType.trim().toLowerCase(Locale.ROOT);
+        return !MODEL_SETTINGS_INHERITANCE_EXCLUDED_CHANNELS.contains(normalizedChannel);
+    }
+
+    public static boolean hasModelSettings(AgentSession session) {
+        if (session == null || session.getMetadata() == null) {
+            return false;
+        }
+        Map<String, Object> metadata = session.getMetadata();
+        return metadata.containsKey(ContextAttributes.SESSION_MODEL_TIER)
+                || metadata.containsKey(ContextAttributes.SESSION_MODEL_TIER_FORCE);
+    }
+
+    public static String readModelTier(AgentSession session) {
+        if (session == null || session.getMetadata() == null) {
+            return null;
+        }
+        Object value = session.getMetadata().get(ContextAttributes.SESSION_MODEL_TIER);
+        if (!(value instanceof String tier)) {
+            return null;
+        }
+        String normalizedTier = tier.trim();
+        return normalizedTier.isEmpty() ? null : normalizedTier;
+    }
+
+    public static boolean readForce(AgentSession session) {
+        if (session == null || session.getMetadata() == null) {
+            return false;
+        }
+        Object value = session.getMetadata().get(ContextAttributes.SESSION_MODEL_TIER_FORCE);
+        if (value instanceof Boolean booleanValue) {
+            return booleanValue;
+        }
+        if (value instanceof String stringValue && !stringValue.isBlank()) {
+            return Boolean.parseBoolean(stringValue.trim());
+        }
+        return false;
+    }
+
+    public static void writeModelSettings(AgentSession session, String tier, boolean force) {
+        if (session == null) {
+            return;
+        }
+        Map<String, Object> metadata = ensureMetadata(session);
+        if (StringValueSupport.isBlank(tier)) {
+            metadata.remove(ContextAttributes.SESSION_MODEL_TIER);
+        } else {
+            metadata.put(ContextAttributes.SESSION_MODEL_TIER, tier.trim());
+        }
+        metadata.put(ContextAttributes.SESSION_MODEL_TIER_FORCE, force);
+    }
+
+    public static void inheritModelSettings(AgentSession source, AgentSession target) {
+        if (source == null || target == null || !hasModelSettings(source) || hasModelSettings(target)) {
+            return;
+        }
+        Map<String, Object> sourceMetadata = source.getMetadata();
+        Map<String, Object> targetMetadata = ensureMetadata(target);
+        copyMetadataValue(sourceMetadata, targetMetadata, ContextAttributes.SESSION_MODEL_TIER);
+        copyMetadataValue(sourceMetadata, targetMetadata, ContextAttributes.SESSION_MODEL_TIER_FORCE);
+    }
+
+    private static Map<String, Object> ensureMetadata(AgentSession session) {
+        if (session.getMetadata() == null) {
+            session.setMetadata(new HashMap<>());
+        }
+        return session.getMetadata();
+    }
+
+    private static void copyMetadataValue(Map<String, Object> source, Map<String, Object> target, String key) {
+        if (source.containsKey(key)) {
+            target.put(key, source.get(key));
+        }
+    }
+}

--- a/src/main/java/me/golemcore/bot/domain/service/SessionService.java
+++ b/src/main/java/me/golemcore/bot/domain/service/SessionService.java
@@ -29,6 +29,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.Clock;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -75,6 +76,7 @@ public class SessionService implements SessionPort {
                     .createdAt(clock.instant())
                     .updatedAt(clock.instant())
                     .build();
+            inheritModelSettings(session);
 
             log.info("Created new session: {}", id);
             return session;
@@ -291,6 +293,59 @@ public class SessionService implements SessionPort {
 
     private Optional<AgentSession> loadFromStoredFile(String filePath) {
         return filePath.endsWith(PROTO_EXTENSION) ? loadProtoFile(filePath) : Optional.empty();
+    }
+
+    private void inheritModelSettings(AgentSession session) {
+        if (session == null || !SessionModelSettingsSupport.shouldInheritModelSettings(session.getChannelType())) {
+            return;
+        }
+
+        findModelSettingsSource(session).ifPresent(source -> {
+            SessionModelSettingsSupport.inheritModelSettings(source, session);
+            log.debug("Inherited model settings from session {} into {}", source.getId(), session.getId());
+        });
+    }
+
+    private Optional<AgentSession> findModelSettingsSource(AgentSession target) {
+        Map<String, AgentSession> candidates = new LinkedHashMap<>();
+        String targetId = target.getId();
+        String channelType = target.getChannelType();
+
+        sessionCache.values().stream()
+                .filter(candidate -> candidate != null)
+                .filter(candidate -> isModelSettingsInheritanceCandidate(candidate, channelType, targetId))
+                .forEach(candidate -> candidates.putIfAbsent(candidate.getId(), candidate));
+
+        loadStoredModelSettingsCandidates(channelType, targetId)
+                .forEach(candidate -> candidates.putIfAbsent(candidate.getId(), candidate));
+
+        return candidates.values().stream()
+                .sorted(ConversationKeyValidator.byRecentActivity())
+                .findFirst();
+    }
+
+    private List<AgentSession> loadStoredModelSettingsCandidates(String channelType, String targetId) {
+        try {
+            return storagePort.listObjects(SESSIONS_DIR, "").join().stream()
+                    .filter(path -> isStoredFileForChannel(path, channelType))
+                    .map(this::loadFromStoredFile)
+                    .flatMap(Optional::stream)
+                    .filter(candidate -> isModelSettingsInheritanceCandidate(candidate, channelType, targetId))
+                    .toList();
+        } catch (RuntimeException e) { // NOSONAR - inheritance must not block session creation
+            log.debug("Failed to scan stored sessions for model settings inheritance: {}", e.getMessage());
+            return List.of();
+        }
+    }
+
+    private boolean isModelSettingsInheritanceCandidate(AgentSession candidate, String channelType, String targetId) {
+        if (candidate == null || targetId.equals(candidate.getId())) {
+            return false;
+        }
+        if (StringValueSupport.isBlank(channelType) || !channelType.equals(candidate.getChannelType())) {
+            return false;
+        }
+        return SessionModelSettingsSupport.hasModelSettings(candidate);
     }
 
     private Optional<AgentSession> loadProtoFile(String filePath) {

--- a/src/main/java/me/golemcore/bot/domain/system/MemoryPersistSystem.java
+++ b/src/main/java/me/golemcore/bot/domain/system/MemoryPersistSystem.java
@@ -18,17 +18,18 @@ package me.golemcore.bot.domain.system;
  * Contact: alex@kuleshov.tech
  */
 
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import me.golemcore.bot.domain.component.MemoryComponent;
 import me.golemcore.bot.domain.model.AgentContext;
 import me.golemcore.bot.domain.model.ContextAttributes;
 import me.golemcore.bot.domain.model.LlmResponse;
+import me.golemcore.bot.domain.model.MemoryPresetIds;
 import me.golemcore.bot.domain.model.Message;
-import me.golemcore.bot.domain.model.TurnOutcome;
 import me.golemcore.bot.domain.model.ToolResult;
 import me.golemcore.bot.domain.model.TurnMemoryEvent;
+import me.golemcore.bot.domain.model.TurnOutcome;
 import me.golemcore.bot.domain.service.MemoryScopeSupport;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.time.Instant;
@@ -61,6 +62,9 @@ public class MemoryPersistSystem implements AgentSystem {
 
     @Override
     public boolean shouldProcess(AgentContext context) {
+        if (isMemoryPresetDisabled(context)) {
+            return false;
+        }
         // Prefer TurnOutcome; fall back to legacy finalAnswerReady
         TurnOutcome outcome = context.getTurnOutcome();
         if (outcome != null) {
@@ -71,6 +75,10 @@ public class MemoryPersistSystem implements AgentSystem {
 
     @Override
     public AgentContext process(AgentContext context) {
+        if (isMemoryPresetDisabled(context)) {
+            return context;
+        }
+
         // Get the last user message
         Message lastUserMessage = getLastUserMessage(context);
         if (lastUserMessage == null) {
@@ -190,5 +198,10 @@ public class MemoryPersistSystem implements AgentSystem {
             scopes.add(sessionScope);
         }
         return new ArrayList<>(scopes);
+    }
+
+    private boolean isMemoryPresetDisabled(AgentContext context) {
+        String memoryPreset = context != null ? context.getAttribute(ContextAttributes.MEMORY_PRESET_ID) : null;
+        return memoryPreset != null && MemoryPresetIds.DISABLED.equalsIgnoreCase(memoryPreset.trim());
     }
 }

--- a/src/main/java/me/golemcore/bot/infrastructure/config/ApplicationLayerConfiguration.java
+++ b/src/main/java/me/golemcore/bot/infrastructure/config/ApplicationLayerConfiguration.java
@@ -63,9 +63,10 @@ public class ApplicationLayerConfiguration {
     RuntimeSettingsValidator runtimeSettingsValidator(
             ModelSelectionService modelSelectionService,
             VoiceProviderCatalogPort voiceProviderCatalogPort,
-            ResponseJsonSchemaValidatorPort responseJsonSchemaValidatorPort) {
+            ResponseJsonSchemaValidatorPort responseJsonSchemaValidatorPort,
+            MemoryPresetService memoryPresetService) {
         return new RuntimeSettingsValidator(modelSelectionService, voiceProviderCatalogPort,
-                responseJsonSchemaValidatorPort);
+                responseJsonSchemaValidatorPort, memoryPresetService);
     }
 
     @Bean

--- a/src/main/java/me/golemcore/bot/infrastructure/config/ApplicationLayerConfiguration.java
+++ b/src/main/java/me/golemcore/bot/infrastructure/config/ApplicationLayerConfiguration.java
@@ -40,6 +40,7 @@ import me.golemcore.bot.port.outbound.ModelRegistryDocumentPort;
 import me.golemcore.bot.port.outbound.ModelConfigAdminPort;
 import me.golemcore.bot.port.outbound.ModelRegistryRemotePort;
 import me.golemcore.bot.port.outbound.ProviderModelDiscoveryPort;
+import me.golemcore.bot.port.outbound.SessionPort;
 import me.golemcore.bot.port.outbound.SkillMarketplaceArtifactPort;
 import me.golemcore.bot.port.outbound.SkillMarketplaceCatalogPort;
 import me.golemcore.bot.port.outbound.SkillMarketplaceInstallPort;
@@ -89,8 +90,10 @@ public class ApplicationLayerConfiguration {
     ModelSelectionCommandService modelSelectionCommandService(
             UserPreferencesService preferencesService,
             ModelSelectionService modelSelectionService,
-            RuntimeConfigService runtimeConfigService) {
-        return new ModelSelectionCommandService(preferencesService, modelSelectionService, runtimeConfigService);
+            RuntimeConfigService runtimeConfigService,
+            SessionPort sessionPort) {
+        return new ModelSelectionCommandService(preferencesService, modelSelectionService, runtimeConfigService,
+                sessionPort);
     }
 
     @Bean

--- a/src/main/java/me/golemcore/bot/infrastructure/config/ApplicationLayerConfiguration.java
+++ b/src/main/java/me/golemcore/bot/infrastructure/config/ApplicationLayerConfiguration.java
@@ -40,6 +40,7 @@ import me.golemcore.bot.port.outbound.ModelRegistryDocumentPort;
 import me.golemcore.bot.port.outbound.ModelConfigAdminPort;
 import me.golemcore.bot.port.outbound.ModelRegistryRemotePort;
 import me.golemcore.bot.port.outbound.ProviderModelDiscoveryPort;
+import me.golemcore.bot.port.outbound.ResponseJsonSchemaValidatorPort;
 import me.golemcore.bot.port.outbound.SessionPort;
 import me.golemcore.bot.port.outbound.SkillMarketplaceArtifactPort;
 import me.golemcore.bot.port.outbound.SkillMarketplaceCatalogPort;
@@ -61,8 +62,10 @@ public class ApplicationLayerConfiguration {
     @Bean
     RuntimeSettingsValidator runtimeSettingsValidator(
             ModelSelectionService modelSelectionService,
-            VoiceProviderCatalogPort voiceProviderCatalogPort) {
-        return new RuntimeSettingsValidator(modelSelectionService, voiceProviderCatalogPort);
+            VoiceProviderCatalogPort voiceProviderCatalogPort,
+            ResponseJsonSchemaValidatorPort responseJsonSchemaValidatorPort) {
+        return new RuntimeSettingsValidator(modelSelectionService, voiceProviderCatalogPort,
+                responseJsonSchemaValidatorPort);
     }
 
     @Bean

--- a/src/main/java/me/golemcore/bot/infrastructure/config/ContextLayerConfiguration.java
+++ b/src/main/java/me/golemcore/bot/infrastructure/config/ContextLayerConfiguration.java
@@ -15,6 +15,7 @@ import me.golemcore.bot.domain.context.layer.RagLayer;
 import me.golemcore.bot.domain.context.layer.SkillLayer;
 import me.golemcore.bot.domain.context.layer.TierAwarenessLayer;
 import me.golemcore.bot.domain.context.layer.ToolLayer;
+import me.golemcore.bot.domain.context.layer.WebhookResponseSchemaLayer;
 import me.golemcore.bot.domain.context.layer.WorkspaceInstructionsLayer;
 import me.golemcore.bot.domain.context.resolution.SkillResolver;
 import me.golemcore.bot.domain.context.resolution.TierResolver;
@@ -107,6 +108,11 @@ public class ContextLayerConfiguration {
     @Bean
     HiveLayer hiveLayer() {
         return new HiveLayer();
+    }
+
+    @Bean
+    WebhookResponseSchemaLayer webhookResponseSchemaLayer() {
+        return new WebhookResponseSchemaLayer();
     }
 
     @Bean

--- a/src/main/java/me/golemcore/bot/infrastructure/config/ContextLayerConfiguration.java
+++ b/src/main/java/me/golemcore/bot/infrastructure/config/ContextLayerConfiguration.java
@@ -21,6 +21,7 @@ import me.golemcore.bot.domain.context.resolution.SkillResolver;
 import me.golemcore.bot.domain.context.resolution.TierResolver;
 import me.golemcore.bot.domain.service.AutoModeService;
 import me.golemcore.bot.domain.service.DelayedActionPolicyService;
+import me.golemcore.bot.domain.service.MemoryPresetService;
 import me.golemcore.bot.domain.service.ModelSelectionService;
 import me.golemcore.bot.domain.service.PlanService;
 import me.golemcore.bot.domain.service.PromptSectionService;
@@ -68,8 +69,11 @@ public class ContextLayerConfiguration {
     }
 
     @Bean
-    MemoryLayer memoryLayer(MemoryComponent memoryComponent, RuntimeConfigService runtimeConfigService) {
-        return new MemoryLayer(memoryComponent, runtimeConfigService);
+    MemoryLayer memoryLayer(
+            MemoryComponent memoryComponent,
+            RuntimeConfigService runtimeConfigService,
+            MemoryPresetService memoryPresetService) {
+        return new MemoryLayer(memoryComponent, runtimeConfigService, memoryPresetService);
     }
 
     @Bean

--- a/src/main/java/me/golemcore/bot/port/outbound/ResponseJsonSchemaValidatorPort.java
+++ b/src/main/java/me/golemcore/bot/port/outbound/ResponseJsonSchemaValidatorPort.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026 Aleksei Kuleshov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contact: alex@kuleshov.tech
+ */
+
+package me.golemcore.bot.port.outbound;
+
+import java.util.Map;
+
+public interface ResponseJsonSchemaValidatorPort {
+
+    void validateResponseJsonSchema(Map<String, Object> responseJsonSchema);
+}

--- a/src/main/java/me/golemcore/bot/tools/MemoryTool.java
+++ b/src/main/java/me/golemcore/bot/tools/MemoryTool.java
@@ -25,6 +25,7 @@ import me.golemcore.bot.domain.component.ToolComponent;
 import me.golemcore.bot.domain.model.MemoryItem;
 import me.golemcore.bot.domain.model.MemoryQuery;
 import me.golemcore.bot.domain.model.ToolDefinition;
+import me.golemcore.bot.domain.model.ToolNames;
 import me.golemcore.bot.domain.model.ToolResult;
 import me.golemcore.bot.domain.service.RuntimeConfigService;
 import org.springframework.stereotype.Component;
@@ -46,7 +47,7 @@ import java.util.concurrent.CompletableFuture;
 @Slf4j
 public class MemoryTool implements ToolComponent {
 
-    public static final String TOOL_NAME = "memory";
+    public static final String TOOL_NAME = ToolNames.MEMORY;
 
     private static final String OP_ADD = "memory_add";
     private static final String OP_READ = "memory_read";

--- a/src/main/java/me/golemcore/bot/tools/TierTool.java
+++ b/src/main/java/me/golemcore/bot/tools/TierTool.java
@@ -25,6 +25,7 @@ import me.golemcore.bot.domain.model.ModelTierCatalog;
 import me.golemcore.bot.domain.model.ToolDefinition;
 import me.golemcore.bot.domain.model.ToolResult;
 import me.golemcore.bot.domain.service.RuntimeConfigService;
+import me.golemcore.bot.domain.service.SessionModelSettingsSupport;
 import me.golemcore.bot.domain.service.UserPreferencesService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -96,14 +97,14 @@ public class TierTool implements ToolComponent {
                                     + ModelTierCatalog.explicitTierListForDisplay()));
         }
 
-        if (userPreferencesService.getPreferences().isTierForce()) {
-            return CompletableFuture.completedFuture(
-                    ToolResult.failure("Tier is locked by user. Use /tier command to unlock."));
-        }
-
         AgentContext context = AgentContextHolder.get();
         if (context == null) {
             return CompletableFuture.completedFuture(ToolResult.failure("No agent context available"));
+        }
+
+        if (isTierForced(context)) {
+            return CompletableFuture.completedFuture(
+                    ToolResult.failure("Tier is locked by user. Use /tier command to unlock."));
         }
 
         String previousTier = context.getModelTier();
@@ -118,5 +119,12 @@ public class TierTool implements ToolComponent {
     @Override
     public boolean isEnabled() {
         return runtimeConfigService.isTierToolEnabled();
+    }
+
+    private boolean isTierForced(AgentContext context) {
+        if (context.getSession() != null && SessionModelSettingsSupport.hasModelSettings(context.getSession())) {
+            return SessionModelSettingsSupport.readForce(context.getSession());
+        }
+        return userPreferencesService.getPreferences().isTierForce();
     }
 }

--- a/src/test/java/me/golemcore/bot/adapter/inbound/command/CommandRouterTest.java
+++ b/src/test/java/me/golemcore/bot/adapter/inbound/command/CommandRouterTest.java
@@ -1093,20 +1093,20 @@ class CommandRouterTest {
 
     @Test
     void tierCommandRendersCurrentTierFromApplicationOutcome() throws Exception {
-        when(modelSelectionCommandService.handleTier(new ModelSelectionCommandService.ShowTierStatus())).thenReturn(
-                new ModelSelectionCommandService.CurrentTier("smart", true));
+        when(modelSelectionCommandService.handleTier(new ModelSelectionCommandService.ShowTierStatus(SESSION_ID)))
+                .thenReturn(new ModelSelectionCommandService.CurrentTier("smart", true));
 
         CommandPort.CommandResult result = router.execute(CMD_TIER, List.of(), CTX).get();
 
         assertTrue(result.success());
         assertEquals("command.tier.current smart on", result.output());
-        verify(modelSelectionCommandService).handleTier(new ModelSelectionCommandService.ShowTierStatus());
+        verify(modelSelectionCommandService).handleTier(new ModelSelectionCommandService.ShowTierStatus(SESSION_ID));
     }
 
     @Test
     void tierCommandParsesForceFlagInAdapter() throws Exception {
         when(modelSelectionCommandService
-                .handleTier(new ModelSelectionCommandService.SetTierSelection(TIER_SMART, true)))
+                .handleTier(new ModelSelectionCommandService.SetTierSelection(TIER_SMART, true, SESSION_ID)))
                 .thenReturn(new ModelSelectionCommandService.TierUpdated(TIER_SMART, true));
 
         CommandPort.CommandResult result = router.execute(CMD_TIER, List.of(TIER_SMART, "force"), CTX).get();
@@ -1114,13 +1114,13 @@ class CommandRouterTest {
         assertTrue(result.success());
         assertEquals("command.tier.set.force smart", result.output());
         verify(modelSelectionCommandService)
-                .handleTier(new ModelSelectionCommandService.SetTierSelection(TIER_SMART, true));
+                .handleTier(new ModelSelectionCommandService.SetTierSelection(TIER_SMART, true, SESSION_ID));
     }
 
     @Test
     void tierCommandRendersNonForcedUpdate() throws Exception {
         when(modelSelectionCommandService
-                .handleTier(new ModelSelectionCommandService.SetTierSelection(TIER_SMART, false)))
+                .handleTier(new ModelSelectionCommandService.SetTierSelection(TIER_SMART, false, SESSION_ID)))
                 .thenReturn(new ModelSelectionCommandService.TierUpdated(TIER_SMART, false));
 
         CommandPort.CommandResult result = router.execute(CMD_TIER, List.of(TIER_SMART), CTX).get();
@@ -1128,13 +1128,13 @@ class CommandRouterTest {
         assertTrue(result.success());
         assertEquals("command.tier.set smart", result.output());
         verify(modelSelectionCommandService)
-                .handleTier(new ModelSelectionCommandService.SetTierSelection(TIER_SMART, false));
+                .handleTier(new ModelSelectionCommandService.SetTierSelection(TIER_SMART, false, SESSION_ID));
     }
 
     @Test
     void tierCommandRendersInvalidOutcomeFromApplicationService() throws Exception {
         when(modelSelectionCommandService
-                .handleTier(new ModelSelectionCommandService.SetTierSelection(TIER_SMART, false)))
+                .handleTier(new ModelSelectionCommandService.SetTierSelection(TIER_SMART, false, SESSION_ID)))
                 .thenReturn(new ModelSelectionCommandService.InvalidTier());
 
         CommandPort.CommandResult result = router.execute(CMD_TIER, List.of(TIER_SMART), CTX).get();

--- a/src/test/java/me/golemcore/bot/adapter/inbound/webhook/WebhookControllerTest.java
+++ b/src/test/java/me/golemcore/bot/adapter/inbound/webhook/WebhookControllerTest.java
@@ -5,11 +5,17 @@ import me.golemcore.bot.adapter.inbound.webhook.dto.AgentRequest;
 import me.golemcore.bot.adapter.inbound.webhook.dto.WakeRequest;
 import me.golemcore.bot.adapter.inbound.webhook.dto.WebhookResponse;
 import me.golemcore.bot.domain.loop.AgentLoop;
+import me.golemcore.bot.domain.model.AgentSession;
 import me.golemcore.bot.domain.model.ContextAttributes;
 import me.golemcore.bot.domain.model.Message;
 import me.golemcore.bot.domain.model.Secret;
 import me.golemcore.bot.domain.model.UserPreferences;
+import me.golemcore.bot.domain.model.trace.TraceContext;
+import me.golemcore.bot.domain.model.trace.TraceSpanKind;
+import me.golemcore.bot.domain.model.trace.TraceStatusCode;
+import me.golemcore.bot.domain.service.TraceService;
 import me.golemcore.bot.domain.service.UserPreferencesService;
+import me.golemcore.bot.port.outbound.SessionPort;
 import me.golemcore.bot.security.InputSanitizer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -23,6 +29,7 @@ import org.springframework.http.ResponseEntity;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -32,7 +39,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.argThat;
 import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -51,6 +60,8 @@ class WebhookControllerTest {
     private WebhookDeliveryTracker deliveryTracker;
     private WebhookResponseSchemaService responseSchemaService;
     private ApplicationEventPublisher eventPublisher;
+    private SessionPort sessionPort;
+    private TraceService traceService;
     private InputSanitizer inputSanitizer;
     private WebhookController controller;
 
@@ -63,14 +74,18 @@ class WebhookControllerTest {
         deliveryTracker = mock(WebhookDeliveryTracker.class);
         responseSchemaService = mock(WebhookResponseSchemaService.class);
         eventPublisher = mock(ApplicationEventPublisher.class);
+        sessionPort = mock(SessionPort.class);
+        traceService = mock(TraceService.class);
         inputSanitizer = new InputSanitizer();
 
         controller = new WebhookController(
                 preferencesService, authenticator, channelAdapter,
-                transformer, deliveryTracker, responseSchemaService, eventPublisher, inputSanitizer);
+                transformer, deliveryTracker, responseSchemaService, eventPublisher,
+                sessionPort, traceService, inputSanitizer);
 
         when(preferencesService.getPreferences()).thenReturn(buildEnabledPrefs());
         when(authenticator.authenticateBearer(any())).thenReturn(true);
+        when(sessionPort.get(anyString())).thenReturn(Optional.empty());
     }
 
     // ==================== /wake ====================
@@ -292,6 +307,53 @@ class WebhookControllerTest {
         assertEquals("{\"type\":\"object\"}",
                 message.getMetadata().get(ContextAttributes.WEBHOOK_RESPONSE_JSON_SCHEMA_TEXT));
         assertEquals("smart", message.getMetadata().get(ContextAttributes.WEBHOOK_RESPONSE_VALIDATION_MODEL_TIER));
+        assertEquals("coding", message.getMetadata().get(ContextAttributes.WEBHOOK_MODEL_TIER));
+    }
+
+    @Test
+    void agentShouldRecordSynchronousSchemaValidationTraceSpan() {
+        Map<String, Object> schema = aliceResponseSchema();
+        Map<String, Object> payload = Map.of(
+                "version", "1.0",
+                "response", Map.of("text", "Ready", "tts", "Ready", "end_session", true));
+        AgentSession session = AgentSession.builder()
+                .id("webhook:trace-chat")
+                .channelType("webhook")
+                .chatId("trace-chat")
+                .build();
+        TraceContext schemaSpan = TraceContext.builder()
+                .traceId("trace-1")
+                .spanId("schema-span")
+                .parentSpanId("root-span")
+                .rootKind("INGRESS")
+                .build();
+        AgentRequest request = AgentRequest.builder()
+                .message("Answer in Alice format")
+                .chatId("trace-chat")
+                .syncResponse(true)
+                .responseJsonSchema(schema)
+                .responseValidationModelTier("smart")
+                .build();
+        when(channelAdapter.registerPendingRun(anyString(), anyString(), any(), any(), any()))
+                .thenReturn(CompletableFuture.completedFuture("Ready"));
+        when(responseSchemaService.renderSchema(schema)).thenReturn("{\"type\":\"object\"}");
+        when(responseSchemaService.validateAndRepair(eq("Ready"), eq(schema), eq("smart"), any(), any()))
+                .thenReturn(new WebhookResponseSchemaService.SchemaResult(payload, 0));
+        when(sessionPort.get("webhook:trace-chat")).thenReturn(Optional.of(session));
+        when(traceService.startSpan(eq(session), any(), eq("webhook.response.schema.validation"),
+                eq(TraceSpanKind.INTERNAL), any(), any()))
+                .thenReturn(schemaSpan);
+
+        ResponseEntity<?> response = controller.agent(toJsonBytes(request), new HttpHeaders()).block();
+
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        verify(traceService).appendEvent(eq(session), eq(schemaSpan), eq("schema.validation.started"), any(), any());
+        verify(traceService).appendEvent(eq(session), eq(schemaSpan), eq("schema.validation.finished"), any(),
+                argThat(attributes -> Boolean.TRUE.equals(attributes.get("success"))
+                        && Integer.valueOf(0).equals(attributes.get("repair_attempts"))));
+        verify(traceService).finishSpan(eq(session), eq(schemaSpan), eq(TraceStatusCode.OK), isNull(), any());
+        verify(sessionPort).save(session);
     }
 
     @Test

--- a/src/test/java/me/golemcore/bot/adapter/inbound/webhook/WebhookControllerTest.java
+++ b/src/test/java/me/golemcore/bot/adapter/inbound/webhook/WebhookControllerTest.java
@@ -7,12 +7,14 @@ import me.golemcore.bot.adapter.inbound.webhook.dto.WebhookResponse;
 import me.golemcore.bot.domain.loop.AgentLoop;
 import me.golemcore.bot.domain.model.AgentSession;
 import me.golemcore.bot.domain.model.ContextAttributes;
+import me.golemcore.bot.domain.model.MemoryPresetIds;
 import me.golemcore.bot.domain.model.Message;
 import me.golemcore.bot.domain.model.Secret;
 import me.golemcore.bot.domain.model.UserPreferences;
 import me.golemcore.bot.domain.model.trace.TraceContext;
 import me.golemcore.bot.domain.model.trace.TraceSpanKind;
 import me.golemcore.bot.domain.model.trace.TraceStatusCode;
+import me.golemcore.bot.domain.service.MemoryPresetService;
 import me.golemcore.bot.domain.service.TraceService;
 import me.golemcore.bot.domain.service.UserPreferencesService;
 import me.golemcore.bot.port.outbound.SessionPort;
@@ -61,6 +63,7 @@ class WebhookControllerTest {
     private WebhookPayloadTransformer transformer;
     private WebhookDeliveryTracker deliveryTracker;
     private WebhookResponseSchemaService responseSchemaService;
+    private MemoryPresetService memoryPresetService;
     private ApplicationEventPublisher eventPublisher;
     private SessionPort sessionPort;
     private TraceService traceService;
@@ -75,6 +78,7 @@ class WebhookControllerTest {
         transformer = mock(WebhookPayloadTransformer.class);
         deliveryTracker = mock(WebhookDeliveryTracker.class);
         responseSchemaService = mock(WebhookResponseSchemaService.class);
+        memoryPresetService = new MemoryPresetService();
         eventPublisher = mock(ApplicationEventPublisher.class);
         sessionPort = mock(SessionPort.class);
         traceService = mock(TraceService.class);
@@ -82,7 +86,7 @@ class WebhookControllerTest {
 
         controller = new WebhookController(
                 preferencesService, authenticator, channelAdapter,
-                transformer, deliveryTracker, responseSchemaService, eventPublisher,
+                transformer, deliveryTracker, responseSchemaService, memoryPresetService, eventPublisher,
                 sessionPort, traceService, inputSanitizer);
 
         when(preferencesService.getPreferences()).thenReturn(buildEnabledPrefs());
@@ -208,6 +212,51 @@ class WebhookControllerTest {
         assertNotNull(webhookBody(response).getRunId());
         assertNotNull(webhookBody(response).getChatId());
         assertEquals("accepted", webhookBody(response).getStatus());
+
+        ArgumentCaptor<AgentLoop.InboundMessageEvent> captor = ArgumentCaptor
+                .forClass(AgentLoop.InboundMessageEvent.class);
+        verify(eventPublisher).publishEvent(captor.capture());
+        assertEquals(MemoryPresetIds.DISABLED,
+                captor.getValue().message().getMetadata().get(ContextAttributes.MEMORY_PRESET_ID));
+    }
+
+    @Test
+    void agentShouldUseConfiguredMemoryPresetMetadata() {
+        UserPreferences prefs = UserPreferences.builder()
+                .webhooks(UserPreferences.WebhookConfig.builder()
+                        .enabled(true)
+                        .token(Secret.of(TOKEN))
+                        .memoryPreset("general_chat")
+                        .build())
+                .build();
+        when(preferencesService.getPreferences()).thenReturn(prefs);
+
+        AgentRequest request = AgentRequest.builder()
+                .message("Summarize issues")
+                .build();
+
+        controller.agent(toJsonBytes(request), new HttpHeaders()).block();
+
+        ArgumentCaptor<AgentLoop.InboundMessageEvent> captor = ArgumentCaptor
+                .forClass(AgentLoop.InboundMessageEvent.class);
+        verify(eventPublisher).publishEvent(captor.capture());
+        assertEquals("general_chat",
+                captor.getValue().message().getMetadata().get(ContextAttributes.MEMORY_PRESET_ID));
+    }
+
+    @Test
+    void agentShouldRejectUnknownMemoryPresetOverride() {
+        AgentRequest request = AgentRequest.builder()
+                .message("Summarize issues")
+                .memoryPreset("unknown")
+                .build();
+
+        ResponseEntity<?> response = controller.agent(toJsonBytes(request), new HttpHeaders()).block();
+
+        assertNotNull(response);
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals("'memoryPreset' must be a known memory preset id", webhookBody(response).getErrorMessage());
+        verify(channelAdapter, never()).registerPendingRun(anyString(), anyString(), any(), any(), any());
     }
 
     @Test
@@ -430,6 +479,22 @@ class WebhookControllerTest {
         assertNotNull(response);
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
         assertEquals("'responseJsonSchema' requires syncResponse=true", webhookBody(response).getErrorMessage());
+        verify(channelAdapter, never()).registerPendingRun(anyString(), anyString(), any(), any(), any());
+    }
+
+    @Test
+    void agentShouldRejectEmptyResponseSchemaBeforeDispatch() {
+        AgentRequest request = AgentRequest.builder()
+                .message("Answer in configured schema")
+                .syncResponse(true)
+                .responseJsonSchema(Map.of())
+                .build();
+
+        ResponseEntity<?> response = controller.agent(toJsonBytes(request), new HttpHeaders()).block();
+
+        assertNotNull(response);
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals("'responseJsonSchema' must not be empty", webhookBody(response).getErrorMessage());
         verify(channelAdapter, never()).registerPendingRun(anyString(), anyString(), any(), any(), any());
     }
 

--- a/src/test/java/me/golemcore/bot/adapter/inbound/webhook/WebhookControllerTest.java
+++ b/src/test/java/me/golemcore/bot/adapter/inbound/webhook/WebhookControllerTest.java
@@ -299,7 +299,7 @@ class WebhookControllerTest {
         when(channelAdapter.registerPendingRun(anyString(), anyString(), any(), any(), any()))
                 .thenReturn(CompletableFuture.completedFuture("Ready"));
         when(responseSchemaService.renderSchema(schema)).thenReturn("{\"type\":\"object\"}");
-        when(responseSchemaService.validateAndRepair(eq("Ready"), eq(schema), eq("smart"), eq("coding"), any()))
+        when(responseSchemaService.validateAndRepair(eq("Ready"), eq(schema), eq("smart"), eq("smart"), any()))
                 .thenReturn(new WebhookResponseSchemaService.SchemaResult(payload, 1));
 
         ResponseEntity<?> response = controller.agent(toJsonBytes(request), new HttpHeaders()).block();
@@ -308,9 +308,10 @@ class WebhookControllerTest {
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals(payload, response.getBody());
         assertEquals(List.of("1"), response.getHeaders().get("X-Golemcore-Schema-Repair-Attempts"));
+        verify(channelAdapter).registerPendingRun(anyString(), anyString(), any(), eq("smart"), any());
         verify(responseSchemaService).validateSchemaDefinition(schema);
         ArgumentCaptor<Duration> repairBudgetCaptor = ArgumentCaptor.forClass(Duration.class);
-        verify(responseSchemaService).validateAndRepair(eq("Ready"), eq(schema), eq("smart"), eq("coding"),
+        verify(responseSchemaService).validateAndRepair(eq("Ready"), eq(schema), eq("smart"), eq("smart"),
                 repairBudgetCaptor.capture());
         assertTrue(repairBudgetCaptor.getValue().compareTo(Duration.ZERO) > 0);
         assertTrue(repairBudgetCaptor.getValue().compareTo(Duration.ofSeconds(300)) <= 0);
@@ -323,7 +324,33 @@ class WebhookControllerTest {
         assertEquals("{\"type\":\"object\"}",
                 message.getMetadata().get(ContextAttributes.WEBHOOK_RESPONSE_JSON_SCHEMA_TEXT));
         assertEquals("smart", message.getMetadata().get(ContextAttributes.WEBHOOK_RESPONSE_VALIDATION_MODEL_TIER));
-        assertEquals("coding", message.getMetadata().get(ContextAttributes.WEBHOOK_MODEL_TIER));
+        assertEquals("smart", message.getMetadata().get(ContextAttributes.WEBHOOK_MODEL_TIER));
+    }
+
+    @Test
+    void agentShouldUseModelTierForSynchronousSchemaWhenValidationTierIsDefault() {
+        Map<String, Object> schema = responseEnvelopeSchema();
+        Map<String, Object> payload = Map.of(
+                "version", "1.0",
+                "response", Map.of("text", "Ready", "tts", "Ready", "end_session", true));
+        AgentRequest request = AgentRequest.builder()
+                .message("Answer in configured schema")
+                .model("coding")
+                .syncResponse(true)
+                .responseJsonSchema(schema)
+                .build();
+        when(channelAdapter.registerPendingRun(anyString(), anyString(), any(), any(), any()))
+                .thenReturn(CompletableFuture.completedFuture("Ready"));
+        when(responseSchemaService.renderSchema(schema)).thenReturn("{\"type\":\"object\"}");
+        when(responseSchemaService.validateAndRepair(eq("Ready"), eq(schema), isNull(), eq("coding"), any()))
+                .thenReturn(new WebhookResponseSchemaService.SchemaResult(payload, 0));
+
+        ResponseEntity<?> response = controller.agent(toJsonBytes(request), new HttpHeaders()).block();
+
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        verify(channelAdapter).registerPendingRun(anyString(), anyString(), any(), eq("coding"), any());
+        verify(responseSchemaService).validateAndRepair(eq("Ready"), eq(schema), isNull(), eq("coding"), any());
     }
 
     @Test
@@ -642,6 +669,43 @@ class WebhookControllerTest {
         verify(responseSchemaService, never()).validateSchemaDefinition(any());
         verify(responseSchemaService, never()).renderSchema(any());
         verify(responseSchemaService, never()).validateAndRepair(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void customHookAgentActionShouldUseSchemaTierForSynchronousSchemaResponse() {
+        Map<String, Object> schema = responseEnvelopeSchema();
+        Map<String, Object> payload = Map.of(
+                "version", "1.0",
+                "response", Map.of("text", "Deployment done", "tts", "Deployment done", "end_session", true));
+        UserPreferences.HookMapping mapping = UserPreferences.HookMapping.builder()
+                .name("agent-hook")
+                .action("agent")
+                .messageTemplate("Process: {event}")
+                .model("balanced")
+                .syncResponse(true)
+                .responseJsonSchema(schema)
+                .responseValidationModelTier("special5")
+                .build();
+        when(preferencesService.getPreferences()).thenReturn(buildPrefsWithMapping(mapping));
+        when(authenticator.authenticate(any(), any(), any())).thenReturn(true);
+        when(transformer.transform(any(), any())).thenReturn("Process: deploy");
+        when(channelAdapter.registerPendingRun(anyString(), anyString(), any(), any(), any()))
+                .thenReturn(CompletableFuture.completedFuture("Deployment done"));
+        when(responseSchemaService.renderSchema(schema)).thenReturn("{\"type\":\"object\"}");
+        when(responseSchemaService.validateAndRepair(
+                eq("Deployment done"), eq(schema), eq("special5"), eq("special5"), any()))
+                .thenReturn(new WebhookResponseSchemaService.SchemaResult(payload, 1));
+
+        byte[] body = "{\"event\":\"deploy\"}".getBytes();
+        ResponseEntity<?> response = controller.customHook("agent-hook", body, new HttpHeaders())
+                .block();
+
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(payload, response.getBody());
+        verify(channelAdapter).registerPendingRun(anyString(), anyString(), any(), eq("special5"), any());
+        verify(responseSchemaService).validateAndRepair(
+                eq("Deployment done"), eq(schema), eq("special5"), eq("special5"), any());
     }
 
     @Test

--- a/src/test/java/me/golemcore/bot/adapter/inbound/webhook/WebhookControllerTest.java
+++ b/src/test/java/me/golemcore/bot/adapter/inbound/webhook/WebhookControllerTest.java
@@ -20,8 +20,10 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -47,6 +49,7 @@ class WebhookControllerTest {
     private WebhookChannelAdapter channelAdapter;
     private WebhookPayloadTransformer transformer;
     private WebhookDeliveryTracker deliveryTracker;
+    private WebhookResponseSchemaService responseSchemaService;
     private ApplicationEventPublisher eventPublisher;
     private InputSanitizer inputSanitizer;
     private WebhookController controller;
@@ -58,12 +61,13 @@ class WebhookControllerTest {
         channelAdapter = mock(WebhookChannelAdapter.class);
         transformer = mock(WebhookPayloadTransformer.class);
         deliveryTracker = mock(WebhookDeliveryTracker.class);
+        responseSchemaService = mock(WebhookResponseSchemaService.class);
         eventPublisher = mock(ApplicationEventPublisher.class);
         inputSanitizer = new InputSanitizer();
 
         controller = new WebhookController(
                 preferencesService, authenticator, channelAdapter,
-                transformer, deliveryTracker, eventPublisher, inputSanitizer);
+                transformer, deliveryTracker, responseSchemaService, eventPublisher, inputSanitizer);
 
         when(preferencesService.getPreferences()).thenReturn(buildEnabledPrefs());
         when(authenticator.authenticateBearer(any())).thenReturn(true);
@@ -180,13 +184,13 @@ class WebhookControllerTest {
                 .model("smart")
                 .build();
 
-        ResponseEntity<WebhookResponse> response = controller.agent(toJsonBytes(request), new HttpHeaders()).block();
+        ResponseEntity<?> response = controller.agent(toJsonBytes(request), new HttpHeaders()).block();
 
         assertNotNull(response);
         assertEquals(HttpStatus.ACCEPTED, response.getStatusCode());
-        assertNotNull(response.getBody().getRunId());
-        assertNotNull(response.getBody().getChatId());
-        assertEquals("accepted", response.getBody().getStatus());
+        assertNotNull(webhookBody(response).getRunId());
+        assertNotNull(webhookBody(response).getChatId());
+        assertEquals("accepted", webhookBody(response).getStatus());
     }
 
     @Test
@@ -196,17 +200,17 @@ class WebhookControllerTest {
                 .chatId("my-session")
                 .build();
 
-        ResponseEntity<WebhookResponse> response = controller.agent(toJsonBytes(request), new HttpHeaders()).block();
+        ResponseEntity<?> response = controller.agent(toJsonBytes(request), new HttpHeaders()).block();
 
         assertNotNull(response);
-        assertEquals("my-session", response.getBody().getChatId());
+        assertEquals("my-session", webhookBody(response).getChatId());
     }
 
     @Test
     void agentShouldReturnBadRequestWhenMessageMissing() {
         AgentRequest request = AgentRequest.builder().message(null).build();
 
-        ResponseEntity<WebhookResponse> response = controller.agent(toJsonBytes(request), new HttpHeaders()).block();
+        ResponseEntity<?> response = controller.agent(toJsonBytes(request), new HttpHeaders()).block();
 
         assertNotNull(response);
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
@@ -229,6 +233,120 @@ class WebhookControllerTest {
                 eq("https://example.com/callback"), eq("coding"));
         verify(channelAdapter).registerPendingRun(anyString(), anyString(),
                 eq("https://example.com/callback"), eq("coding"), eq("delivery-1"));
+    }
+
+    @Test
+    void agentShouldReturnSynchronousResponseWhenRequested() {
+        AgentRequest request = AgentRequest.builder()
+                .message("Answer directly")
+                .syncResponse(true)
+                .build();
+        when(channelAdapter.registerPendingRun(anyString(), anyString(), any(), any(), any()))
+                .thenReturn(CompletableFuture.completedFuture("Direct answer"));
+
+        ResponseEntity<?> response = controller.agent(toJsonBytes(request), new HttpHeaders()).block();
+
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals("completed", webhookBody(response).getStatus());
+        assertEquals("Direct answer", webhookBody(response).getResponse());
+    }
+
+    @Test
+    void agentShouldReturnSchemaPayloadForSynchronousJsonSchema() {
+        Map<String, Object> schema = aliceResponseSchema();
+        Map<String, Object> payload = Map.of(
+                "version", "1.0",
+                "response", Map.of("text", "Ready", "tts", "Ready", "end_session", true));
+        AgentRequest request = AgentRequest.builder()
+                .message("Answer in Alice format")
+                .model("coding")
+                .syncResponse(true)
+                .responseJsonSchema(schema)
+                .responseValidationModelTier("smart")
+                .build();
+        when(channelAdapter.registerPendingRun(anyString(), anyString(), any(), any(), any()))
+                .thenReturn(CompletableFuture.completedFuture("Ready"));
+        when(responseSchemaService.renderSchema(schema)).thenReturn("{\"type\":\"object\"}");
+        when(responseSchemaService.validateAndRepair(eq("Ready"), eq(schema), eq("smart"), eq("coding"), any()))
+                .thenReturn(new WebhookResponseSchemaService.SchemaResult(payload, 1));
+
+        ResponseEntity<?> response = controller.agent(toJsonBytes(request), new HttpHeaders()).block();
+
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(payload, response.getBody());
+        assertEquals(List.of("1"), response.getHeaders().get("X-Golemcore-Schema-Repair-Attempts"));
+        verify(responseSchemaService).validateSchemaDefinition(schema);
+        ArgumentCaptor<Duration> repairBudgetCaptor = ArgumentCaptor.forClass(Duration.class);
+        verify(responseSchemaService).validateAndRepair(eq("Ready"), eq(schema), eq("smart"), eq("coding"),
+                repairBudgetCaptor.capture());
+        assertTrue(repairBudgetCaptor.getValue().compareTo(Duration.ZERO) > 0);
+        assertTrue(repairBudgetCaptor.getValue().compareTo(Duration.ofSeconds(300)) <= 0);
+
+        ArgumentCaptor<AgentLoop.InboundMessageEvent> captor = ArgumentCaptor
+                .forClass(AgentLoop.InboundMessageEvent.class);
+        verify(eventPublisher).publishEvent(captor.capture());
+        Message message = captor.getValue().message();
+        assertEquals(schema, message.getMetadata().get(ContextAttributes.WEBHOOK_RESPONSE_JSON_SCHEMA));
+        assertEquals("{\"type\":\"object\"}",
+                message.getMetadata().get(ContextAttributes.WEBHOOK_RESPONSE_JSON_SCHEMA_TEXT));
+        assertEquals("smart", message.getMetadata().get(ContextAttributes.WEBHOOK_RESPONSE_VALIDATION_MODEL_TIER));
+    }
+
+    @Test
+    void agentShouldRejectInvalidResponseSchemaBeforeDispatch() {
+        Map<String, Object> schema = Map.of("type", "invalid");
+        AgentRequest request = AgentRequest.builder()
+                .message("Answer in JSON")
+                .syncResponse(true)
+                .responseJsonSchema(schema)
+                .build();
+        doThrow(new WebhookResponseSchemaService.SchemaProcessingException("Invalid responseJsonSchema"))
+                .when(responseSchemaService).validateSchemaDefinition(schema);
+
+        ResponseEntity<?> response = controller.agent(toJsonBytes(request), new HttpHeaders()).block();
+
+        assertNotNull(response);
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals("Invalid responseJsonSchema", webhookBody(response).getErrorMessage());
+        verify(channelAdapter, never()).registerPendingRun(anyString(), anyString(), any(), any(), any());
+    }
+
+    @Test
+    void agentShouldRejectResponseSchemaWithoutSynchronousResponse() {
+        AgentRequest request = AgentRequest.builder()
+                .message("Answer in JSON")
+                .responseJsonSchema(aliceResponseSchema())
+                .build();
+
+        ResponseEntity<?> response = controller.agent(toJsonBytes(request), new HttpHeaders()).block();
+
+        assertNotNull(response);
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals("'responseJsonSchema' requires syncResponse=true", webhookBody(response).getErrorMessage());
+        verify(channelAdapter, never()).registerPendingRun(anyString(), anyString(), any(), any(), any());
+    }
+
+    @Test
+    void agentShouldReturnGatewayTimeoutWhenSchemaRepairBudgetExpires() {
+        Map<String, Object> schema = aliceResponseSchema();
+        AgentRequest request = AgentRequest.builder()
+                .message("Answer in Alice format")
+                .syncResponse(true)
+                .responseJsonSchema(schema)
+                .build();
+        when(channelAdapter.registerPendingRun(anyString(), anyString(), any(), any(), any()))
+                .thenReturn(CompletableFuture.completedFuture("Ready"));
+        when(responseSchemaService.renderSchema(schema)).thenReturn("{\"type\":\"object\"}");
+        when(responseSchemaService.validateAndRepair(eq("Ready"), eq(schema), any(), any(), any()))
+                .thenThrow(new WebhookResponseSchemaService.SchemaTimeoutException("Response schema repair timed out"));
+
+        ResponseEntity<?> response = controller.agent(toJsonBytes(request), new HttpHeaders()).block();
+
+        assertNotNull(response);
+        assertEquals(HttpStatus.GATEWAY_TIMEOUT, response.getStatusCode());
+        assertEquals("Synchronous webhook response timed out", webhookBody(response).getErrorMessage());
     }
 
     @Test
@@ -283,7 +401,7 @@ class WebhookControllerTest {
         when(deliveryTracker.registerPendingDelivery(anyString(), anyString(), anyString(), anyString()))
                 .thenReturn("delivery-special");
 
-        ResponseEntity<WebhookResponse> response = controller.agent(toJsonBytes(request), new HttpHeaders()).block();
+        ResponseEntity<?> response = controller.agent(toJsonBytes(request), new HttpHeaders()).block();
 
         assertNotNull(response);
         assertEquals(HttpStatus.ACCEPTED, response.getStatusCode());
@@ -298,11 +416,11 @@ class WebhookControllerTest {
                 .model("turbo")
                 .build();
 
-        ResponseEntity<WebhookResponse> response = controller.agent(toJsonBytes(request), new HttpHeaders()).block();
+        ResponseEntity<?> response = controller.agent(toJsonBytes(request), new HttpHeaders()).block();
 
         assertNotNull(response);
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
-        assertEquals("'model' must be a known tier id", response.getBody().getErrorMessage());
+        assertEquals("'model' must be a known tier id", webhookBody(response).getErrorMessage());
         verify(channelAdapter, never()).registerPendingRun(anyString(), anyString(), any(), any(), any());
     }
 
@@ -315,12 +433,12 @@ class WebhookControllerTest {
         doThrow(new IllegalArgumentException("callbackUrl must be a valid http(s) URL"))
                 .when(deliveryTracker).validateCallbackUrl("ftp://example.com/callback");
 
-        ResponseEntity<WebhookResponse> response = controller.agent(toJsonBytes(request), new HttpHeaders()).block();
+        ResponseEntity<?> response = controller.agent(toJsonBytes(request), new HttpHeaders()).block();
 
         assertNotNull(response);
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
-        assertEquals("error", response.getBody().getStatus());
-        assertEquals("callbackUrl must be a valid http(s) URL", response.getBody().getErrorMessage());
+        assertEquals("error", webhookBody(response).getStatus());
+        assertEquals("callbackUrl must be a valid http(s) URL", webhookBody(response).getErrorMessage());
 
         verify(channelAdapter, never()).registerPendingRun(anyString(), anyString(), anyString(), anyString(),
                 anyString());
@@ -341,7 +459,7 @@ class WebhookControllerTest {
                 .thenReturn("Push to myapp");
 
         byte[] body = "{}".getBytes();
-        ResponseEntity<WebhookResponse> response = controller.customHook("github-push", body, new HttpHeaders())
+        ResponseEntity<?> response = controller.customHook("github-push", body, new HttpHeaders())
                 .block();
 
         assertNotNull(response);
@@ -351,7 +469,7 @@ class WebhookControllerTest {
     @Test
     void customHookShouldReturn404ForUnknownMapping() {
         byte[] body = "{}".getBytes();
-        ResponseEntity<WebhookResponse> response = controller.customHook("unknown", body, new HttpHeaders()).block();
+        ResponseEntity<?> response = controller.customHook("unknown", body, new HttpHeaders()).block();
 
         assertNotNull(response);
         assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
@@ -369,7 +487,7 @@ class WebhookControllerTest {
         when(authenticator.authenticate(any(), any(), any())).thenReturn(false);
 
         byte[] body = "{}".getBytes();
-        ResponseEntity<WebhookResponse> response = controller.customHook("auth-fail", body, new HttpHeaders()).block();
+        ResponseEntity<?> response = controller.customHook("auth-fail", body, new HttpHeaders()).block();
 
         assertNotNull(response);
         assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
@@ -394,7 +512,7 @@ class WebhookControllerTest {
         when(authenticator.authenticate(any(), any(), any())).thenReturn(true);
 
         byte[] body = "this payload is way too large for the limit".getBytes();
-        ResponseEntity<WebhookResponse> response = controller.customHook("big", body, new HttpHeaders()).block();
+        ResponseEntity<?> response = controller.customHook("big", body, new HttpHeaders()).block();
 
         assertNotNull(response);
         assertEquals(HttpStatusCode.valueOf(413), response.getStatusCode());
@@ -413,12 +531,36 @@ class WebhookControllerTest {
         when(transformer.transform(any(), any())).thenReturn("Process: deploy");
 
         byte[] body = "{\"event\":\"deploy\"}".getBytes();
-        ResponseEntity<WebhookResponse> response = controller.customHook("agent-hook", body, new HttpHeaders())
+        ResponseEntity<?> response = controller.customHook("agent-hook", body, new HttpHeaders())
                 .block();
 
         assertNotNull(response);
         assertEquals(HttpStatus.ACCEPTED, response.getStatusCode());
-        assertNotNull(response.getBody().getRunId());
+        assertNotNull(webhookBody(response).getRunId());
+    }
+
+    @Test
+    void customHookAgentActionShouldReturnSynchronousResponseWhenConfigured() {
+        UserPreferences.HookMapping mapping = UserPreferences.HookMapping.builder()
+                .name("agent-hook")
+                .action("agent")
+                .messageTemplate("Process: {event}")
+                .syncResponse(true)
+                .build();
+        when(preferencesService.getPreferences()).thenReturn(buildPrefsWithMapping(mapping));
+        when(authenticator.authenticate(any(), any(), any())).thenReturn(true);
+        when(transformer.transform(any(), any())).thenReturn("Process: deploy");
+        when(channelAdapter.registerPendingRun(anyString(), anyString(), any(), any(), any()))
+                .thenReturn(CompletableFuture.completedFuture("Deployment done"));
+
+        byte[] body = "{\"event\":\"deploy\"}".getBytes();
+        ResponseEntity<?> response = controller.customHook("agent-hook", body, new HttpHeaders())
+                .block();
+
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals("completed", webhookBody(response).getStatus());
+        assertEquals("Deployment done", webhookBody(response).getResponse());
     }
 
     @Test
@@ -461,12 +603,12 @@ class WebhookControllerTest {
         when(transformer.transform(any(), any())).thenReturn("Process: deploy");
 
         byte[] body = "{\"event\":\"deploy\"}".getBytes();
-        ResponseEntity<WebhookResponse> response = controller.customHook("agent-hook", body, new HttpHeaders())
+        ResponseEntity<?> response = controller.customHook("agent-hook", body, new HttpHeaders())
                 .block();
 
         assertNotNull(response);
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
-        assertEquals("Webhook mapping model must be a known tier id", response.getBody().getErrorMessage());
+        assertEquals("Webhook mapping model must be a known tier id", webhookBody(response).getErrorMessage());
     }
 
     private UserPreferences buildEnabledPrefs() {
@@ -494,5 +636,18 @@ class WebhookControllerTest {
         } catch (Exception e) {
             throw new IllegalStateException("Failed to serialize test payload", e);
         }
+    }
+
+    private WebhookResponse webhookBody(ResponseEntity<?> response) {
+        return (WebhookResponse) response.getBody();
+    }
+
+    private Map<String, Object> aliceResponseSchema() {
+        return Map.of(
+                "type", "object",
+                "required", List.of("version", "response"),
+                "properties", Map.of(
+                        "version", Map.of("const", "1.0"),
+                        "response", Map.of("type", "object")));
     }
 }

--- a/src/test/java/me/golemcore/bot/adapter/inbound/webhook/WebhookControllerTest.java
+++ b/src/test/java/me/golemcore/bot/adapter/inbound/webhook/WebhookControllerTest.java
@@ -24,6 +24,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 
 import java.time.Duration;
@@ -33,6 +34,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -254,6 +256,7 @@ class WebhookControllerTest {
     void agentShouldReturnSynchronousResponseWhenRequested() {
         AgentRequest request = AgentRequest.builder()
                 .message("Answer directly")
+                .responseValidationModelTier("turbo")
                 .syncResponse(true)
                 .build();
         when(channelAdapter.registerPendingRun(anyString(), anyString(), any(), any(), any()))
@@ -263,18 +266,31 @@ class WebhookControllerTest {
 
         assertNotNull(response);
         assertEquals(HttpStatus.OK, response.getStatusCode());
-        assertEquals("completed", webhookBody(response).getStatus());
-        assertEquals("Direct answer", webhookBody(response).getResponse());
+        assertEquals(MediaType.TEXT_PLAIN, response.getHeaders().getContentType());
+        assertEquals("Direct answer", response.getBody());
+        assertNotNull(response.getHeaders().getFirst("X-Golemcore-Run-Id"));
+        assertNotNull(response.getHeaders().getFirst("X-Golemcore-Chat-Id"));
+        verify(responseSchemaService, never()).validateSchemaDefinition(any());
+        verify(responseSchemaService, never()).renderSchema(any());
+        verify(responseSchemaService, never()).validateAndRepair(any(), any(), any(), any(), any());
+
+        ArgumentCaptor<AgentLoop.InboundMessageEvent> captor = ArgumentCaptor
+                .forClass(AgentLoop.InboundMessageEvent.class);
+        verify(eventPublisher).publishEvent(captor.capture());
+        Map<String, Object> metadata = captor.getValue().message().getMetadata();
+        assertFalse(metadata.containsKey(ContextAttributes.WEBHOOK_RESPONSE_JSON_SCHEMA));
+        assertFalse(metadata.containsKey(ContextAttributes.WEBHOOK_RESPONSE_JSON_SCHEMA_TEXT));
+        assertFalse(metadata.containsKey(ContextAttributes.WEBHOOK_RESPONSE_VALIDATION_MODEL_TIER));
     }
 
     @Test
     void agentShouldReturnSchemaPayloadForSynchronousJsonSchema() {
-        Map<String, Object> schema = aliceResponseSchema();
+        Map<String, Object> schema = responseEnvelopeSchema();
         Map<String, Object> payload = Map.of(
                 "version", "1.0",
                 "response", Map.of("text", "Ready", "tts", "Ready", "end_session", true));
         AgentRequest request = AgentRequest.builder()
-                .message("Answer in Alice format")
+                .message("Answer in configured schema")
                 .model("coding")
                 .syncResponse(true)
                 .responseJsonSchema(schema)
@@ -312,7 +328,7 @@ class WebhookControllerTest {
 
     @Test
     void agentShouldRecordSynchronousSchemaValidationTraceSpan() {
-        Map<String, Object> schema = aliceResponseSchema();
+        Map<String, Object> schema = responseEnvelopeSchema();
         Map<String, Object> payload = Map.of(
                 "version", "1.0",
                 "response", Map.of("text", "Ready", "tts", "Ready", "end_session", true));
@@ -328,7 +344,7 @@ class WebhookControllerTest {
                 .rootKind("INGRESS")
                 .build();
         AgentRequest request = AgentRequest.builder()
-                .message("Answer in Alice format")
+                .message("Answer in configured schema")
                 .chatId("trace-chat")
                 .syncResponse(true)
                 .responseJsonSchema(schema)
@@ -379,7 +395,7 @@ class WebhookControllerTest {
     void agentShouldRejectResponseSchemaWithoutSynchronousResponse() {
         AgentRequest request = AgentRequest.builder()
                 .message("Answer in JSON")
-                .responseJsonSchema(aliceResponseSchema())
+                .responseJsonSchema(responseEnvelopeSchema())
                 .build();
 
         ResponseEntity<?> response = controller.agent(toJsonBytes(request), new HttpHeaders()).block();
@@ -392,9 +408,9 @@ class WebhookControllerTest {
 
     @Test
     void agentShouldReturnGatewayTimeoutWhenSchemaRepairBudgetExpires() {
-        Map<String, Object> schema = aliceResponseSchema();
+        Map<String, Object> schema = responseEnvelopeSchema();
         AgentRequest request = AgentRequest.builder()
-                .message("Answer in Alice format")
+                .message("Answer in configured schema")
                 .syncResponse(true)
                 .responseJsonSchema(schema)
                 .build();
@@ -621,8 +637,11 @@ class WebhookControllerTest {
 
         assertNotNull(response);
         assertEquals(HttpStatus.OK, response.getStatusCode());
-        assertEquals("completed", webhookBody(response).getStatus());
-        assertEquals("Deployment done", webhookBody(response).getResponse());
+        assertEquals(MediaType.TEXT_PLAIN, response.getHeaders().getContentType());
+        assertEquals("Deployment done", response.getBody());
+        verify(responseSchemaService, never()).validateSchemaDefinition(any());
+        verify(responseSchemaService, never()).renderSchema(any());
+        verify(responseSchemaService, never()).validateAndRepair(any(), any(), any(), any(), any());
     }
 
     @Test
@@ -704,7 +723,7 @@ class WebhookControllerTest {
         return (WebhookResponse) response.getBody();
     }
 
-    private Map<String, Object> aliceResponseSchema() {
+    private Map<String, Object> responseEnvelopeSchema() {
         return Map.of(
                 "type", "object",
                 "required", List.of("version", "response"),

--- a/src/test/java/me/golemcore/bot/adapter/inbound/webhook/WebhookHttpIntegrationTest.java
+++ b/src/test/java/me/golemcore/bot/adapter/inbound/webhook/WebhookHttpIntegrationTest.java
@@ -4,6 +4,7 @@ import me.golemcore.bot.adapter.inbound.web.security.DashboardSecurityConfig;
 import me.golemcore.bot.adapter.inbound.web.security.JwtAuthenticationFilter;
 import me.golemcore.bot.domain.model.Secret;
 import me.golemcore.bot.domain.model.UserPreferences;
+import me.golemcore.bot.domain.service.MemoryPresetService;
 import me.golemcore.bot.domain.service.UserPreferencesService;
 import me.golemcore.bot.infrastructure.config.BotProperties;
 import me.golemcore.bot.infrastructure.security.JwtTokenProvider;
@@ -60,6 +61,7 @@ class WebhookHttpIntegrationTest {
                 new WebhookPayloadTransformer(),
                 mock(WebhookDeliveryTracker.class),
                 mock(WebhookResponseSchemaService.class),
+                new MemoryPresetService(),
                 mock(ApplicationEventPublisher.class),
                 mock(me.golemcore.bot.port.outbound.SessionPort.class),
                 mock(me.golemcore.bot.domain.service.TraceService.class),

--- a/src/test/java/me/golemcore/bot/adapter/inbound/webhook/WebhookHttpIntegrationTest.java
+++ b/src/test/java/me/golemcore/bot/adapter/inbound/webhook/WebhookHttpIntegrationTest.java
@@ -61,6 +61,8 @@ class WebhookHttpIntegrationTest {
                 mock(WebhookDeliveryTracker.class),
                 mock(WebhookResponseSchemaService.class),
                 mock(ApplicationEventPublisher.class),
+                mock(me.golemcore.bot.port.outbound.SessionPort.class),
+                mock(me.golemcore.bot.domain.service.TraceService.class),
                 new InputSanitizer());
 
         JwtTokenProvider jwtTokenProvider = new JwtTokenProvider(properties);

--- a/src/test/java/me/golemcore/bot/adapter/inbound/webhook/WebhookHttpIntegrationTest.java
+++ b/src/test/java/me/golemcore/bot/adapter/inbound/webhook/WebhookHttpIntegrationTest.java
@@ -59,6 +59,7 @@ class WebhookHttpIntegrationTest {
                 mock(WebhookChannelAdapter.class),
                 new WebhookPayloadTransformer(),
                 mock(WebhookDeliveryTracker.class),
+                mock(WebhookResponseSchemaService.class),
                 mock(ApplicationEventPublisher.class),
                 new InputSanitizer());
 

--- a/src/test/java/me/golemcore/bot/adapter/inbound/webhook/WebhookResponseSchemaServiceTest.java
+++ b/src/test/java/me/golemcore/bot/adapter/inbound/webhook/WebhookResponseSchemaServiceTest.java
@@ -1,6 +1,5 @@
 package me.golemcore.bot.adapter.inbound.webhook;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import me.golemcore.bot.domain.model.LlmRequest;
 import me.golemcore.bot.domain.model.LlmResponse;
@@ -51,8 +50,8 @@ class WebhookResponseSchemaServiceTest {
                 "smart",
                 "coding");
 
-        JsonNode payload = assertInstanceOf(JsonNode.class, result.payload());
-        assertEquals("1.0", payload.path("version").asText());
+        Map<?, ?> payload = assertInstanceOf(Map.class, result.payload());
+        assertEquals("1.0", payload.get("version"));
         assertEquals(0, result.repairAttempts());
         verify(llmPort, never()).chat(any());
     }
@@ -97,8 +96,9 @@ class WebhookResponseSchemaServiceTest {
                 "smart",
                 "coding");
 
-        JsonNode payload = assertInstanceOf(JsonNode.class, result.payload());
-        assertEquals("Ready", payload.path("response").path("text").asText());
+        Map<?, ?> payload = assertInstanceOf(Map.class, result.payload());
+        Map<?, ?> response = assertInstanceOf(Map.class, payload.get("response"));
+        assertEquals("Ready", response.get("text"));
         assertEquals(1, result.repairAttempts());
 
         ArgumentCaptor<LlmRequest> requestCaptor = ArgumentCaptor.forClass(LlmRequest.class);
@@ -127,8 +127,9 @@ class WebhookResponseSchemaServiceTest {
                 "smart",
                 "coding");
 
-        JsonNode payload = assertInstanceOf(JsonNode.class, result.payload());
-        assertEquals("Ready", payload.path("response").path("tts").asText());
+        Map<?, ?> payload = assertInstanceOf(Map.class, result.payload());
+        Map<?, ?> response = assertInstanceOf(Map.class, payload.get("response"));
+        assertEquals("Ready", response.get("tts"));
         assertEquals(1, result.repairAttempts());
     }
 
@@ -144,8 +145,8 @@ class WebhookResponseSchemaServiceTest {
                 null,
                 null);
 
-        JsonNode payload = assertInstanceOf(JsonNode.class, result.payload());
-        assertEquals("1.0", payload.path("version").asText());
+        Map<?, ?> payload = assertInstanceOf(Map.class, result.payload());
+        assertEquals("1.0", payload.get("version"));
         verify(llmPort, never()).chat(any());
     }
 
@@ -157,8 +158,26 @@ class WebhookResponseSchemaServiceTest {
                 null,
                 null);
 
-        JsonNode payload = assertInstanceOf(JsonNode.class, result.payload());
-        assertEquals("ready", payload.get(0).asText());
+        List<?> payload = assertInstanceOf(List.class, result.payload());
+        assertEquals("ready", payload.get(0));
+        verify(llmPort, never()).chat(any());
+    }
+
+    @Test
+    void shouldAcceptDraft202012SchemaAsSerializablePayload() {
+        WebhookResponseSchemaService.SchemaResult result = service.validateAndRepair(
+                """
+                        {"version":"1.0","response":{"text":"Ready","tts":"Ready","end_session":true}}
+                        """,
+                strictResponseSchema(),
+                null,
+                null);
+
+        Map<?, ?> payload = assertInstanceOf(Map.class, result.payload());
+        Map<?, ?> response = assertInstanceOf(Map.class, payload.get("response"));
+        assertEquals("1.0", payload.get("version"));
+        assertEquals("Ready", response.get("text"));
+        assertEquals(0, result.repairAttempts());
         verify(llmPort, never()).chat(any());
     }
 
@@ -311,5 +330,25 @@ class WebhookResponseSchemaServiceTest {
                                         "text", Map.of("type", "string"),
                                         "tts", Map.of("type", "string"),
                                         "end_session", Map.of("type", "boolean")))));
+    }
+
+    private Map<String, Object> strictResponseSchema() {
+        return Map.of(
+                "$schema", "https://json-schema.org/draft/2020-12/schema",
+                "title", "Response Schema",
+                "type", "object",
+                "additionalProperties", false,
+                "required", List.of("version", "response"),
+                "properties", Map.of(
+                        "version", Map.of("type", "string", "const", "1.0"),
+                        "response", Map.of(
+                                "type", "object",
+                                "additionalProperties", false,
+                                "required", List.of("text", "tts", "end_session"),
+                                "properties", Map.of(
+                                        "text", Map.of("type", "string", "description", "Response text"),
+                                        "tts", Map.of("type", "string", "description", "Text to speak"),
+                                        "end_session", Map.of("type", "boolean",
+                                                "description", "Session completion flag")))));
     }
 }

--- a/src/test/java/me/golemcore/bot/adapter/inbound/webhook/WebhookResponseSchemaServiceTest.java
+++ b/src/test/java/me/golemcore/bot/adapter/inbound/webhook/WebhookResponseSchemaServiceTest.java
@@ -70,6 +70,21 @@ class WebhookResponseSchemaServiceTest {
     }
 
     @Test
+    void shouldRejectEmptySchemaDefinition() {
+        WebhookResponseSchemaService.SchemaProcessingException exception = assertThrows(
+                WebhookResponseSchemaService.SchemaProcessingException.class,
+                () -> service.validateSchemaDefinition(Map.of()));
+
+        assertTrue(exception.getMessage().contains("schema must not be empty"));
+
+        WebhookResponseSchemaService.SchemaProcessingException validationException = assertThrows(
+                WebhookResponseSchemaService.SchemaProcessingException.class,
+                () -> service.validateAndRepair("{}", Map.of(), null, null));
+
+        assertTrue(validationException.getMessage().contains("schema must not be empty"));
+    }
+
+    @Test
     void shouldRenderAndValidateSchemaDefinition() {
         service.validateSchemaDefinition(responseEnvelopeSchema());
 

--- a/src/test/java/me/golemcore/bot/adapter/inbound/webhook/WebhookResponseSchemaServiceTest.java
+++ b/src/test/java/me/golemcore/bot/adapter/inbound/webhook/WebhookResponseSchemaServiceTest.java
@@ -1,0 +1,315 @@
+package me.golemcore.bot.adapter.inbound.webhook;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import me.golemcore.bot.domain.model.LlmRequest;
+import me.golemcore.bot.domain.model.LlmResponse;
+import me.golemcore.bot.domain.service.ModelSelectionService;
+import me.golemcore.bot.port.outbound.LlmPort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class WebhookResponseSchemaServiceTest {
+
+    private ModelSelectionService modelSelectionService;
+    private LlmPort llmPort;
+    private WebhookResponseSchemaService service;
+
+    @BeforeEach
+    void setUp() {
+        modelSelectionService = mock(ModelSelectionService.class);
+        llmPort = mock(LlmPort.class);
+        service = new WebhookResponseSchemaService(new ObjectMapper(), modelSelectionService, llmPort);
+    }
+
+    @Test
+    void shouldAcceptValidJsonWithoutRepair() {
+        WebhookResponseSchemaService.SchemaResult result = service.validateAndRepair(
+                """
+                        {"version":"1.0","response":{"text":"Ready","tts":"Ready","end_session":true}}
+                        """,
+                aliceResponseSchema(),
+                "smart",
+                "coding");
+
+        JsonNode payload = assertInstanceOf(JsonNode.class, result.payload());
+        assertEquals("1.0", payload.path("version").asText());
+        assertEquals(0, result.repairAttempts());
+        verify(llmPort, never()).chat(any());
+    }
+
+    @Test
+    void shouldReturnRawResponseWhenNoSchemaConfigured() {
+        WebhookResponseSchemaService.SchemaResult result = service.validateAndRepair(
+                "plain response",
+                null,
+                null,
+                null);
+
+        assertEquals("plain response", result.payload());
+        assertEquals(0, result.repairAttempts());
+        verify(llmPort, never()).chat(any());
+    }
+
+    @Test
+    void shouldRenderAndValidateSchemaDefinition() {
+        service.validateSchemaDefinition(aliceResponseSchema());
+
+        String rendered = service.renderSchema(aliceResponseSchema());
+
+        assertTrue(rendered.contains("\"version\""));
+        verify(llmPort, never()).chat(any());
+    }
+
+    @Test
+    void shouldRepairInvalidJsonWithConfiguredTier() {
+        when(modelSelectionService.resolveForTier("smart"))
+                .thenReturn(new ModelSelectionService.ModelSelection("openai/gpt-test", "low"));
+        when(llmPort.chat(any()))
+                .thenReturn(CompletableFuture.completedFuture(LlmResponse.builder()
+                        .content("""
+                                {"version":"1.0","response":{"text":"Ready","tts":"Ready","end_session":true}}
+                                """)
+                        .build()));
+
+        WebhookResponseSchemaService.SchemaResult result = service.validateAndRepair(
+                "Ready",
+                aliceResponseSchema(),
+                "smart",
+                "coding");
+
+        JsonNode payload = assertInstanceOf(JsonNode.class, result.payload());
+        assertEquals("Ready", payload.path("response").path("text").asText());
+        assertEquals(1, result.repairAttempts());
+
+        ArgumentCaptor<LlmRequest> requestCaptor = ArgumentCaptor.forClass(LlmRequest.class);
+        verify(llmPort).chat(requestCaptor.capture());
+        assertEquals("openai/gpt-test", requestCaptor.getValue().getModel());
+        assertEquals("low", requestCaptor.getValue().getReasoningEffort());
+        assertEquals("smart", requestCaptor.getValue().getModelTier());
+    }
+
+    @Test
+    void shouldRepairSchemaValidationErrors() {
+        when(modelSelectionService.resolveForTier("smart"))
+                .thenReturn(new ModelSelectionService.ModelSelection("openai/gpt-test", "low"));
+        when(llmPort.chat(any()))
+                .thenReturn(CompletableFuture.completedFuture(LlmResponse.builder()
+                        .content("""
+                                {"version":"1.0","response":{"text":"Ready","tts":"Ready","end_session":true}}
+                                """)
+                        .build()));
+
+        WebhookResponseSchemaService.SchemaResult result = service.validateAndRepair(
+                """
+                        {"version":"1.0"}
+                        """,
+                aliceResponseSchema(),
+                "smart",
+                "coding");
+
+        JsonNode payload = assertInstanceOf(JsonNode.class, result.payload());
+        assertEquals("Ready", payload.path("response").path("tts").asText());
+        assertEquals(1, result.repairAttempts());
+    }
+
+    @Test
+    void shouldAcceptJsonFromMarkdownFence() {
+        WebhookResponseSchemaService.SchemaResult result = service.validateAndRepair(
+                """
+                        ```json
+                        {"version":"1.0","response":{"text":"Ready","tts":"Ready","end_session":true}}
+                        ```
+                        """,
+                aliceResponseSchema(),
+                null,
+                null);
+
+        JsonNode payload = assertInstanceOf(JsonNode.class, result.payload());
+        assertEquals("1.0", payload.path("version").asText());
+        verify(llmPort, never()).chat(any());
+    }
+
+    @Test
+    void shouldAcceptArrayPayloadExtractedFromProse() {
+        WebhookResponseSchemaService.SchemaResult result = service.validateAndRepair(
+                "Result: [\"ready\"] done",
+                Map.of("type", "array", "items", Map.of("type", "string")),
+                null,
+                null);
+
+        JsonNode payload = assertInstanceOf(JsonNode.class, result.payload());
+        assertEquals("ready", payload.get(0).asText());
+        verify(llmPort, never()).chat(any());
+    }
+
+    @Test
+    void shouldFailAfterThreeUnsuccessfulRepairAttempts() {
+        when(modelSelectionService.resolveForTier("smart"))
+                .thenReturn(new ModelSelectionService.ModelSelection("openai/gpt-test", "low"));
+        when(llmPort.chat(any()))
+                .thenReturn(CompletableFuture.completedFuture(LlmResponse.builder()
+                        .content("""
+                                {"version":"wrong"}
+                                """)
+                        .build()));
+
+        WebhookResponseSchemaService.SchemaProcessingException exception = assertThrows(
+                WebhookResponseSchemaService.SchemaProcessingException.class,
+                () -> service.validateAndRepair("Ready", aliceResponseSchema(), "smart", null));
+
+        assertTrue(exception.getMessage().contains("repair attempts"));
+        verify(llmPort, times(3)).chat(any());
+    }
+
+    @Test
+    void shouldRejectRepairWhenBudgetIsExhausted() {
+        WebhookResponseSchemaService.SchemaTimeoutException exception = assertThrows(
+                WebhookResponseSchemaService.SchemaTimeoutException.class,
+                () -> service.validateAndRepair("Ready", aliceResponseSchema(), "smart", null, Duration.ZERO));
+
+        assertTrue(exception.getMessage().contains("timed out"));
+        verify(llmPort, never()).chat(any());
+    }
+
+    @Test
+    void shouldRejectEmptyRepairResponse() {
+        when(modelSelectionService.resolveForTier("smart"))
+                .thenReturn(new ModelSelectionService.ModelSelection("openai/gpt-test", "low"));
+        when(llmPort.chat(any()))
+                .thenReturn(CompletableFuture.completedFuture(LlmResponse.builder()
+                        .content(" ")
+                        .build()));
+
+        WebhookResponseSchemaService.SchemaProcessingException exception = assertThrows(
+                WebhookResponseSchemaService.SchemaProcessingException.class,
+                () -> service.validateAndRepair("Ready", aliceResponseSchema(), "smart", null));
+
+        assertTrue(exception.getMessage().contains("empty response"));
+    }
+
+    @Test
+    void shouldUseFallbackTierWhenValidationTierIsBlank() {
+        when(modelSelectionService.resolveForTier("coding"))
+                .thenReturn(new ModelSelectionService.ModelSelection("openai/gpt-coding", "medium"));
+        when(llmPort.chat(any()))
+                .thenReturn(CompletableFuture.completedFuture(LlmResponse.builder()
+                        .content("""
+                                {"version":"1.0","response":{"text":"Ready","tts":"Ready","end_session":true}}
+                                """)
+                        .build()));
+
+        service.validateAndRepair("Ready", aliceResponseSchema(), " ", "coding");
+
+        ArgumentCaptor<LlmRequest> requestCaptor = ArgumentCaptor.forClass(LlmRequest.class);
+        verify(llmPort).chat(requestCaptor.capture());
+        assertEquals("coding", requestCaptor.getValue().getModelTier());
+    }
+
+    @Test
+    void shouldUseBalancedTierWhenNoTierIsConfigured() {
+        when(modelSelectionService.resolveForTier("balanced"))
+                .thenReturn(new ModelSelectionService.ModelSelection("openai/gpt-balanced", "low"));
+        when(llmPort.chat(any()))
+                .thenReturn(CompletableFuture.completedFuture(LlmResponse.builder()
+                        .content("""
+                                {"version":"1.0","response":{"text":"Ready","tts":"Ready","end_session":true}}
+                                """)
+                        .build()));
+
+        service.validateAndRepair("Ready", aliceResponseSchema(), null, null);
+
+        ArgumentCaptor<LlmRequest> requestCaptor = ArgumentCaptor.forClass(LlmRequest.class);
+        verify(llmPort).chat(requestCaptor.capture());
+        assertEquals("balanced", requestCaptor.getValue().getModelTier());
+    }
+
+    @Test
+    void shouldReportRepairExecutionFailure() {
+        when(modelSelectionService.resolveForTier("smart"))
+                .thenReturn(new ModelSelectionService.ModelSelection("openai/gpt-test", "low"));
+        when(llmPort.chat(any()))
+                .thenReturn(CompletableFuture.failedFuture(new IllegalStateException("downstream unavailable")));
+
+        WebhookResponseSchemaService.SchemaProcessingException exception = assertThrows(
+                WebhookResponseSchemaService.SchemaProcessingException.class,
+                () -> service.validateAndRepair("Ready", aliceResponseSchema(), "smart", null));
+
+        assertTrue(exception.getMessage().contains("repair failed"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldPreserveInterruptedFlagWhenRepairIsInterrupted() throws Exception {
+        CompletableFuture<LlmResponse> responseFuture = mock(CompletableFuture.class);
+        when(responseFuture.get(anyLong(), any()))
+                .thenThrow(new InterruptedException("stop"));
+        when(modelSelectionService.resolveForTier("smart"))
+                .thenReturn(new ModelSelectionService.ModelSelection("openai/gpt-test", "low"));
+        when(llmPort.chat(any())).thenReturn(responseFuture);
+
+        WebhookResponseSchemaService.SchemaProcessingException exception = assertThrows(
+                WebhookResponseSchemaService.SchemaProcessingException.class,
+                () -> service.validateAndRepair("Ready", aliceResponseSchema(), "smart", null));
+
+        assertTrue(exception.getMessage().contains("interrupted"));
+        assertTrue(Thread.currentThread().isInterrupted());
+        Thread.interrupted();
+    }
+
+    @Test
+    void shouldRejectInvalidSchemaDefinition() {
+        WebhookResponseSchemaService.SchemaProcessingException exception = assertThrows(
+                WebhookResponseSchemaService.SchemaProcessingException.class,
+                () -> service.validateSchemaDefinition(Map.of("type", "invalid")));
+
+        assertTrue(exception.getMessage().contains("Invalid responseJsonSchema"));
+        verify(llmPort, never()).chat(any());
+    }
+
+    @Test
+    void shouldRejectSelfReferentialSchemaRendering() {
+        Map<String, Object> schema = new HashMap<>();
+        schema.put("self", schema);
+
+        WebhookResponseSchemaService.SchemaProcessingException exception = assertThrows(
+                WebhookResponseSchemaService.SchemaProcessingException.class,
+                () -> service.renderSchema(schema));
+
+        assertTrue(exception.getMessage().contains("Failed to render responseJsonSchema"));
+    }
+
+    private Map<String, Object> aliceResponseSchema() {
+        return Map.of(
+                "type", "object",
+                "required", List.of("version", "response"),
+                "properties", Map.of(
+                        "version", Map.of("const", "1.0"),
+                        "response", Map.of(
+                                "type", "object",
+                                "required", List.of("text", "tts", "end_session"),
+                                "properties", Map.of(
+                                        "text", Map.of("type", "string"),
+                                        "tts", Map.of("type", "string"),
+                                        "end_session", Map.of("type", "boolean")))));
+    }
+}

--- a/src/test/java/me/golemcore/bot/adapter/inbound/webhook/WebhookResponseSchemaServiceTest.java
+++ b/src/test/java/me/golemcore/bot/adapter/inbound/webhook/WebhookResponseSchemaServiceTest.java
@@ -46,7 +46,7 @@ class WebhookResponseSchemaServiceTest {
                 """
                         {"version":"1.0","response":{"text":"Ready","tts":"Ready","end_session":true}}
                         """,
-                aliceResponseSchema(),
+                responseEnvelopeSchema(),
                 "smart",
                 "coding");
 
@@ -71,9 +71,9 @@ class WebhookResponseSchemaServiceTest {
 
     @Test
     void shouldRenderAndValidateSchemaDefinition() {
-        service.validateSchemaDefinition(aliceResponseSchema());
+        service.validateSchemaDefinition(responseEnvelopeSchema());
 
-        String rendered = service.renderSchema(aliceResponseSchema());
+        String rendered = service.renderSchema(responseEnvelopeSchema());
 
         assertTrue(rendered.contains("\"version\""));
         verify(llmPort, never()).chat(any());
@@ -92,7 +92,7 @@ class WebhookResponseSchemaServiceTest {
 
         WebhookResponseSchemaService.SchemaResult result = service.validateAndRepair(
                 "Ready",
-                aliceResponseSchema(),
+                responseEnvelopeSchema(),
                 "smart",
                 "coding");
 
@@ -123,7 +123,7 @@ class WebhookResponseSchemaServiceTest {
                 """
                         {"version":"1.0"}
                         """,
-                aliceResponseSchema(),
+                responseEnvelopeSchema(),
                 "smart",
                 "coding");
 
@@ -141,7 +141,7 @@ class WebhookResponseSchemaServiceTest {
                         {"version":"1.0","response":{"text":"Ready","tts":"Ready","end_session":true}}
                         ```
                         """,
-                aliceResponseSchema(),
+                responseEnvelopeSchema(),
                 null,
                 null);
 
@@ -194,7 +194,7 @@ class WebhookResponseSchemaServiceTest {
 
         WebhookResponseSchemaService.SchemaProcessingException exception = assertThrows(
                 WebhookResponseSchemaService.SchemaProcessingException.class,
-                () -> service.validateAndRepair("Ready", aliceResponseSchema(), "smart", null));
+                () -> service.validateAndRepair("Ready", responseEnvelopeSchema(), "smart", null));
 
         assertTrue(exception.getMessage().contains("repair attempts"));
         verify(llmPort, times(3)).chat(any());
@@ -204,7 +204,7 @@ class WebhookResponseSchemaServiceTest {
     void shouldRejectRepairWhenBudgetIsExhausted() {
         WebhookResponseSchemaService.SchemaTimeoutException exception = assertThrows(
                 WebhookResponseSchemaService.SchemaTimeoutException.class,
-                () -> service.validateAndRepair("Ready", aliceResponseSchema(), "smart", null, Duration.ZERO));
+                () -> service.validateAndRepair("Ready", responseEnvelopeSchema(), "smart", null, Duration.ZERO));
 
         assertTrue(exception.getMessage().contains("timed out"));
         verify(llmPort, never()).chat(any());
@@ -221,7 +221,7 @@ class WebhookResponseSchemaServiceTest {
 
         WebhookResponseSchemaService.SchemaProcessingException exception = assertThrows(
                 WebhookResponseSchemaService.SchemaProcessingException.class,
-                () -> service.validateAndRepair("Ready", aliceResponseSchema(), "smart", null));
+                () -> service.validateAndRepair("Ready", responseEnvelopeSchema(), "smart", null));
 
         assertTrue(exception.getMessage().contains("empty response"));
     }
@@ -237,7 +237,7 @@ class WebhookResponseSchemaServiceTest {
                                 """)
                         .build()));
 
-        service.validateAndRepair("Ready", aliceResponseSchema(), " ", "coding");
+        service.validateAndRepair("Ready", responseEnvelopeSchema(), " ", "coding");
 
         ArgumentCaptor<LlmRequest> requestCaptor = ArgumentCaptor.forClass(LlmRequest.class);
         verify(llmPort).chat(requestCaptor.capture());
@@ -255,7 +255,7 @@ class WebhookResponseSchemaServiceTest {
                                 """)
                         .build()));
 
-        service.validateAndRepair("Ready", aliceResponseSchema(), null, null);
+        service.validateAndRepair("Ready", responseEnvelopeSchema(), null, null);
 
         ArgumentCaptor<LlmRequest> requestCaptor = ArgumentCaptor.forClass(LlmRequest.class);
         verify(llmPort).chat(requestCaptor.capture());
@@ -271,7 +271,7 @@ class WebhookResponseSchemaServiceTest {
 
         WebhookResponseSchemaService.SchemaProcessingException exception = assertThrows(
                 WebhookResponseSchemaService.SchemaProcessingException.class,
-                () -> service.validateAndRepair("Ready", aliceResponseSchema(), "smart", null));
+                () -> service.validateAndRepair("Ready", responseEnvelopeSchema(), "smart", null));
 
         assertTrue(exception.getMessage().contains("repair failed"));
     }
@@ -288,7 +288,7 @@ class WebhookResponseSchemaServiceTest {
 
         WebhookResponseSchemaService.SchemaProcessingException exception = assertThrows(
                 WebhookResponseSchemaService.SchemaProcessingException.class,
-                () -> service.validateAndRepair("Ready", aliceResponseSchema(), "smart", null));
+                () -> service.validateAndRepair("Ready", responseEnvelopeSchema(), "smart", null));
 
         assertTrue(exception.getMessage().contains("interrupted"));
         assertTrue(Thread.currentThread().isInterrupted());
@@ -317,7 +317,7 @@ class WebhookResponseSchemaServiceTest {
         assertTrue(exception.getMessage().contains("Failed to render responseJsonSchema"));
     }
 
-    private Map<String, Object> aliceResponseSchema() {
+    private Map<String, Object> responseEnvelopeSchema() {
         return Map.of(
                 "type", "object",
                 "required", List.of("version", "response"),

--- a/src/test/java/me/golemcore/bot/adapter/outbound/schema/NetworkntResponseJsonSchemaValidatorAdapterTest.java
+++ b/src/test/java/me/golemcore/bot/adapter/outbound/schema/NetworkntResponseJsonSchemaValidatorAdapterTest.java
@@ -1,0 +1,42 @@
+package me.golemcore.bot.adapter.outbound.schema;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class NetworkntResponseJsonSchemaValidatorAdapterTest {
+
+    private NetworkntResponseJsonSchemaValidatorAdapter adapter;
+
+    @BeforeEach
+    void setUp() {
+        adapter = new NetworkntResponseJsonSchemaValidatorAdapter(new ObjectMapper());
+    }
+
+    @Test
+    void shouldAcceptDraft202012ResponseSchema() {
+        Map<String, Object> schema = Map.of(
+                "$schema", "https://json-schema.org/draft/2020-12/schema",
+                "type", "object",
+                "required", List.of("version"),
+                "properties", Map.of(
+                        "version", Map.of("type", "string", "const", "1.0")));
+
+        assertDoesNotThrow(() -> adapter.validateResponseJsonSchema(schema));
+    }
+
+    @Test
+    void shouldRejectInvalidResponseSchemaType() {
+        IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
+                () -> adapter.validateResponseJsonSchema(Map.of("type", "invalid")));
+
+        assertTrue(error.getMessage().contains("Invalid responseJsonSchema"));
+    }
+}

--- a/src/test/java/me/golemcore/bot/adapter/outbound/schema/NetworkntResponseJsonSchemaValidatorAdapterTest.java
+++ b/src/test/java/me/golemcore/bot/adapter/outbound/schema/NetworkntResponseJsonSchemaValidatorAdapterTest.java
@@ -39,4 +39,12 @@ class NetworkntResponseJsonSchemaValidatorAdapterTest {
 
         assertTrue(error.getMessage().contains("Invalid responseJsonSchema"));
     }
+
+    @Test
+    void shouldRejectEmptyResponseSchema() {
+        IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
+                () -> adapter.validateResponseJsonSchema(Map.of()));
+
+        assertTrue(error.getMessage().contains("schema must not be empty"));
+    }
 }

--- a/src/test/java/me/golemcore/bot/application/command/ModelSelectionCommandServiceTest.java
+++ b/src/test/java/me/golemcore/bot/application/command/ModelSelectionCommandServiceTest.java
@@ -1,16 +1,20 @@
 package me.golemcore.bot.application.command;
 
+import me.golemcore.bot.domain.model.AgentSession;
+import me.golemcore.bot.domain.model.ContextAttributes;
 import me.golemcore.bot.domain.model.ModelTierCatalog;
 import me.golemcore.bot.domain.model.UserPreferences;
 import me.golemcore.bot.domain.service.ModelSelectionService;
 import me.golemcore.bot.domain.service.RuntimeConfigService;
 import me.golemcore.bot.domain.service.UserPreferencesService;
+import me.golemcore.bot.port.outbound.SessionPort;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -18,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -28,6 +33,7 @@ class ModelSelectionCommandServiceTest {
     private UserPreferencesService preferencesService;
     private ModelSelectionService modelSelectionService;
     private RuntimeConfigService runtimeConfigService;
+    private SessionPort sessionPort;
     private UserPreferences preferences;
     private ModelSelectionCommandService service;
 
@@ -36,11 +42,14 @@ class ModelSelectionCommandServiceTest {
         preferencesService = mock(UserPreferencesService.class);
         modelSelectionService = mock(ModelSelectionService.class);
         runtimeConfigService = mock(RuntimeConfigService.class);
+        sessionPort = mock(SessionPort.class);
         preferences = UserPreferences.builder()
                 .tierOverrides(new LinkedHashMap<>())
                 .build();
         when(preferencesService.getPreferences()).thenReturn(preferences);
-        service = new ModelSelectionCommandService(preferencesService, modelSelectionService, runtimeConfigService);
+        when(sessionPort.get(anyString())).thenReturn(Optional.empty());
+        service = new ModelSelectionCommandService(preferencesService, modelSelectionService, runtimeConfigService,
+                sessionPort);
     }
 
     @Test
@@ -57,6 +66,26 @@ class ModelSelectionCommandServiceTest {
     }
 
     @Test
+    void shouldShowCurrentTierFromSessionSettingsWhenSessionIsProvided() {
+        AgentSession session = AgentSession.builder()
+                .id("web:conv-1")
+                .channelType("web")
+                .chatId("conv-1")
+                .metadata(new LinkedHashMap<>(Map.of(
+                        ContextAttributes.SESSION_MODEL_TIER, "deep",
+                        ContextAttributes.SESSION_MODEL_TIER_FORCE, true)))
+                .build();
+        when(sessionPort.get("web:conv-1")).thenReturn(Optional.of(session));
+
+        ModelSelectionCommandService.CurrentTier result = assertInstanceOf(
+                ModelSelectionCommandService.CurrentTier.class,
+                service.handleTier(new ModelSelectionCommandService.ShowTierStatus("web:conv-1")));
+
+        assertEquals("deep", result.tier());
+        assertTrue(result.force());
+    }
+
+    @Test
     void shouldSetTierAndForceWhenRequested() {
         ModelSelectionCommandService.TierUpdated result = assertInstanceOf(
                 ModelSelectionCommandService.TierUpdated.class,
@@ -67,6 +96,49 @@ class ModelSelectionCommandServiceTest {
         assertEquals("smart", preferences.getModelTier());
         assertTrue(preferences.isTierForce());
         verify(preferencesService).savePreferences(preferences);
+    }
+
+    @Test
+    void shouldSetTierOnSessionWhenSessionIsProvided() {
+        AgentSession session = AgentSession.builder()
+                .id("web:conv-1")
+                .channelType("web")
+                .chatId("conv-1")
+                .metadata(new LinkedHashMap<>())
+                .build();
+        when(sessionPort.get("web:conv-1")).thenReturn(Optional.of(session));
+
+        ModelSelectionCommandService.TierUpdated result = assertInstanceOf(
+                ModelSelectionCommandService.TierUpdated.class,
+                service.handleTier(new ModelSelectionCommandService.SetTierSelection("smart", true, "web:conv-1")));
+
+        assertEquals("smart", result.tier());
+        assertTrue(result.force());
+        assertEquals("smart", session.getMetadata().get(ContextAttributes.SESSION_MODEL_TIER));
+        assertEquals(true, session.getMetadata().get(ContextAttributes.SESSION_MODEL_TIER_FORCE));
+        verify(sessionPort).save(session);
+        verify(preferencesService, never()).savePreferences(any());
+    }
+
+    @Test
+    void shouldCreateSessionBeforePersistingTierWhenSessionIsNotLoaded() {
+        AgentSession session = AgentSession.builder()
+                .id("web:conv-2")
+                .channelType("web")
+                .chatId("conv-2")
+                .metadata(new LinkedHashMap<>())
+                .build();
+        when(sessionPort.get("web:conv-2")).thenReturn(Optional.empty());
+        when(sessionPort.getOrCreate("web", "conv-2")).thenReturn(session);
+
+        ModelSelectionCommandService.TierUpdated result = assertInstanceOf(
+                ModelSelectionCommandService.TierUpdated.class,
+                service.handleTier(new ModelSelectionCommandService.SetTierSelection("coding", false, "web:conv-2")));
+
+        assertEquals("coding", result.tier());
+        assertEquals("coding", session.getMetadata().get(ContextAttributes.SESSION_MODEL_TIER));
+        assertEquals(false, session.getMetadata().get(ContextAttributes.SESSION_MODEL_TIER_FORCE));
+        verify(sessionPort).save(session);
     }
 
     @Test

--- a/src/test/java/me/golemcore/bot/application/settings/RuntimeSettingsValidatorTest.java
+++ b/src/test/java/me/golemcore/bot/application/settings/RuntimeSettingsValidatorTest.java
@@ -273,12 +273,30 @@ class RuntimeSettingsValidatorTest {
                 .mappings(List.of(UserPreferences.HookMapping.builder()
                         .name("build")
                         .model("default")
+                        .responseValidationModelTier("SMART")
+                        .syncResponse(true)
                         .build()))
                 .build();
 
         validator.validateWebhookConfig(webhookConfig);
 
         assertNull(webhookConfig.getMappings().getFirst().getModel());
+        assertEquals("smart", webhookConfig.getMappings().getFirst().getResponseValidationModelTier());
+    }
+
+    @Test
+    void shouldRejectWebhookResponseSchemaWithoutSynchronousResponse() {
+        UserPreferences.WebhookConfig webhookConfig = UserPreferences.WebhookConfig.builder()
+                .mappings(List.of(UserPreferences.HookMapping.builder()
+                        .name("build")
+                        .responseJsonSchema(Map.of("type", "object"))
+                        .build()))
+                .build();
+
+        IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
+                () -> validator.validateWebhookConfig(webhookConfig));
+
+        assertEquals("webhooks.mapping.responseJsonSchema requires syncResponse=true", error.getMessage());
     }
 
     @Test

--- a/src/test/java/me/golemcore/bot/application/settings/RuntimeSettingsValidatorTest.java
+++ b/src/test/java/me/golemcore/bot/application/settings/RuntimeSettingsValidatorTest.java
@@ -345,6 +345,40 @@ class RuntimeSettingsValidatorTest {
     }
 
     @Test
+    void shouldDefaultWebhookMemoryPresetToDisabled() {
+        UserPreferences.WebhookConfig webhookConfig = UserPreferences.WebhookConfig.builder()
+                .memoryPreset(null)
+                .build();
+
+        validator.validateWebhookConfig(webhookConfig);
+
+        assertEquals("disabled", webhookConfig.getMemoryPreset());
+    }
+
+    @Test
+    void shouldNormalizeWebhookMemoryPreset() {
+        UserPreferences.WebhookConfig webhookConfig = UserPreferences.WebhookConfig.builder()
+                .memoryPreset(" GENERAL_CHAT ")
+                .build();
+
+        validator.validateWebhookConfig(webhookConfig);
+
+        assertEquals("general_chat", webhookConfig.getMemoryPreset());
+    }
+
+    @Test
+    void shouldRejectUnknownWebhookMemoryPreset() {
+        UserPreferences.WebhookConfig webhookConfig = UserPreferences.WebhookConfig.builder()
+                .memoryPreset("unknown")
+                .build();
+
+        IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
+                () -> validator.validateWebhookConfig(webhookConfig));
+
+        assertEquals("webhooks.memoryPreset must be a known memory preset id", error.getMessage());
+    }
+
+    @Test
     void shouldRejectWebhookResponseSchemaWithoutSynchronousResponse() {
         UserPreferences.WebhookConfig webhookConfig = UserPreferences.WebhookConfig.builder()
                 .mappings(List.of(UserPreferences.HookMapping.builder()
@@ -357,6 +391,23 @@ class RuntimeSettingsValidatorTest {
                 () -> validator.validateWebhookConfig(webhookConfig));
 
         assertEquals("webhooks.mapping.responseJsonSchema requires syncResponse=true", error.getMessage());
+    }
+
+    @Test
+    void shouldRejectEmptyWebhookResponseSchema() {
+        UserPreferences.WebhookConfig webhookConfig = UserPreferences.WebhookConfig.builder()
+                .mappings(List.of(UserPreferences.HookMapping.builder()
+                        .name("build")
+                        .responseJsonSchema(Map.of())
+                        .syncResponse(true)
+                        .build()))
+                .build();
+
+        IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
+                () -> validator.validateWebhookConfig(webhookConfig));
+
+        assertEquals("webhooks.mapping.responseJsonSchema must not be empty", error.getMessage());
+        verify(responseJsonSchemaValidatorPort, never()).validateResponseJsonSchema(any());
     }
 
     @Test

--- a/src/test/java/me/golemcore/bot/application/settings/RuntimeSettingsValidatorTest.java
+++ b/src/test/java/me/golemcore/bot/application/settings/RuntimeSettingsValidatorTest.java
@@ -4,6 +4,7 @@ import me.golemcore.bot.domain.model.RuntimeConfig;
 import me.golemcore.bot.domain.model.UserPreferences;
 import me.golemcore.bot.domain.service.ModelSelectionService;
 import me.golemcore.bot.adapter.outbound.voice.PluginVoiceProviderCatalogAdapter;
+import me.golemcore.bot.port.outbound.ResponseJsonSchemaValidatorPort;
 import me.golemcore.bot.port.outbound.VoiceProviderCatalogPort;
 import me.golemcore.bot.plugin.runtime.SttProviderRegistry;
 import me.golemcore.bot.plugin.runtime.TtsProviderRegistry;
@@ -21,13 +22,18 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class RuntimeSettingsValidatorTest {
 
     private ModelSelectionService modelSelectionService;
     private VoiceProviderCatalogPort voiceProviderCatalogPort;
+    private ResponseJsonSchemaValidatorPort responseJsonSchemaValidatorPort;
     private RuntimeSettingsValidator validator;
 
     @BeforeEach
@@ -35,9 +41,11 @@ class RuntimeSettingsValidatorTest {
         modelSelectionService = mock(ModelSelectionService.class);
         voiceProviderCatalogPort = new PluginVoiceProviderCatalogAdapter(new SttProviderRegistry(),
                 new TtsProviderRegistry());
+        responseJsonSchemaValidatorPort = mock(ResponseJsonSchemaValidatorPort.class);
         validator = new RuntimeSettingsValidator(
                 modelSelectionService,
-                voiceProviderCatalogPort);
+                voiceProviderCatalogPort,
+                responseJsonSchemaValidatorPort);
     }
 
     @Test
@@ -273,6 +281,7 @@ class RuntimeSettingsValidatorTest {
                 .mappings(List.of(UserPreferences.HookMapping.builder()
                         .name("build")
                         .model("default")
+                        .responseJsonSchema(Map.of("type", "object"))
                         .responseValidationModelTier("SMART")
                         .syncResponse(true)
                         .build()))
@@ -282,6 +291,57 @@ class RuntimeSettingsValidatorTest {
 
         assertNull(webhookConfig.getMappings().getFirst().getModel());
         assertEquals("smart", webhookConfig.getMappings().getFirst().getResponseValidationModelTier());
+    }
+
+    @Test
+    void shouldValidateWebhookResponseSchemaWhenConfigured() {
+        Map<String, Object> responseJsonSchema = Map.of("type", "object");
+        UserPreferences.WebhookConfig webhookConfig = UserPreferences.WebhookConfig.builder()
+                .mappings(List.of(UserPreferences.HookMapping.builder()
+                        .name("build")
+                        .responseJsonSchema(responseJsonSchema)
+                        .syncResponse(true)
+                        .build()))
+                .build();
+
+        validator.validateWebhookConfig(webhookConfig);
+
+        verify(responseJsonSchemaValidatorPort).validateResponseJsonSchema(responseJsonSchema);
+    }
+
+    @Test
+    void shouldRejectInvalidWebhookResponseSchema() {
+        Map<String, Object> responseJsonSchema = Map.of("type", "invalid");
+        UserPreferences.WebhookConfig webhookConfig = UserPreferences.WebhookConfig.builder()
+                .mappings(List.of(UserPreferences.HookMapping.builder()
+                        .name("build")
+                        .responseJsonSchema(responseJsonSchema)
+                        .syncResponse(true)
+                        .build()))
+                .build();
+        doThrow(new IllegalArgumentException("Invalid responseJsonSchema"))
+                .when(responseJsonSchemaValidatorPort).validateResponseJsonSchema(responseJsonSchema);
+
+        IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
+                () -> validator.validateWebhookConfig(webhookConfig));
+
+        assertEquals("Invalid responseJsonSchema", error.getMessage());
+    }
+
+    @Test
+    void shouldClearWebhookSchemaValidationTierWhenResponseSchemaIsMissing() {
+        UserPreferences.WebhookConfig webhookConfig = UserPreferences.WebhookConfig.builder()
+                .mappings(List.of(UserPreferences.HookMapping.builder()
+                        .name("build")
+                        .responseValidationModelTier("SMART")
+                        .syncResponse(true)
+                        .build()))
+                .build();
+
+        validator.validateWebhookConfig(webhookConfig);
+
+        assertNull(webhookConfig.getMappings().getFirst().getResponseValidationModelTier());
+        verify(responseJsonSchemaValidatorPort, never()).validateResponseJsonSchema(any());
     }
 
     @Test

--- a/src/test/java/me/golemcore/bot/domain/context/layer/MemoryLayerTest.java
+++ b/src/test/java/me/golemcore/bot/domain/context/layer/MemoryLayerTest.java
@@ -6,10 +6,13 @@ import me.golemcore.bot.domain.model.AgentContext;
 import me.golemcore.bot.domain.model.AgentSession;
 import me.golemcore.bot.domain.model.ContextAttributes;
 import me.golemcore.bot.domain.model.MemoryPack;
+import me.golemcore.bot.domain.model.MemoryQuery;
 import me.golemcore.bot.domain.model.Message;
+import me.golemcore.bot.domain.service.MemoryPresetService;
 import me.golemcore.bot.domain.service.RuntimeConfigService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import java.util.List;
 import java.util.Map;
@@ -19,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class MemoryLayerTest {
@@ -31,12 +35,25 @@ class MemoryLayerTest {
     void setUp() {
         memoryComponent = mock(MemoryComponent.class);
         runtimeConfigService = mock(RuntimeConfigService.class);
-        layer = new MemoryLayer(memoryComponent, runtimeConfigService);
+        layer = new MemoryLayer(memoryComponent, runtimeConfigService, new MemoryPresetService());
     }
 
     @Test
     void shouldAlwaysApply() {
         assertTrue(layer.appliesTo(AgentContext.builder().build()));
+    }
+
+    @Test
+    void shouldSkipWhenMemoryPresetIsDisabled() {
+        AgentContext context = AgentContext.builder()
+                .attributes(Map.of(ContextAttributes.MEMORY_PRESET_ID, "disabled"))
+                .build();
+
+        assertFalse(layer.appliesTo(context));
+        ContextLayerResult result = layer.assemble(context);
+
+        assertFalse(result.hasContent());
+        assertEquals("", context.getMemoryContext());
     }
 
     @Test
@@ -74,6 +91,30 @@ class MemoryLayerTest {
         layer.assemble(context);
 
         assertEquals("memory content", context.getMemoryContext());
+    }
+
+    @Test
+    void shouldApplyConfiguredMemoryPresetBudgets() {
+        MemoryPack pack = MemoryPack.builder().renderedContext("").build();
+        when(memoryComponent.buildMemoryPack(any())).thenReturn(pack);
+
+        AgentContext context = AgentContext.builder()
+                .messages(List.of(Message.builder().role("user").content("Hi").build()))
+                .session(AgentSession.builder().channelType("web").chatId("1").build())
+                .build();
+        context.setAttribute(ContextAttributes.MEMORY_PRESET_ID, "general_chat");
+
+        layer.assemble(context);
+
+        ArgumentCaptor<MemoryQuery> queryCaptor = ArgumentCaptor.forClass(MemoryQuery.class);
+        verify(memoryComponent).buildMemoryPack(queryCaptor.capture());
+        MemoryQuery query = queryCaptor.getValue();
+        assertEquals(1000, query.getSoftPromptBudgetTokens());
+        assertEquals(1800, query.getMaxPromptBudgetTokens());
+        assertEquals(4, query.getWorkingTopK());
+        assertEquals(6, query.getEpisodicTopK());
+        assertEquals(5, query.getSemanticTopK());
+        assertEquals(1, query.getProceduralTopK());
     }
 
     @Test

--- a/src/test/java/me/golemcore/bot/domain/context/layer/MemoryLayerTest.java
+++ b/src/test/java/me/golemcore/bot/domain/context/layer/MemoryLayerTest.java
@@ -12,6 +12,8 @@ import me.golemcore.bot.domain.service.MemoryPresetService;
 import me.golemcore.bot.domain.service.RuntimeConfigService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 
 import java.util.List;
@@ -54,6 +56,22 @@ class MemoryLayerTest {
 
         assertFalse(result.hasContent());
         assertEquals("", context.getMemoryContext());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "telegram", "hive", "web" })
+    void shouldKeepMemoryEnabledForNonWebhookChatsWhenPresetIsMissing(String channelType) {
+        MemoryPack pack = MemoryPack.builder().renderedContext("").build();
+        when(memoryComponent.buildMemoryPack(any())).thenReturn(pack);
+        AgentContext context = AgentContext.builder()
+                .messages(List.of(Message.builder().role("user").content("Hi").build()))
+                .session(AgentSession.builder().channelType(channelType).chatId("1").build())
+                .build();
+
+        assertTrue(layer.appliesTo(context));
+        layer.assemble(context);
+
+        verify(memoryComponent).buildMemoryPack(any());
     }
 
     @Test

--- a/src/test/java/me/golemcore/bot/domain/context/layer/ToolLayerTest.java
+++ b/src/test/java/me/golemcore/bot/domain/context/layer/ToolLayerTest.java
@@ -14,6 +14,8 @@ import me.golemcore.bot.domain.service.ToolCallExecutionService;
 import me.golemcore.bot.port.outbound.McpPort;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.List;
 
@@ -106,6 +108,26 @@ class ToolLayerTest {
 
         assertEquals(1, context.getAvailableTools().size());
         assertEquals("shell", context.getAvailableTools().get(0).getName());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "telegram", "hive", "web" })
+    void shouldAdvertiseMemoryToolForNonWebhookChatsWhenPresetIsMissing(String channelType) {
+        ToolComponent memoryTool = mock(ToolComponent.class);
+        when(memoryTool.isEnabled()).thenReturn(true);
+        when(memoryTool.getToolName()).thenReturn(ToolNames.MEMORY);
+        when(memoryTool.getDefinition()).thenReturn(
+                ToolDefinition.builder().name(ToolNames.MEMORY).description("Memory").build());
+        when(toolCallExecutionService.listTools()).thenReturn(List.of(memoryTool));
+
+        AgentContext context = AgentContext.builder()
+                .session(AgentSession.builder().channelType(channelType).chatId("chat-1").build())
+                .build();
+
+        layer.assemble(context);
+
+        assertEquals(1, context.getAvailableTools().size());
+        assertEquals(ToolNames.MEMORY, context.getAvailableTools().get(0).getName());
     }
 
     @Test

--- a/src/test/java/me/golemcore/bot/domain/context/layer/ToolLayerTest.java
+++ b/src/test/java/me/golemcore/bot/domain/context/layer/ToolLayerTest.java
@@ -3,6 +3,7 @@ package me.golemcore.bot.domain.context.layer;
 import me.golemcore.bot.domain.component.ToolComponent;
 import me.golemcore.bot.domain.context.ContextLayerResult;
 import me.golemcore.bot.domain.model.AgentContext;
+import me.golemcore.bot.domain.model.ContextAttributes;
 import me.golemcore.bot.domain.model.Skill;
 import me.golemcore.bot.domain.model.AgentSession;
 import me.golemcore.bot.domain.model.ToolDefinition;
@@ -81,6 +82,30 @@ class ToolLayerTest {
         layer.assemble(context);
 
         assertEquals(1, context.getAvailableTools().size());
+    }
+
+    @Test
+    void shouldHideMemoryToolWhenMemoryPresetIsDisabled() {
+        ToolComponent memoryTool = mock(ToolComponent.class);
+        when(memoryTool.isEnabled()).thenReturn(true);
+        when(memoryTool.getToolName()).thenReturn(ToolNames.MEMORY);
+        when(memoryTool.getDefinition()).thenReturn(
+                ToolDefinition.builder().name(ToolNames.MEMORY).description("Memory").build());
+
+        ToolComponent shellTool = mock(ToolComponent.class);
+        when(shellTool.isEnabled()).thenReturn(true);
+        when(shellTool.getToolName()).thenReturn("shell");
+        when(shellTool.getDefinition()).thenReturn(
+                ToolDefinition.builder().name("shell").description("Shell").build());
+
+        when(toolCallExecutionService.listTools()).thenReturn(List.of(memoryTool, shellTool));
+
+        AgentContext context = AgentContext.builder().build();
+        context.setAttribute(ContextAttributes.MEMORY_PRESET_ID, "disabled");
+        layer.assemble(context);
+
+        assertEquals(1, context.getAvailableTools().size());
+        assertEquals("shell", context.getAvailableTools().get(0).getName());
     }
 
     @Test

--- a/src/test/java/me/golemcore/bot/domain/context/layer/WebhookResponseSchemaLayerTest.java
+++ b/src/test/java/me/golemcore/bot/domain/context/layer/WebhookResponseSchemaLayerTest.java
@@ -39,6 +39,7 @@ class WebhookResponseSchemaLayerTest {
                 .build();
 
         assertFalse(layer.appliesTo(context));
+        assertFalse(layer.assemble(context).hasContent());
     }
 
     @Test

--- a/src/test/java/me/golemcore/bot/domain/context/layer/WebhookResponseSchemaLayerTest.java
+++ b/src/test/java/me/golemcore/bot/domain/context/layer/WebhookResponseSchemaLayerTest.java
@@ -1,0 +1,73 @@
+package me.golemcore.bot.domain.context.layer;
+
+import me.golemcore.bot.domain.context.ContextLayerResult;
+import me.golemcore.bot.domain.model.AgentContext;
+import me.golemcore.bot.domain.model.ContextAttributes;
+import me.golemcore.bot.domain.model.Message;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class WebhookResponseSchemaLayerTest {
+
+    private final WebhookResponseSchemaLayer layer = new WebhookResponseSchemaLayer();
+
+    @Test
+    void shouldApplyWhenWebhookMessageCarriesResponseSchema() {
+        AgentContext context = AgentContext.builder()
+                .messages(List.of(Message.builder()
+                        .role("user")
+                        .metadata(Map.of(ContextAttributes.WEBHOOK_RESPONSE_JSON_SCHEMA_TEXT, schemaText()))
+                        .build()))
+                .build();
+
+        ContextLayerResult result = layer.assemble(context);
+
+        assertTrue(layer.appliesTo(context));
+        assertTrue(result.hasContent());
+        assertTrue(result.getContent().contains("Webhook Response JSON Contract"));
+        assertTrue(result.getContent().contains("\"version\""));
+    }
+
+    @Test
+    void shouldSkipWhenNoResponseSchemaIsPresent() {
+        AgentContext context = AgentContext.builder()
+                .messages(List.of(Message.builder().role("user").build()))
+                .build();
+
+        assertFalse(layer.appliesTo(context));
+    }
+
+    @Test
+    void shouldSkipWhenContextHasNoUsableSchemaText() {
+        AgentContext emptyContext = AgentContext.builder()
+                .messages(List.of())
+                .build();
+        AgentContext blankSchemaContext = AgentContext.builder()
+                .messages(List.of(Message.builder()
+                        .role("user")
+                        .metadata(Map.of(ContextAttributes.WEBHOOK_RESPONSE_JSON_SCHEMA_TEXT, " "))
+                        .build()))
+                .build();
+
+        assertFalse(layer.appliesTo(null));
+        assertFalse(layer.appliesTo(emptyContext));
+        assertFalse(layer.appliesTo(blankSchemaContext));
+    }
+
+    private String schemaText() {
+        return """
+                {
+                  "type" : "object",
+                  "properties" : {
+                    "version" : {
+                      "const" : "1.0"
+                    }
+                  }
+                }
+                """;
+    }
+}

--- a/src/test/java/me/golemcore/bot/domain/context/resolution/TierResolverTest.java
+++ b/src/test/java/me/golemcore/bot/domain/context/resolution/TierResolverTest.java
@@ -2,6 +2,7 @@ package me.golemcore.bot.domain.context.resolution;
 
 import me.golemcore.bot.domain.component.SkillComponent;
 import me.golemcore.bot.domain.model.AgentContext;
+import me.golemcore.bot.domain.model.AgentSession;
 import me.golemcore.bot.domain.model.ContextAttributes;
 import me.golemcore.bot.domain.model.Message;
 import me.golemcore.bot.domain.model.Skill;
@@ -12,6 +13,7 @@ import me.golemcore.bot.domain.service.UserPreferencesService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -59,6 +61,26 @@ class TierResolverTest {
     }
 
     @Test
+    void shouldApplyForcedSessionTierBeforeUserPreferences() {
+        when(userPreferencesService.getPreferences())
+                .thenReturn(UserPreferences.builder().modelTier("power").tierForce(true).build());
+        AgentSession session = AgentSession.builder()
+                .metadata(Map.of(
+                        ContextAttributes.SESSION_MODEL_TIER, "coding",
+                        ContextAttributes.SESSION_MODEL_TIER_FORCE, true))
+                .build();
+
+        AgentContext context = AgentContext.builder()
+                .session(session)
+                .currentIteration(0)
+                .build();
+        resolver.resolve(context);
+
+        assertEquals("coding", context.getModelTier());
+        assertEquals("session_pref_forced", context.getAttribute(ContextAttributes.MODEL_TIER_SOURCE));
+    }
+
+    @Test
     void shouldApplySkillTierWhenNotForced() {
         Skill skill = Skill.builder().name("test").description("Test").modelTier("reasoning").build();
 
@@ -73,6 +95,38 @@ class TierResolverTest {
     }
 
     @Test
+    void shouldApplyWebhookTierBeforeSkillAndUserPreferenceWhenNotForced() {
+        when(userPreferencesService.getPreferences())
+                .thenReturn(UserPreferences.builder().modelTier("fast").build());
+        Skill skill = Skill.builder().name("test").description("Test").modelTier("reasoning").build();
+
+        AgentContext context = AgentContext.builder()
+                .currentIteration(0)
+                .activeSkill(skill)
+                .attributes(new HashMap<>(Map.of(ContextAttributes.WEBHOOK_MODEL_TIER, "coding")))
+                .build();
+        resolver.resolve(context);
+
+        assertEquals("coding", context.getModelTier());
+        assertEquals("webhook", context.getAttribute(ContextAttributes.MODEL_TIER_SOURCE));
+    }
+
+    @Test
+    void shouldKeepForcedUserTierAboveWebhookTier() {
+        when(userPreferencesService.getPreferences())
+                .thenReturn(UserPreferences.builder().modelTier("power").tierForce(true).build());
+
+        AgentContext context = AgentContext.builder()
+                .currentIteration(0)
+                .attributes(new HashMap<>(Map.of(ContextAttributes.WEBHOOK_MODEL_TIER, "coding")))
+                .build();
+        resolver.resolve(context);
+
+        assertEquals("power", context.getModelTier());
+        assertEquals("user_pref_forced", context.getAttribute(ContextAttributes.MODEL_TIER_SOURCE));
+    }
+
+    @Test
     void shouldFallBackToUserPrefWhenNoSkillTier() {
         when(userPreferencesService.getPreferences())
                 .thenReturn(UserPreferences.builder().modelTier("fast").build());
@@ -82,6 +136,24 @@ class TierResolverTest {
 
         assertEquals("fast", context.getModelTier());
         assertEquals("user_pref", context.getAttribute(ContextAttributes.MODEL_TIER_SOURCE));
+    }
+
+    @Test
+    void shouldFallBackToSessionTierWhenNoSkillTier() {
+        when(userPreferencesService.getPreferences())
+                .thenReturn(UserPreferences.builder().modelTier("fast").build());
+        AgentSession session = AgentSession.builder()
+                .metadata(Map.of(ContextAttributes.SESSION_MODEL_TIER, "deep"))
+                .build();
+
+        AgentContext context = AgentContext.builder()
+                .session(session)
+                .currentIteration(0)
+                .build();
+        resolver.resolve(context);
+
+        assertEquals("deep", context.getModelTier());
+        assertEquals("session_pref", context.getAttribute(ContextAttributes.MODEL_TIER_SOURCE));
     }
 
     @Test

--- a/src/test/java/me/golemcore/bot/domain/context/resolution/TierResolverTest.java
+++ b/src/test/java/me/golemcore/bot/domain/context/resolution/TierResolverTest.java
@@ -112,18 +112,37 @@ class TierResolverTest {
     }
 
     @Test
-    void shouldKeepForcedUserTierAboveWebhookTier() {
+    void shouldApplyWebhookTierAboveForcedUserTier() {
         when(userPreferencesService.getPreferences())
                 .thenReturn(UserPreferences.builder().modelTier("power").tierForce(true).build());
 
         AgentContext context = AgentContext.builder()
                 .currentIteration(0)
-                .attributes(new HashMap<>(Map.of(ContextAttributes.WEBHOOK_MODEL_TIER, "coding")))
+                .attributes(new HashMap<>(Map.of(ContextAttributes.WEBHOOK_MODEL_TIER, "special5")))
                 .build();
         resolver.resolve(context);
 
-        assertEquals("power", context.getModelTier());
-        assertEquals("user_pref_forced", context.getAttribute(ContextAttributes.MODEL_TIER_SOURCE));
+        assertEquals("special5", context.getModelTier());
+        assertEquals("webhook", context.getAttribute(ContextAttributes.MODEL_TIER_SOURCE));
+    }
+
+    @Test
+    void shouldApplyWebhookTierAboveForcedSessionTier() {
+        AgentSession session = AgentSession.builder()
+                .metadata(Map.of(
+                        ContextAttributes.SESSION_MODEL_TIER, "balanced",
+                        ContextAttributes.SESSION_MODEL_TIER_FORCE, true))
+                .build();
+
+        AgentContext context = AgentContext.builder()
+                .session(session)
+                .currentIteration(0)
+                .attributes(new HashMap<>(Map.of(ContextAttributes.WEBHOOK_MODEL_TIER, "special5")))
+                .build();
+        resolver.resolve(context);
+
+        assertEquals("special5", context.getModelTier());
+        assertEquals("webhook", context.getAttribute(ContextAttributes.MODEL_TIER_SOURCE));
     }
 
     @Test

--- a/src/test/java/me/golemcore/bot/domain/loop/AgentLoopTest.java
+++ b/src/test/java/me/golemcore/bot/domain/loop/AgentLoopTest.java
@@ -439,6 +439,90 @@ class AgentLoopTest {
     }
 
     @Test
+    void shouldRecordWebhookResponseSchemaInstructionTraceEvent() {
+        SessionPort sessionPort = mock(SessionPort.class);
+        RateLimitPort rateLimitPort = mock(RateLimitPort.class);
+        UserPreferencesService preferencesService = mock(UserPreferencesService.class);
+        when(preferencesService.getMessage(any())).thenReturn(MSG_GENERIC);
+        when(preferencesService.getMessage(any(), any())).thenReturn("x");
+        LlmPort llmPort = mock(LlmPort.class);
+        when(llmPort.isAvailable()).thenReturn(false);
+
+        Clock clock = Clock.fixed(Instant.parse(FIXED_INSTANT), ZoneOffset.UTC);
+        AgentSession session = AgentSession.builder()
+                .id("webhook:hook:test")
+                .channelType("webhook")
+                .chatId("hook:test")
+                .messages(new ArrayList<>())
+                .build();
+        when(sessionPort.getOrCreate("webhook", "hook:test")).thenReturn(session);
+        when(rateLimitPort.tryConsume()).thenReturn(RateLimitResult.allowed(0));
+
+        ChannelPort channel = mock(ChannelPort.class);
+        when(channel.getChannelType()).thenReturn("webhook");
+        when(channel.sendMessage(any(), any())).thenReturn(CompletableFuture.completedFuture(null));
+        when(channel.sendMessage(any(), any(), any())).thenReturn(CompletableFuture.completedFuture(null));
+
+        AgentSystem contextSystem = new AgentSystem() {
+            @Override
+            public String getName() {
+                return "ContextBuildingSystem";
+            }
+
+            @Override
+            public int getOrder() {
+                return 1;
+            }
+
+            @Override
+            public AgentContext process(AgentContext context) {
+                context.setModelTier("coding");
+                context.setSystemPrompt("# Webhook Response JSON Contract\n{}");
+                context.setAttribute(ContextAttributes.MODEL_TIER_SOURCE, "webhook");
+                context.setAttribute(ContextAttributes.MODEL_TIER_MODEL_ID, "gpt-5-coding");
+                context.setOutgoingResponse(OutgoingResponse.textOnly("done"));
+                return context;
+            }
+        };
+
+        AgentLoop loop = createLoop(
+                sessionPort,
+                rateLimitPort,
+                List.of(contextSystem),
+                List.of(channel),
+                mockRuntimeConfigService(1),
+                preferencesService,
+                llmPort,
+                clock);
+
+        Message inbound = Message.builder()
+                .role(ROLE_USER)
+                .content("trace schema")
+                .channelType("webhook")
+                .chatId("hook:test")
+                .senderId("u1")
+                .metadata(Map.of(
+                        ContextAttributes.TRACE_ID, "trace-1",
+                        ContextAttributes.TRACE_SPAN_ID, "span-1",
+                        ContextAttributes.TRACE_ROOT_KIND, TraceSpanKind.INGRESS.name(),
+                        ContextAttributes.TRACE_NAME, "webhook.agent",
+                        ContextAttributes.WEBHOOK_RESPONSE_JSON_SCHEMA_TEXT, "{\"type\":\"object\"}",
+                        ContextAttributes.WEBHOOK_RESPONSE_VALIDATION_MODEL_TIER, "smart"))
+                .timestamp(clock.instant())
+                .build();
+
+        loop.processMessage(inbound);
+
+        TraceRecord trace = session.getTraces().get(0);
+        TraceSpanRecord contextSpan = findSpan(trace, "system.ContextBuildingSystem");
+        TraceEventRecord event = findEvent(contextSpan, "webhook.response.schema.instructions");
+        assertEquals(true, event.getAttributes().get("schema.present"));
+        assertEquals(true, event.getAttributes().get("prompt.injected"));
+        assertEquals("smart", event.getAttributes().get("validation.model.tier"));
+        assertEquals("coding", event.getAttributes().get("response.model.tier"));
+    }
+
+    @Test
     void shouldNotSendGenericFallbackDuringSkillTransition() {
         SessionPort sessionPort = mock(SessionPort.class);
         RateLimitPort rateLimitPort = mock(RateLimitPort.class);

--- a/src/test/java/me/golemcore/bot/domain/service/SessionServiceTest.java
+++ b/src/test/java/me/golemcore/bot/domain/service/SessionServiceTest.java
@@ -1,6 +1,7 @@
 package me.golemcore.bot.domain.service;
 
 import me.golemcore.bot.domain.model.AgentSession;
+import me.golemcore.bot.domain.model.ContextAttributes;
 import me.golemcore.bot.domain.model.Message;
 import me.golemcore.bot.adapter.outbound.storage.ProtoSessionRecordCodecAdapter;
 import me.golemcore.bot.port.outbound.StoragePort;
@@ -56,6 +57,8 @@ class SessionServiceTest {
                 .thenReturn(CompletableFuture.completedFuture(null));
         when(storagePort.getText(anyString(), anyString()))
                 .thenReturn(CompletableFuture.completedFuture(null));
+        when(storagePort.listObjects(anyString(), anyString()))
+                .thenReturn(CompletableFuture.completedFuture(List.of()));
         when(storagePort.putObject(anyString(), anyString(), any(byte[].class)))
                 .thenReturn(CompletableFuture.completedFuture(null));
         when(storagePort.deleteObject(anyString(), anyString()))
@@ -87,6 +90,40 @@ class SessionServiceTest {
         AgentSession second = service.getOrCreate(CHANNEL_TELEGRAM, CHAT_ID);
 
         assertSame(first, second);
+    }
+
+    @Test
+    void getOrCreateInheritsModelSettingsFromLatestSameChannelSession() {
+        when(storagePort.getObject(SESSIONS_DIR, "telegram:source.pb"))
+                .thenReturn(CompletableFuture.failedFuture(new RuntimeException(NOT_FOUND)));
+        when(storagePort.getObject(SESSIONS_DIR, "telegram:new.pb"))
+                .thenReturn(CompletableFuture.failedFuture(new RuntimeException(NOT_FOUND)));
+
+        AgentSession source = service.getOrCreate(CHANNEL_TELEGRAM, "source");
+        source.getMetadata().put(ContextAttributes.SESSION_MODEL_TIER, "coding");
+        source.getMetadata().put(ContextAttributes.SESSION_MODEL_TIER_FORCE, true);
+
+        AgentSession created = service.getOrCreate(CHANNEL_TELEGRAM, "new");
+
+        assertEquals("coding", created.getMetadata().get(ContextAttributes.SESSION_MODEL_TIER));
+        assertEquals(true, created.getMetadata().get(ContextAttributes.SESSION_MODEL_TIER_FORCE));
+    }
+
+    @Test
+    void getOrCreateDoesNotInheritModelSettingsForExcludedChannels() {
+        when(storagePort.getObject(SESSIONS_DIR, "webhook:source.pb"))
+                .thenReturn(CompletableFuture.failedFuture(new RuntimeException(NOT_FOUND)));
+        when(storagePort.getObject(SESSIONS_DIR, "webhook:new.pb"))
+                .thenReturn(CompletableFuture.failedFuture(new RuntimeException(NOT_FOUND)));
+
+        AgentSession source = service.getOrCreate("webhook", "source");
+        source.getMetadata().put(ContextAttributes.SESSION_MODEL_TIER, "coding");
+        source.getMetadata().put(ContextAttributes.SESSION_MODEL_TIER_FORCE, true);
+
+        AgentSession created = service.getOrCreate("webhook", "new");
+
+        assertFalse(created.getMetadata().containsKey(ContextAttributes.SESSION_MODEL_TIER));
+        assertFalse(created.getMetadata().containsKey(ContextAttributes.SESSION_MODEL_TIER_FORCE));
     }
 
     // ==================== get ====================

--- a/src/test/java/me/golemcore/bot/domain/system/ContextBuildingSystemPromptTest.java
+++ b/src/test/java/me/golemcore/bot/domain/system/ContextBuildingSystemPromptTest.java
@@ -15,6 +15,7 @@ import me.golemcore.bot.domain.context.layer.RagLayer;
 import me.golemcore.bot.domain.context.layer.SkillLayer;
 import me.golemcore.bot.domain.context.layer.TierAwarenessLayer;
 import me.golemcore.bot.domain.context.layer.ToolLayer;
+import me.golemcore.bot.domain.context.layer.WebhookResponseSchemaLayer;
 import me.golemcore.bot.domain.context.layer.WorkspaceInstructionsLayer;
 import me.golemcore.bot.domain.context.resolution.SkillResolver;
 import me.golemcore.bot.domain.context.resolution.TierResolver;
@@ -138,7 +139,8 @@ class ContextBuildingSystemPromptTest {
                 new TierAwarenessLayer(userPreferencesService),
                 new AutoModeLayer(autoModeService),
                 new PlanModeLayer(planService),
-                new HiveLayer());
+                new HiveLayer(),
+                new WebhookResponseSchemaLayer());
 
         ContextAssembler contextAssembler = new ContextAssembler(skillResolver, tierResolver, layers, promptComposer);
         return new ContextBuildingSystem(contextAssembler, null, null, null);
@@ -150,6 +152,31 @@ class ContextBuildingSystemPromptTest {
                 .messages(new ArrayList<>(List.of(
                         Message.builder().role("user").content("Hello").timestamp(Instant.now()).build())))
                 .build();
+    }
+
+    @Test
+    void buildSystemPrompt_withWebhookResponseSchema() {
+        AgentContext context = AgentContext.builder()
+                .session(AgentSession.builder().chatId("hook-1").channelType("webhook").build())
+                .messages(new ArrayList<>(List.of(Message.builder()
+                        .role("user")
+                        .content("Answer in JSON")
+                        .metadata(Map.of(ContextAttributes.WEBHOOK_RESPONSE_JSON_SCHEMA_TEXT, """
+                                {
+                                  "$schema" : "https://json-schema.org/draft/2020-12/schema",
+                                  "type" : "object",
+                                  "required" : [ "version", "response" ]
+                                }
+                                """))
+                        .timestamp(Instant.now())
+                        .build())))
+                .build();
+
+        system.process(context);
+
+        assertTrue(context.getSystemPrompt().contains("Webhook Response JSON Contract"));
+        assertTrue(context.getSystemPrompt().contains("Return only the JSON payload"));
+        assertTrue(context.getSystemPrompt().contains("\"version\""));
     }
 
     @Test

--- a/src/test/java/me/golemcore/bot/domain/system/ContextBuildingSystemPromptTest.java
+++ b/src/test/java/me/golemcore/bot/domain/system/ContextBuildingSystemPromptTest.java
@@ -34,6 +34,7 @@ import me.golemcore.bot.domain.model.ToolDefinition;
 import me.golemcore.bot.domain.model.UserPreferences;
 import me.golemcore.bot.domain.service.AutoModeService;
 import me.golemcore.bot.domain.service.DelayedActionPolicyService;
+import me.golemcore.bot.domain.service.MemoryPresetService;
 import me.golemcore.bot.domain.service.ModelSelectionService;
 import me.golemcore.bot.domain.service.PlanService;
 import me.golemcore.bot.domain.service.PromptSectionService;
@@ -132,7 +133,7 @@ class ContextBuildingSystemPromptTest {
         List<ContextLayer> layers = List.of(
                 new IdentityLayer(promptSectionService, userPreferencesService),
                 new WorkspaceInstructionsLayer(workspaceInstructionService),
-                new MemoryLayer(memoryComponent, runtimeConfigService),
+                new MemoryLayer(memoryComponent, runtimeConfigService, new MemoryPresetService()),
                 new RagLayer(ragPort),
                 new SkillLayer(skillComponent, templateEngine),
                 new ToolLayer(toolCallExecutionService, mcpPort, planService, delayedActionPolicyService),

--- a/src/test/java/me/golemcore/bot/domain/system/MemoryPersistSystemTest.java
+++ b/src/test/java/me/golemcore/bot/domain/system/MemoryPersistSystemTest.java
@@ -12,6 +12,8 @@ import me.golemcore.bot.domain.model.TurnMemoryEvent;
 import me.golemcore.bot.domain.model.TurnOutcome;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.time.Instant;
 import java.util.ArrayList;
@@ -154,6 +156,25 @@ class MemoryPersistSystemTest {
 
         verify(memoryComponent, never()).persistTurnMemory(any());
         assertFalse(system.shouldProcess(ctx));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "telegram", "hive", "web" })
+    void processKeepsMemoryEnabledForNonWebhookChatsWhenPresetIsMissing(String channelType) {
+        AgentContext ctx = AgentContext.builder()
+                .session(AgentSession.builder().id(SESSION_ID).channelType(channelType).chatId("chat-1").build())
+                .messages(new ArrayList<>(List.of(
+                        Message.builder().role(ROLE_USER).content("user input").timestamp(Instant.now()).build())))
+                .build();
+        ctx.setTurnOutcome(TurnOutcome.builder()
+                .finishReason(FinishReason.SUCCESS)
+                .assistantText("assistant reply")
+                .build());
+
+        assertTrue(system.shouldProcess(ctx));
+        system.process(ctx);
+
+        verify(memoryComponent).persistTurnMemory(any());
     }
 
     @Test

--- a/src/test/java/me/golemcore/bot/domain/system/MemoryPersistSystemTest.java
+++ b/src/test/java/me/golemcore/bot/domain/system/MemoryPersistSystemTest.java
@@ -144,6 +144,19 @@ class MemoryPersistSystemTest {
     }
 
     @Test
+    void processSkipsWhenMemoryPresetIsDisabled() {
+        AgentContext ctx = contextWith(
+                List.of(Message.builder().role(ROLE_USER).content("user input").timestamp(Instant.now()).build()),
+                LlmResponse.builder().content("assistant reply").build());
+        ctx.setAttribute(ContextAttributes.MEMORY_PRESET_ID, "disabled");
+
+        system.process(ctx);
+
+        verify(memoryComponent, never()).persistTurnMemory(any());
+        assertFalse(system.shouldProcess(ctx));
+    }
+
+    @Test
     void processIgnoresInternalRetryMessageAsLastUserInput() {
         Message visibleUser = Message.builder()
                 .role(ROLE_USER)

--- a/src/test/java/me/golemcore/bot/domain/system/PlanWorkLifecycleBddTest.java
+++ b/src/test/java/me/golemcore/bot/domain/system/PlanWorkLifecycleBddTest.java
@@ -27,6 +27,7 @@ import me.golemcore.bot.domain.context.resolution.SkillResolver;
 import me.golemcore.bot.domain.context.resolution.TierResolver;
 import me.golemcore.bot.domain.service.AutoModeService;
 import me.golemcore.bot.domain.service.DelayedActionPolicyService;
+import me.golemcore.bot.domain.service.MemoryPresetService;
 import me.golemcore.bot.domain.service.ModelSelectionService;
 import me.golemcore.bot.domain.service.PlanService;
 import me.golemcore.bot.domain.service.PromptSectionService;
@@ -237,7 +238,7 @@ class PlanWorkLifecycleBddTest {
         List<ContextLayer> layers = List.of(
                 new IdentityLayer(promptSectionService, userPreferencesService),
                 new WorkspaceInstructionsLayer(workspaceInstructionService),
-                new MemoryLayer(memoryComponent, runtimeConfigService),
+                new MemoryLayer(memoryComponent, runtimeConfigService, new MemoryPresetService()),
                 new RagLayer(ragPort),
                 new SkillLayer(skillComponent, templateEngine),
                 new ToolLayer(toolCallExecutionService, mcpPort, planService, delayedActionPolicyService),

--- a/src/test/java/me/golemcore/bot/infrastructure/config/ApplicationLayerConfigurationTest.java
+++ b/src/test/java/me/golemcore/bot/infrastructure/config/ApplicationLayerConfigurationTest.java
@@ -61,7 +61,8 @@ class ApplicationLayerConfigurationTest {
         RuntimeSettingsValidator validator = configuration.runtimeSettingsValidator(
                 mock(ModelSelectionService.class),
                 mock(VoiceProviderCatalogPort.class),
-                mock(ResponseJsonSchemaValidatorPort.class));
+                mock(ResponseJsonSchemaValidatorPort.class),
+                mock(MemoryPresetService.class));
         RuntimeSettingsFacade facade = configuration.runtimeSettingsFacade(
                 mock(RuntimeConfigService.class),
                 mock(UserPreferencesService.class),

--- a/src/test/java/me/golemcore/bot/infrastructure/config/ApplicationLayerConfigurationTest.java
+++ b/src/test/java/me/golemcore/bot/infrastructure/config/ApplicationLayerConfigurationTest.java
@@ -80,7 +80,8 @@ class ApplicationLayerConfigurationTest {
         ModelSelectionCommandService modelSelection = configuration.modelSelectionCommandService(
                 mock(UserPreferencesService.class),
                 mock(ModelSelectionService.class),
-                mock(RuntimeConfigService.class));
+                mock(RuntimeConfigService.class),
+                mock(me.golemcore.bot.port.outbound.SessionPort.class));
         AutomationCommandService automation = configuration.automationCommandService(
                 mock(AutoModeService.class),
                 mock(RuntimeConfigService.class),

--- a/src/test/java/me/golemcore/bot/infrastructure/config/ApplicationLayerConfigurationTest.java
+++ b/src/test/java/me/golemcore/bot/infrastructure/config/ApplicationLayerConfigurationTest.java
@@ -42,6 +42,7 @@ import me.golemcore.bot.port.outbound.ModelRegistryDocumentPort;
 import me.golemcore.bot.port.outbound.ModelConfigAdminPort;
 import me.golemcore.bot.port.outbound.ModelRegistryRemotePort;
 import me.golemcore.bot.port.outbound.ProviderModelDiscoveryPort;
+import me.golemcore.bot.port.outbound.ResponseJsonSchemaValidatorPort;
 import me.golemcore.bot.port.outbound.SkillMarketplaceArtifactPort;
 import me.golemcore.bot.port.outbound.SkillMarketplaceCatalogPort;
 import me.golemcore.bot.port.outbound.SkillMarketplaceInstallPort;
@@ -59,7 +60,8 @@ class ApplicationLayerConfigurationTest {
         RuntimeSettingsMergeService mergeService = configuration.runtimeSettingsMergeService();
         RuntimeSettingsValidator validator = configuration.runtimeSettingsValidator(
                 mock(ModelSelectionService.class),
-                mock(VoiceProviderCatalogPort.class));
+                mock(VoiceProviderCatalogPort.class),
+                mock(ResponseJsonSchemaValidatorPort.class));
         RuntimeSettingsFacade facade = configuration.runtimeSettingsFacade(
                 mock(RuntimeConfigService.class),
                 mock(UserPreferencesService.class),

--- a/src/test/java/me/golemcore/bot/infrastructure/config/CoreLayerConfigurationTest.java
+++ b/src/test/java/me/golemcore/bot/infrastructure/config/CoreLayerConfigurationTest.java
@@ -111,6 +111,7 @@ class CoreLayerConfigurationTest {
                 contextLayerConfiguration.autoModeLayer(mock(me.golemcore.bot.domain.service.AutoModeService.class)));
         assertNotNull(contextLayerConfiguration.planModeLayer(mock(PlanService.class)));
         assertNotNull(contextLayerConfiguration.hiveLayer());
+        assertNotNull(contextLayerConfiguration.webhookResponseSchemaLayer());
         assertNotNull(contextLayerConfiguration.contextAssembler(
                 mock(me.golemcore.bot.domain.context.resolution.SkillResolver.class),
                 mock(me.golemcore.bot.domain.context.resolution.TierResolver.class),

--- a/src/test/java/me/golemcore/bot/infrastructure/config/CoreLayerConfigurationTest.java
+++ b/src/test/java/me/golemcore/bot/infrastructure/config/CoreLayerConfigurationTest.java
@@ -96,7 +96,8 @@ class CoreLayerConfigurationTest {
                 mock(me.golemcore.bot.domain.service.WorkspaceInstructionService.class)));
         assertNotNull(contextLayerConfiguration.memoryLayer(
                 mock(me.golemcore.bot.domain.component.MemoryComponent.class),
-                mock(RuntimeConfigService.class)));
+                mock(RuntimeConfigService.class),
+                mock(me.golemcore.bot.domain.service.MemoryPresetService.class)));
         assertNotNull(contextLayerConfiguration.ragLayer(mock(me.golemcore.bot.port.outbound.RagPort.class)));
         assertNotNull(contextLayerConfiguration.skillLayer(
                 mock(me.golemcore.bot.domain.component.SkillComponent.class),

--- a/src/test/java/me/golemcore/bot/integration/GolemCoreBotIntegrationTestBase.java
+++ b/src/test/java/me/golemcore/bot/integration/GolemCoreBotIntegrationTestBase.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import me.golemcore.bot.infrastructure.telemetry.GaTelemetryClient;
+import me.golemcore.bot.infrastructure.telemetry.TelemetryEventPublisher;
 import org.junit.jupiter.api.io.TempDir;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -39,7 +39,7 @@ abstract class GolemCoreBotIntegrationTestBase {
     protected ObjectMapper objectMapper;
 
     @MockitoBean
-    GaTelemetryClient gaTelemetryClient;
+    TelemetryEventPublisher telemetryEventPublisher;
 
     @DynamicPropertySource
     static void overrideProperties(DynamicPropertyRegistry registry) {

--- a/src/test/java/me/golemcore/bot/tools/TierToolTest.java
+++ b/src/test/java/me/golemcore/bot/tools/TierToolTest.java
@@ -3,6 +3,7 @@ package me.golemcore.bot.tools;
 import me.golemcore.bot.domain.loop.AgentContextHolder;
 import me.golemcore.bot.domain.model.AgentContext;
 import me.golemcore.bot.domain.model.AgentSession;
+import me.golemcore.bot.domain.model.ContextAttributes;
 import me.golemcore.bot.domain.model.ToolResult;
 import me.golemcore.bot.domain.model.UserPreferences;
 import me.golemcore.bot.domain.service.RuntimeConfigService;
@@ -100,6 +101,17 @@ class TierToolTest {
     void shouldRejectWhenTierForceEnabled() {
         when(preferencesService.getPreferences()).thenReturn(
                 UserPreferences.builder().modelTier("smart").tierForce(true).build());
+
+        ToolResult result = tool.execute(Map.of(PARAM_TIER, TIER_CODING)).join();
+
+        assertNotNull(result.getError());
+        assertTrue(result.getError().contains("locked"));
+    }
+
+    @Test
+    void shouldRejectWhenSessionTierForceEnabled() {
+        AgentContextHolder.get().getSession().getMetadata().put(ContextAttributes.SESSION_MODEL_TIER, "smart");
+        AgentContextHolder.get().getSession().getMetadata().put(ContextAttributes.SESSION_MODEL_TIER_FORCE, true);
 
         ToolResult result = tool.execute(Map.of(PARAM_TIER, TIER_CODING)).join();
 


### PR DESCRIPTION
## Summary

This PR makes synchronous webhook responses schema-aware end to end. When a hook request or mapping includes `responseJsonSchema`, that schema becomes the response contract: it is rendered into the agent prompt, validated as a JSON Schema Draft 2020-12 document before the run is accepted, used to validate the synchronous HTTP response, and used by the repair path if the initial assistant output is not valid JSON or does not satisfy the schema. Empty `{}` schemas are rejected instead of being treated as an accidental no-op.

For tier selection, schema-constrained synchronous webhooks now use `responseValidationModelTier` as the effective agent response tier when a schema is present. That keeps the model used to produce the structured payload aligned with the model used for schema repair, and it gives the webhook response contract higher priority than forced user/session tier settings. When no schema is configured, `responseValidationModelTier` is ignored and the webhook `model` or mapping model continues to drive the normal agent run.

When no `responseJsonSchema` is configured, synchronous webhooks now return the agent answer as `text/plain` with the run/chat headers. They no longer inject schema instructions, attempt JSON validation, or wrap the response in a synthetic schema payload. This keeps the plain synchronous HTTP response path focused on callers that only need text.

Webhook memory behavior is now explicitly controlled through a `memoryPreset` setting. Webhook configuration and ad hoc `/agent` requests default to `disabled`, so webhook traffic does not read from or persist into global memory unless a known preset is selected. The memory layer, memory persistence system, and `memory` tool all honor the preset. Missing preset metadata still falls back to normal runtime memory behavior for non-webhook channels, so Telegram, Hive, and Web UI chats do not get downgraded to disabled memory by this change.

The dashboard now exposes the webhook memory preset selector and the synchronous response schema settings with stricter client-side schema parsing. Hook mappings serialize and deserialize the new fields, invalid schema JSON is blocked before save, and backend runtime settings validation enforces the same contract so persisted webhook preferences stay aligned with what the runtime accepts.

The PR also preserves related model-tier behavior outside webhooks: `/tier` settings are persisted per session and inherited into compatible same-channel sessions, but excluded for `judge`, `webhook`, and `hive` where carrying the setting forward would be unsafe. Expected unauthenticated WebSocket JWT rejections are also downgraded from warn to debug so routine connection noise does not appear as operational warnings.