### PR TITLE
fix: allow hive dashboard public url env

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -452,6 +452,8 @@ Hive runtime settings live in `preferences/hive.json` and are also available in 
     "serverUrl": "https://hive.example.com",
     "displayName": "Build Runner",
     "hostLabel": "builder-lab-a",
+    "dashboardBaseUrl": "https://bot.example.com/dashboard",
+    "ssoEnabled": true,
     "autoConnect": true,
     "managedByProperties": false
   }
@@ -462,6 +464,7 @@ Rules:
 
 - `RuntimeConfig.HiveConfig` is the effective UI/runtime configuration.
 - `bot.hive.*` acts as a managed bootstrap override.
+- `BOT_HIVE_DASHBOARD_PUBLIC_URL` maps to the runtime `hive.dashboardBaseUrl` value used for Hive SSO redirects. `BOT_HIVE_DASHBOARD_BASE_URL` is still supported as a legacy alias.
 - When managed bootstrap is active, the dashboard Hive tab becomes read-only and the backend rejects edits to the Hive section.
 - Rotating machine auth state does not belong in `hive.json`; it lives in `preferences/hive-session.json`.
 - Buffered control channel commands live in `preferences/hive-control-inbox.json`.

--- a/docs/HIVE_INTEGRATION.md
+++ b/docs/HIVE_INTEGRATION.md
@@ -30,9 +30,12 @@ The bot supports these managed bootstrap properties:
 - `bot.hive.join-code`
 - `bot.hive.display-name`
 - `bot.hive.host-label`
+- `bot.hive.dashboard-public-url`
 - `bot.hive.auto-connect-on-startup`
+- `bot.hive.sso-enabled`
 
 If any of these are set, Hive settings are treated as property-managed.
+Use `BOT_HIVE_DASHBOARD_PUBLIC_URL` to configure the externally reachable bot dashboard URL for Hive SSO redirects. `BOT_HIVE_DASHBOARD_BASE_URL` remains supported as a legacy alias.
 
 ## Join Code Format
 

--- a/src/main/java/me/golemcore/bot/adapter/outbound/hive/BotPropertiesHiveBootstrapSettingsAdapter.java
+++ b/src/main/java/me/golemcore/bot/adapter/outbound/hive/BotPropertiesHiveBootstrapSettingsAdapter.java
@@ -38,11 +38,20 @@ public class BotPropertiesHiveBootstrapSettingsAdapter implements HiveBootstrapS
 
     @Override
     public String dashboardBaseUrl() {
-        return botProperties.getHive().getDashboardBaseUrl();
+        return firstConfigured(
+                botProperties.getHive().getDashboardPublicUrl(),
+                botProperties.getHive().getDashboardBaseUrl());
     }
 
     @Override
     public Boolean ssoEnabled() {
         return botProperties.getHive().getSsoEnabled();
+    }
+
+    private String firstConfigured(String primary, String fallback) {
+        if (primary != null && !primary.isBlank()) {
+            return primary;
+        }
+        return fallback;
     }
 }

--- a/src/main/java/me/golemcore/bot/infrastructure/config/BotProperties.java
+++ b/src/main/java/me/golemcore/bot/infrastructure/config/BotProperties.java
@@ -271,6 +271,7 @@ public class BotProperties {
         private String joinCode = "";
         private String displayName = "";
         private String hostLabel = "";
+        private String dashboardPublicUrl = "";
         private String dashboardBaseUrl = "";
         private Boolean ssoEnabled;
         private Boolean autoConnectOnStartup;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -56,5 +56,6 @@ bot.plugins.marketplace.remote-cache-ttl=${BOT_PLUGINS_MARKETPLACE_REMOTE_CACHE_
 bot.webhooks.delivery-history-max-entries=${BOT_WEBHOOKS_DELIVERY_HISTORY_MAX_ENTRIES:500}
 
 # ===== HIVE =====
-bot.hive.dashboard-base-url=${BOT_HIVE_DASHBOARD_BASE_URL:}
+bot.hive.dashboard-public-url=${BOT_HIVE_DASHBOARD_PUBLIC_URL:}
+bot.hive.dashboard-base-url=${BOT_HIVE_DASHBOARD_BASE_URL:${BOT_HIVE_DASHBOARD_PUBLIC_URL:}}
 bot.hive.sso-enabled=${BOT_HIVE_SSO_ENABLED:}

--- a/src/test/java/me/golemcore/bot/adapter/outbound/hive/BotPropertiesHiveBootstrapSettingsAdapterTest.java
+++ b/src/test/java/me/golemcore/bot/adapter/outbound/hive/BotPropertiesHiveBootstrapSettingsAdapterTest.java
@@ -15,6 +15,8 @@ class BotPropertiesHiveBootstrapSettingsAdapterTest {
         botProperties.getHive().setJoinCode("et_demo.secret:https://hive.example.com");
         botProperties.getHive().setDisplayName("Builder");
         botProperties.getHive().setHostLabel("lab-a");
+        botProperties.getHive().setDashboardBaseUrl("https://legacy-bot.example.com/dashboard");
+        botProperties.getHive().setDashboardPublicUrl("https://bot.example.com/dashboard");
 
         BotPropertiesHiveBootstrapSettingsAdapter adapter = new BotPropertiesHiveBootstrapSettingsAdapter(
                 botProperties);
@@ -24,5 +26,18 @@ class BotPropertiesHiveBootstrapSettingsAdapterTest {
         assertEquals("et_demo.secret:https://hive.example.com", adapter.joinCode());
         assertEquals("Builder", adapter.displayName());
         assertEquals("lab-a", adapter.hostLabel());
+        assertEquals("https://bot.example.com/dashboard", adapter.dashboardBaseUrl());
+    }
+
+    @Test
+    void shouldFallbackToDashboardBaseUrlWhenPublicUrlIsBlank() {
+        BotProperties botProperties = new BotProperties();
+        botProperties.getHive().setDashboardPublicUrl(" ");
+        botProperties.getHive().setDashboardBaseUrl("https://legacy-bot.example.com/dashboard");
+
+        BotPropertiesHiveBootstrapSettingsAdapter adapter = new BotPropertiesHiveBootstrapSettingsAdapter(
+                botProperties);
+
+        assertEquals("https://legacy-bot.example.com/dashboard", adapter.dashboardBaseUrl());
     }
 }


### PR DESCRIPTION
## What changed

- Added `bot.hive.dashboard-public-url` backed by `BOT_HIVE_DASHBOARD_PUBLIC_URL`.
- Kept `BOT_HIVE_DASHBOARD_BASE_URL` as a legacy fallback for the existing runtime `hive.dashboardBaseUrl` value.
- Mapped the new public URL through the outbound bootstrap settings adapter so Hive SSO redirects can use the externally reachable dashboard URL without changing the domain port.
- Updated Hive configuration docs and adapter tests.

## Validation

- `git diff --check`
- `./mvnw -Dtest=BotPropertiesHiveBootstrapSettingsAdapterTest test`
- `./mvnw test`
