### PR TITLE
fix: allow major self-update releases

### DIFF
--- a/src/main/java/me/golemcore/bot/application/update/UpdateService.java
+++ b/src/main/java/me/golemcore/bot/application/update/UpdateService.java
@@ -409,13 +409,6 @@ public class UpdateService {
                 return new CheckResolution(null, "Already up to date", currentVersion);
             }
 
-            if (!updateVersionSupport.isSameMajorUpdate(currentVersion, latestRelease.getVersion())) {
-                availableRelease = Optional.empty();
-                transientState = UpdateState.IDLE;
-                return new CheckResolution(null, "New major version found. Use Docker image upgrade.",
-                        latestRelease.getVersion());
-            }
-
             availableRelease = Optional.of(latestRelease);
             activeTarget = Optional.of(toVersionInfo(latestRelease));
             transientState = UpdateState.IDLE;

--- a/src/main/java/me/golemcore/bot/application/update/UpdateVersionSupport.java
+++ b/src/main/java/me/golemcore/bot/application/update/UpdateVersionSupport.java
@@ -55,15 +55,6 @@ final class UpdateVersionSupport {
         return compareVersions(remoteVersion, currentVersion) > 0;
     }
 
-    boolean isSameMajorUpdate(String currentVersion, String remoteVersion) {
-        Semver current = parseSemver(currentVersion);
-        Semver remote = parseSemver(remoteVersion);
-        if (current == null || remote == null) {
-            return false;
-        }
-        return current.major() == remote.major();
-    }
-
     int compareVersions(String left, String right) {
         Semver leftSemver = parseSemver(left);
         Semver rightSemver = parseSemver(right);

--- a/src/test/java/me/golemcore/bot/domain/service/UpdateServiceTest.java
+++ b/src/test/java/me/golemcore/bot/domain/service/UpdateServiceTest.java
@@ -222,14 +222,15 @@ class UpdateServiceTest {
     }
 
     @Test
-    void shouldSuggestDockerRolloutWhenMajorReleaseIsFound(@TempDir Path tempDir) {
+    void shouldDiscoverMajorUpdateWhenRemoteVersionIsNewer(@TempDir Path tempDir) {
         enableUpdates(tempDir);
         StubReleaseSource source = new StubReleaseSource();
         source.enqueueRelease("1.0.0", "bot-1.0.0.jar", "2026-02-22T10:00:00Z");
         TestableUpdateService service = createTestableService(source);
 
-        assertTrue(service.check().getMessage().contains("Docker image upgrade"));
-        assertNull(service.getStatus().getAvailable());
+        assertEquals("Update available: 1.0.0", service.check().getMessage());
+        assertEquals(UpdateState.AVAILABLE, service.getStatus().getState());
+        assertEquals("1.0.0", service.getStatus().getAvailable().getVersion());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- allow self-update to accept any newer release version, including major bumps such as 0.x.x -> 1.0.0
- remove the same-major-only updater guard
- update the updater regression test to expect 1.0.0 as an available update

## Why
The previous check treated a newer major release as incompatible and returned a Docker upgrade message instead of staging the runtime jar. For the current 1.0.0 transition we want the runtime self-update path to handle the major bump.

