### PR TITLE
fix(tools): extend shell recovery guidance

### DIFF
--- a/src/main/java/me/golemcore/bot/domain/context/layer/ToolLayer.java
+++ b/src/main/java/me/golemcore/bot/domain/context/layer/ToolLayer.java
@@ -61,6 +61,12 @@ public class ToolLayer implements ContextLayer {
 
     private static final String TOOL_PLAN_SET_CONTENT = "plan_set_content";
     private static final String TOOL_PLAN_GET = "plan_get";
+    private static final String SHELL_TOOL_POLICY = """
+
+            ## Shell Tool Policy
+
+            Prefer `command -v` before using shell tools. Avoid issuing the same missing command twice without proving the binary is available.
+            """;
 
     private final ToolCallExecutionService toolCallExecutionService;
     private final McpPort mcpPort;
@@ -136,6 +142,9 @@ public class ToolLayer implements ContextLayer {
         for (ToolDefinition tool : tools) {
             sb.append("- **").append(tool.getName()).append("**: ");
             sb.append(tool.getDescription()).append("\n");
+        }
+        if (toolsByName.containsKey(ToolNames.SHELL)) {
+            sb.append(SHELL_TOOL_POLICY);
         }
 
         String content = sb.toString();

--- a/src/main/java/me/golemcore/bot/domain/model/ToolNames.java
+++ b/src/main/java/me/golemcore/bot/domain/model/ToolNames.java
@@ -14,6 +14,7 @@ public final class ToolNames {
     public static final String HIVE_CREATE_FOLLOWUP_CARD = "hive_create_followup_card";
     public static final String SCHEDULE_SESSION_ACTION = "schedule_session_action";
     public static final String MEMORY = "memory";
+    public static final String SHELL = "shell";
 
     private ToolNames() {
     }

--- a/src/main/java/me/golemcore/bot/domain/system/toolloop/ToolFailureRecoveryService.java
+++ b/src/main/java/me/golemcore/bot/domain/system/toolloop/ToolFailureRecoveryService.java
@@ -46,7 +46,7 @@ import java.util.Map;
 @Component
 public class ToolFailureRecoveryService {
 
-    private static final int SHELL_RECOVERY_MAX_ATTEMPTS = 2;
+    private static final int SHELL_RECOVERY_MAX_ATTEMPTS = 6;
     private static final int MAX_COMMAND_FINGERPRINT_LENGTH = 120;
 
     /**

--- a/src/test/java/me/golemcore/bot/domain/context/layer/ToolLayerTest.java
+++ b/src/test/java/me/golemcore/bot/domain/context/layer/ToolLayerTest.java
@@ -68,6 +68,43 @@ class ToolLayerTest {
     }
 
     @Test
+    void shouldIncludeShellPolicyWhenShellToolIsAdvertised() {
+        ToolComponent tool = mock(ToolComponent.class);
+        when(tool.isEnabled()).thenReturn(true);
+        when(tool.getToolName()).thenReturn(ToolNames.SHELL);
+        when(tool.getDefinition()).thenReturn(
+                ToolDefinition.builder().name(ToolNames.SHELL).description("Run shell commands").build());
+
+        when(toolCallExecutionService.listTools()).thenReturn(List.of(tool));
+
+        AgentContext context = AgentContext.builder().build();
+        ContextLayerResult result = layer.assemble(context);
+
+        assertTrue(result.hasContent());
+        assertTrue(result.getContent().contains("## Shell Tool Policy"));
+        assertTrue(result.getContent().contains("command -v"));
+        assertTrue(result.getContent().contains("same missing command twice"));
+    }
+
+    @Test
+    void shouldNotIncludeShellPolicyWhenShellToolIsNotAdvertised() {
+        ToolComponent tool = mock(ToolComponent.class);
+        when(tool.isEnabled()).thenReturn(true);
+        when(tool.getToolName()).thenReturn("filesystem");
+        when(tool.getDefinition()).thenReturn(
+                ToolDefinition.builder().name("filesystem").description("Work with files").build());
+
+        when(toolCallExecutionService.listTools()).thenReturn(List.of(tool));
+
+        AgentContext context = AgentContext.builder().build();
+        ContextLayerResult result = layer.assemble(context);
+
+        assertTrue(result.hasContent());
+        assertFalse(result.getContent().contains("## Shell Tool Policy"));
+        assertFalse(result.getContent().contains("command -v"));
+    }
+
+    @Test
     void shouldFilterDisabledTools() {
         ToolComponent enabled = mock(ToolComponent.class);
         when(enabled.isEnabled()).thenReturn(true);

--- a/src/test/java/me/golemcore/bot/domain/system/toolloop/DefaultToolLoopSystemTest.java
+++ b/src/test/java/me/golemcore/bot/domain/system/toolloop/DefaultToolLoopSystemTest.java
@@ -51,6 +51,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -939,42 +940,24 @@ class DefaultToolLoopSystemTest {
     @Test
     void shouldStopWhenRecoverableShellFailureExhaustsRecoveryBudget() {
         AgentContext context = buildContext();
-        Message.ToolCall firstCall = toolCall(TOOL_CALL_ID, "shell");
-        firstCall.setArguments(Map.of("command", "cat missing.txt"));
-        Message.ToolCall secondCall = toolCall("tc-2", "shell");
-        secondCall.setArguments(Map.of("command", "cat missing.txt"));
-        Message.ToolCall thirdCall = toolCall("tc-3", "shell");
-        thirdCall.setArguments(Map.of("command", "cat missing.txt"));
-        Message.ToolCall fourthCall = toolCall("tc-4", "shell");
-        fourthCall.setArguments(Map.of("command", "cat missing.txt"));
-
-        when(llmPort.chat(any()))
-                .thenReturn(CompletableFuture.completedFuture(toolCallResponse(List.of(firstCall))))
-                .thenReturn(CompletableFuture.completedFuture(toolCallResponse(List.of(secondCall))))
-                .thenReturn(CompletableFuture.completedFuture(toolCallResponse(List.of(thirdCall))))
-                .thenReturn(CompletableFuture.completedFuture(toolCallResponse(List.of(fourthCall))));
-
-        ToolExecutionOutcome failureOne = new ToolExecutionOutcome(
-                TOOL_CALL_ID, "shell",
-                ToolResult.failure(ToolFailureKind.EXECUTION_FAILED, "No such file or directory"),
-                "No such file or directory", false, null);
-        ToolExecutionOutcome failureTwo = new ToolExecutionOutcome(
-                "tc-2", "shell",
-                ToolResult.failure(ToolFailureKind.EXECUTION_FAILED, "No such file or directory"),
-                "No such file or directory", false, null);
-        ToolExecutionOutcome failureThree = new ToolExecutionOutcome(
-                "tc-3", "shell",
-                ToolResult.failure(ToolFailureKind.EXECUTION_FAILED, "No such file or directory"),
-                "No such file or directory", false, null);
-        ToolExecutionOutcome failureFour = new ToolExecutionOutcome(
-                "tc-4", "shell",
-                ToolResult.failure(ToolFailureKind.EXECUTION_FAILED, "No such file or directory"),
-                "No such file or directory", false, null);
+        List<Message.ToolCall> calls = new ArrayList<>();
+        List<ToolExecutionOutcome> failures = new ArrayList<>();
+        for (int index = 1; index <= 8; index++) {
+            String callId = index == 1 ? TOOL_CALL_ID : "tc-" + index;
+            Message.ToolCall call = toolCall(callId, "shell");
+            call.setArguments(Map.of("command", "cat missing.txt"));
+            calls.add(call);
+            failures.add(new ToolExecutionOutcome(
+                    callId, "shell",
+                    ToolResult.failure(ToolFailureKind.EXECUTION_FAILED, "No such file or directory"),
+                    "No such file or directory", false, null));
+        }
+        AtomicInteger llmCallIndex = new AtomicInteger();
+        when(llmPort.chat(any())).thenAnswer(invocation -> CompletableFuture.completedFuture(
+                toolCallResponse(List.of(calls.get(llmCallIndex.getAndIncrement())))));
+        AtomicInteger toolCallIndex = new AtomicInteger();
         when(toolExecutor.execute(any(), any()))
-                .thenReturn(failureOne)
-                .thenReturn(failureTwo)
-                .thenReturn(failureThree)
-                .thenReturn(failureFour);
+                .thenAnswer(invocation -> failures.get(toolCallIndex.getAndIncrement()));
 
         ToolFailureRecoveryService recoveryService = new ToolFailureRecoveryService();
         DefaultToolLoopSystem recoverySystem = buildSystemWithRecovery(recoveryService);
@@ -982,8 +965,8 @@ class DefaultToolLoopSystemTest {
         ToolLoopTurnResult result = recoverySystem.processTurn(context);
 
         assertTrue(result.finalAnswerReady());
-        assertEquals(4, result.llmCalls());
-        verify(historyWriter, times(2)).appendInternalRecoveryHint(eq(context), any());
+        assertEquals(8, result.llmCalls());
+        verify(historyWriter, times(6)).appendInternalRecoveryHint(eq(context), any());
         LlmResponse llmResponse = context.getAttribute(ContextAttributes.LLM_RESPONSE);
         assertNotNull(llmResponse);
         assertTrue(llmResponse.getContent().contains("repeated tool failure (shell)"));

--- a/src/test/java/me/golemcore/bot/domain/system/toolloop/ToolFailurePolicyTest.java
+++ b/src/test/java/me/golemcore/bot/domain/system/toolloop/ToolFailurePolicyTest.java
@@ -195,7 +195,7 @@ class ToolFailurePolicyTest {
         assertInstanceOf(ToolFailurePolicy.Verdict.RecoveryHint.class, second);
         ToolFailurePolicy.Verdict.RecoveryHint hint = (ToolFailurePolicy.Verdict.RecoveryHint) second;
         assertTrue(hint.hint().contains("Shell recovery note"));
-        assertTrue(hint.hint().contains("Recovery attempt 1 of 2"));
+        assertTrue(hint.hint().contains("Recovery attempt 1 of 6"));
     }
 
     // -----------------------------------------------------------------------
@@ -220,17 +220,18 @@ class ToolFailurePolicyTest {
         ToolFailurePolicy.Verdict v2 = policy.evaluate(turnState, toolCall, outcome);
         assertInstanceOf(ToolFailurePolicy.Verdict.RecoveryHint.class, v2);
 
-        // Act — occurrence 3: RecoveryHint (count=3, recovery attempt 2)
-        ToolFailurePolicy.Verdict v3 = policy.evaluate(turnState, toolCall, outcome);
-        assertInstanceOf(ToolFailurePolicy.Verdict.RecoveryHint.class, v3);
+        // Act - occurrences 3-7: RecoveryHint (recovery attempts 2-6)
+        for (int attempt = 0; attempt < 5; attempt++) {
+            ToolFailurePolicy.Verdict recoveryHint = policy.evaluate(turnState, toolCall, outcome);
+            assertInstanceOf(ToolFailurePolicy.Verdict.RecoveryHint.class, recoveryHint);
+        }
 
-        // Act — occurrence 4: StopTurn (count=4, recovery attempt 3 exceeds budget of
-        // 2)
-        ToolFailurePolicy.Verdict v4 = policy.evaluate(turnState, toolCall, outcome);
+        // Act - occurrence 8: StopTurn (recovery attempt 7 exceeds budget of 6)
+        ToolFailurePolicy.Verdict v8 = policy.evaluate(turnState, toolCall, outcome);
 
         // Assert
-        assertInstanceOf(ToolFailurePolicy.Verdict.StopTurn.class, v4);
-        ToolFailurePolicy.Verdict.StopTurn stop = (ToolFailurePolicy.Verdict.StopTurn) v4;
+        assertInstanceOf(ToolFailurePolicy.Verdict.StopTurn.class, v8);
+        ToolFailurePolicy.Verdict.StopTurn stop = (ToolFailurePolicy.Verdict.StopTurn) v8;
         assertTrue(stop.reason().contains("repeated tool failure"));
         assertTrue(stop.reason().contains("shell"));
     }

--- a/src/test/java/me/golemcore/bot/domain/system/toolloop/ToolFailureRecoveryServiceTest.java
+++ b/src/test/java/me/golemcore/bot/domain/system/toolloop/ToolFailureRecoveryServiceTest.java
@@ -172,9 +172,10 @@ class ToolFailureRecoveryServiceTest {
         ToolExecutionOutcome outcome = new ToolExecutionOutcome("tc-1", "shell", failureResult,
                 "No such file or directory", false, null);
 
-        // Act - exhaust the budget (2 attempts)
-        service.evaluate(toolCall, outcome, recoveryCounts);
-        service.evaluate(toolCall, outcome, recoveryCounts);
+        // Act - exhaust the budget (6 attempts)
+        for (int attempt = 0; attempt < 6; attempt++) {
+            service.evaluate(toolCall, outcome, recoveryCounts);
+        }
         ToolFailureRecoveryDecision decision = service.evaluate(toolCall, outcome, recoveryCounts);
 
         // Assert
@@ -426,28 +427,26 @@ class ToolFailureRecoveryServiceTest {
     }
 
     // -----------------------------------------------------------------------
-    // 11. Recovery budget tracking: first two attempts get hints, third stops
+    // 11. Recovery budget tracking: first six attempts get hints, seventh stops
     // -----------------------------------------------------------------------
 
     @Test
-    void shouldAllowTwoRecoveryAttemptsBeforeStopping() {
+    void shouldAllowSixRecoveryAttemptsBeforeStopping() {
         // Arrange
         Message.ToolCall toolCall = shellToolCall("cat /missing/file.txt");
         ToolResult failureResult = ToolResult.failure(ToolFailureKind.EXECUTION_FAILED, "No such file or directory");
         ToolExecutionOutcome outcome = new ToolExecutionOutcome("tc-1", "shell", failureResult,
                 "No such file or directory", false, null);
 
-        // Act & Assert - first attempt: InjectHint
-        ToolFailureRecoveryDecision first = service.evaluate(toolCall, outcome, recoveryCounts);
-        assertInstanceOf(ToolFailureRecoveryDecision.InjectHint.class, first);
+        // Act & Assert - first six attempts: InjectHint
+        for (int attempt = 0; attempt < 6; attempt++) {
+            ToolFailureRecoveryDecision decision = service.evaluate(toolCall, outcome, recoveryCounts);
+            assertInstanceOf(ToolFailureRecoveryDecision.InjectHint.class, decision);
+        }
 
-        // Act & Assert - second attempt: InjectHint
-        ToolFailureRecoveryDecision second = service.evaluate(toolCall, outcome, recoveryCounts);
-        assertInstanceOf(ToolFailureRecoveryDecision.InjectHint.class, second);
-
-        // Act & Assert - third attempt: Stop (budget exhausted)
-        ToolFailureRecoveryDecision third = service.evaluate(toolCall, outcome, recoveryCounts);
-        assertInstanceOf(ToolFailureRecoveryDecision.Stop.class, third);
+        // Act & Assert - seventh attempt: Stop (budget exhausted)
+        ToolFailureRecoveryDecision seventh = service.evaluate(toolCall, outcome, recoveryCounts);
+        assertInstanceOf(ToolFailureRecoveryDecision.Stop.class, seventh);
     }
 
     @Test
@@ -465,8 +464,8 @@ class ToolFailureRecoveryServiceTest {
                 .evaluate(toolCall, outcome, recoveryCounts);
 
         // Assert
-        assertTrue(first.hint().contains("Recovery attempt 1 of 2"));
-        assertTrue(second.hint().contains("Recovery attempt 2 of 2"));
+        assertTrue(first.hint().contains("Recovery attempt 1 of 6"));
+        assertTrue(second.hint().contains("Recovery attempt 2 of 6"));
     }
 
     // -----------------------------------------------------------------------
@@ -485,15 +484,16 @@ class ToolFailureRecoveryServiceTest {
                 "No such file or directory", false, null);
 
         // Act - exhaust budget for command A
-        service.evaluate(toolCallA, outcomeA, recoveryCounts);
-        service.evaluate(toolCallA, outcomeA, recoveryCounts);
-        ToolFailureRecoveryDecision thirdA = service.evaluate(toolCallA, outcomeA, recoveryCounts);
+        for (int attempt = 0; attempt < 6; attempt++) {
+            service.evaluate(toolCallA, outcomeA, recoveryCounts);
+        }
+        ToolFailureRecoveryDecision exhaustedA = service.evaluate(toolCallA, outcomeA, recoveryCounts);
 
         // Command B should still have its own budget
         ToolFailureRecoveryDecision firstB = service.evaluate(toolCallB, outcomeB, recoveryCounts);
 
         // Assert
-        assertInstanceOf(ToolFailureRecoveryDecision.Stop.class, thirdA);
+        assertInstanceOf(ToolFailureRecoveryDecision.Stop.class, exhaustedA);
         assertInstanceOf(ToolFailureRecoveryDecision.InjectHint.class, firstB);
     }
 


### PR DESCRIPTION
## Summary

- Increase the built-in shell recovery hint budget from 2 to 6 attempts before stopping on repeated recoverable shell failures.
- Add a shell-specific ToolLayer prompt policy that advises checking executable availability with `command -v` and avoiding repeated missing commands.
- Update tool-loop and ToolLayer tests to cover the new recovery budget and prompt guidance.