### PR TITLE
fix(auto): bound delayed session actions

### DIFF
--- a/docs/DELAYED_ACTIONS.md
+++ b/docs/DELAYED_ACTIONS.md
@@ -721,7 +721,7 @@ Recommended new config block:
 delayedActions:
   enabled: true
   tickSeconds: 1
-  maxPendingPerSession: 50
+  maxPendingPerSession: 3
   maxDelay: "P30D"
   defaultMaxAttempts: 4
   leaseDuration: "PT2M"
@@ -732,7 +732,9 @@ delayedActions:
 Recommended behavior:
 
 - disable tool exposure when `enabled = false`
-- reject new actions beyond `maxPendingPerSession`
+- reject new actions beyond `maxPendingPerSession` (capped at 3 active actions per session)
+- keep only the latest active action for each duplicate delayed action identity
+- clear active delayed actions for the session when `/stop` is requested
 - reject schedules beyond `maxDelay`
 - prune old terminal actions after `retentionAfterCompletion`
 

--- a/src/main/java/me/golemcore/bot/domain/model/RuntimeConfig.java
+++ b/src/main/java/me/golemcore/bot/domain/model/RuntimeConfig.java
@@ -1248,7 +1248,7 @@ public class RuntimeConfig {
         @Builder.Default
         private Integer tickSeconds = 1;
         @Builder.Default
-        private Integer maxPendingPerSession = 50;
+        private Integer maxPendingPerSession = 3;
         @Builder.Default
         private String maxDelay = "P30D";
         @Builder.Default

--- a/src/main/java/me/golemcore/bot/domain/service/DelayedSessionActionService.java
+++ b/src/main/java/me/golemcore/bot/domain/service/DelayedSessionActionService.java
@@ -50,6 +50,7 @@ import java.util.UUID;
 public class DelayedSessionActionService {
 
     private static final int REGISTRY_VERSION = 1;
+    private static final int MAX_ACTIVE_ACTIONS_PER_SESSION = 3;
 
     private final DelayedActionRegistryPort delayedActionRegistryPort;
     private final RuntimeConfigService runtimeConfigService;
@@ -78,17 +79,15 @@ public class DelayedSessionActionService {
             Instant now = clock.instant();
             DelayedSessionAction normalized = normalizeForCreate(candidate, now);
 
-            if (normalized.getDedupeKey() != null) {
-                DelayedSessionAction existing = findActiveByDedupeKeyLocked(normalized.getDedupeKey());
-                if (existing != null) {
-                    return copyAction(existing);
-                }
-            }
+            int removedDuplicates = removeActiveDuplicatesLocked(normalized);
 
             int pendingForSession = countPendingForSessionLocked(
                     normalized.getChannelType(),
                     normalized.getConversationKey());
-            if (pendingForSession >= runtimeConfigService.getDelayedActionsMaxPendingPerSession()) {
+            if (pendingForSession >= resolveMaxActiveActionsPerSession()) {
+                if (removedDuplicates > 0) {
+                    persistLocked();
+                }
                 throw new IllegalStateException("Maximum pending delayed actions reached for this session");
             }
 
@@ -158,11 +157,7 @@ public class DelayedSessionActionService {
             if (!isUserMutable(action, channelType, conversationKey, now)) {
                 return false;
             }
-            action.setStatus(DelayedActionStatus.CANCELLED);
-            action.setLeaseUntil(null);
-            action.setUpdatedAt(now);
-            action.setCompletedAt(now);
-            action.setExpiresAt(resolveRetentionExpiry(now));
+            cancelActionLocked(action, now);
             persistLocked();
             return true;
         }
@@ -205,16 +200,32 @@ public class DelayedSessionActionService {
                 if (action.getRunAt() != null && !action.getRunAt().isAfter(now)) {
                     continue;
                 }
-                action.setStatus(DelayedActionStatus.CANCELLED);
-                action.setLeaseUntil(null);
-                action.setUpdatedAt(now);
-                action.setCompletedAt(now);
-                action.setExpiresAt(resolveRetentionExpiry(now));
+                cancelActionLocked(action, now);
                 changed = true;
             }
             if (changed) {
                 persistLocked();
             }
+        }
+    }
+
+    public int clearActiveActions(String channelType, String conversationKey) {
+        ensureLoaded();
+        String normalizedChannel = normalizeChannelType(channelType);
+        String normalizedConversation = normalizeConversationKey(conversationKey);
+        synchronized (lock) {
+            List<String> actionIds = actions.values().stream()
+                    .filter(action -> !action.isTerminal())
+                    .filter(action -> matchesSession(action, normalizedChannel, normalizedConversation))
+                    .map(DelayedSessionAction::getId)
+                    .toList();
+            for (String actionId : actionIds) {
+                actions.remove(actionId);
+            }
+            if (!actionIds.isEmpty()) {
+                persistLocked();
+            }
+            return actionIds.size();
         }
     }
 
@@ -312,12 +323,73 @@ public class DelayedSessionActionService {
                 .count();
     }
 
-    private DelayedSessionAction findActiveByDedupeKeyLocked(String dedupeKey) {
-        return actions.values().stream()
+    private int removeActiveDuplicatesLocked(DelayedSessionAction normalized) {
+        String candidateIdentity = buildDedupeIdentity(normalized);
+        if (candidateIdentity == null) {
+            return 0;
+        }
+        List<String> duplicateIds = actions.values().stream()
                 .filter(action -> !action.isTerminal())
-                .filter(action -> dedupeKey.equals(action.getDedupeKey()))
-                .findFirst()
-                .orElse(null);
+                .filter(action -> !Objects.equals(action.getId(), normalized.getId()))
+                .filter(action -> candidateIdentity.equals(buildDedupeIdentity(action)))
+                .map(DelayedSessionAction::getId)
+                .toList();
+        for (String duplicateId : duplicateIds) {
+            actions.remove(duplicateId);
+        }
+        return duplicateIds.size();
+    }
+
+    private void cancelActionLocked(DelayedSessionAction action, Instant now) {
+        action.setStatus(DelayedActionStatus.CANCELLED);
+        action.setLeaseUntil(null);
+        action.setUpdatedAt(now);
+        action.setCompletedAt(now);
+        action.setExpiresAt(resolveRetentionExpiry(now));
+    }
+
+    private int resolveMaxActiveActionsPerSession() {
+        return Math.min(runtimeConfigService.getDelayedActionsMaxPendingPerSession(), MAX_ACTIVE_ACTIONS_PER_SESSION);
+    }
+
+    private String buildDedupeIdentity(DelayedSessionAction action) {
+        if (action == null) {
+            return null;
+        }
+        String channelType = normalizeChannelType(action.getChannelType());
+        String conversationKey = normalizeConversationKey(action.getConversationKey());
+        if (StringValueSupport.isBlank(channelType) || StringValueSupport.isBlank(conversationKey)) {
+            return null;
+        }
+        if (!StringValueSupport.isBlank(action.getDedupeKey())) {
+            return "explicit:" + channelType + ":" + conversationKey + ":" + action.getDedupeKey().trim();
+        }
+        return String.join(":",
+                "auto",
+                channelType,
+                conversationKey,
+                action.getKind() != null ? action.getKind().name() : "unknown",
+                action.getDeliveryMode() != null ? action.getDeliveryMode().name() : "unknown",
+                normalizedValue(action.getJobId()),
+                payloadValue(action, "message"),
+                payloadValue(action, "instruction"),
+                payloadValue(action, "artifactPath"),
+                payloadValue(action, "artifactName"),
+                payloadValue(action, "originalSummary"));
+    }
+
+    private String payloadValue(DelayedSessionAction action, String key) {
+        if (action == null || action.getPayload() == null) {
+            return "";
+        }
+        return normalizedValue(action.getPayload().get(key));
+    }
+
+    private String normalizedValue(Object value) {
+        if (value == null) {
+            return "";
+        }
+        return String.valueOf(value).trim().replaceAll("\\s+", " ").toLowerCase(Locale.ROOT);
     }
 
     private boolean isUserMutable(DelayedSessionAction action, String channelType, String conversationKey,

--- a/src/main/java/me/golemcore/bot/domain/service/RuntimeConfigService.java
+++ b/src/main/java/me/golemcore/bot/domain/service/RuntimeConfigService.java
@@ -166,7 +166,7 @@ public class RuntimeConfigService {
     private static final boolean DEFAULT_PLAN_STOP_ON_FAILURE = true;
     private static final boolean DEFAULT_DELAYED_ACTIONS_ENABLED = true;
     private static final int DEFAULT_DELAYED_ACTIONS_TICK_SECONDS = 1;
-    private static final int DEFAULT_DELAYED_ACTIONS_MAX_PENDING_PER_SESSION = 50;
+    private static final int DEFAULT_DELAYED_ACTIONS_MAX_PENDING_PER_SESSION = 3;
     private static final Duration DEFAULT_DELAYED_ACTIONS_MAX_DELAY = Duration.ofDays(30);
     private static final int DEFAULT_DELAYED_ACTIONS_MAX_ATTEMPTS = 4;
     private static final Duration DEFAULT_DELAYED_ACTIONS_LEASE_DURATION = Duration.ofMinutes(2);
@@ -864,7 +864,8 @@ public class RuntimeConfigService {
             return DEFAULT_DELAYED_ACTIONS_MAX_PENDING_PER_SESSION;
         }
         Integer val = delayedConfig.getMaxPendingPerSession();
-        return val != null && val > 0 ? val : DEFAULT_DELAYED_ACTIONS_MAX_PENDING_PER_SESSION;
+        return val != null && val > 0 ? Math.min(val, DEFAULT_DELAYED_ACTIONS_MAX_PENDING_PER_SESSION)
+                : DEFAULT_DELAYED_ACTIONS_MAX_PENDING_PER_SESSION;
     }
 
     public Duration getDelayedActionsMaxDelay() {
@@ -1946,7 +1947,8 @@ public class RuntimeConfigService {
             cfg.getDelayedActions().setTickSeconds(DEFAULT_DELAYED_ACTIONS_TICK_SECONDS);
         }
         Integer delayedMaxPending = cfg.getDelayedActions().getMaxPendingPerSession();
-        if (delayedMaxPending == null || delayedMaxPending < 1) {
+        if (delayedMaxPending == null || delayedMaxPending < 1
+                || delayedMaxPending > DEFAULT_DELAYED_ACTIONS_MAX_PENDING_PER_SESSION) {
             cfg.getDelayedActions().setMaxPendingPerSession(DEFAULT_DELAYED_ACTIONS_MAX_PENDING_PER_SESSION);
         }
         if (cfg.getDelayedActions().getMaxDelay() == null || cfg.getDelayedActions().getMaxDelay().isBlank()) {

--- a/src/main/java/me/golemcore/bot/domain/service/SessionRunCoordinator.java
+++ b/src/main/java/me/golemcore/bot/domain/service/SessionRunCoordinator.java
@@ -137,6 +137,7 @@ public class SessionRunCoordinator {
     }
 
     public void requestStop(String channelType, String chatId) {
+        clearDelayedActionsForStop(channelType, chatId);
         requestStop(channelType, chatId, null, null);
     }
 
@@ -157,6 +158,20 @@ public class SessionRunCoordinator {
         markInterruptRequested(key);
         publishStopRequestedEvent(key);
         log.info("[Stop] stop requested while no active runner: channel={}, chatId={}", channelType, chatId);
+    }
+
+    private void clearDelayedActionsForStop(String channelType, String chatId) {
+        if (delayedSessionActionService == null) {
+            return;
+        }
+        try {
+            int cleared = delayedSessionActionService.clearActiveActions(channelType, chatId);
+            if (cleared > 0) {
+                log.info("[Stop] cleared {} delayed actions for channel={}, chatId={}", cleared, channelType, chatId);
+            }
+        } catch (RuntimeException e) { // NOSONAR - stop must remain available even if cleanup fails
+            log.warn("[Stop] failed to clear delayed actions: {}", e.getMessage());
+        }
     }
 
     int runnerCount() {

--- a/src/test/java/me/golemcore/bot/domain/service/DelayedSessionActionServiceTest.java
+++ b/src/test/java/me/golemcore/bot/domain/service/DelayedSessionActionServiceTest.java
@@ -38,7 +38,7 @@ class DelayedSessionActionServiceTest {
         delayedActionRegistryPort = new InMemoryDelayedActionRegistryPort();
         runtimeConfigService = mock(RuntimeConfigService.class);
         when(runtimeConfigService.isDelayedActionsEnabled()).thenReturn(true);
-        when(runtimeConfigService.getDelayedActionsMaxPendingPerSession()).thenReturn(50);
+        when(runtimeConfigService.getDelayedActionsMaxPendingPerSession()).thenReturn(3);
         when(runtimeConfigService.getDelayedActionsMaxDelay()).thenReturn(Duration.ofDays(30));
         when(runtimeConfigService.getDelayedActionsDefaultMaxAttempts()).thenReturn(4);
         when(runtimeConfigService.getDelayedActionsLeaseDuration()).thenReturn(Duration.ofMinutes(2));
@@ -68,7 +68,7 @@ class DelayedSessionActionServiceTest {
     }
 
     @Test
-    void shouldReturnExistingActionForMatchingDedupeKey() {
+    void shouldKeepLatestActionForMatchingDedupeKey() {
         DelayedSessionAction first = service.schedule(DelayedSessionAction.builder()
                 .channelType("telegram")
                 .conversationKey("conv-1")
@@ -91,8 +91,95 @@ class DelayedSessionActionServiceTest {
                 .payload(Map.of("message", "Reminder again"))
                 .build());
 
-        assertEquals(first.getId(), second.getId());
-        assertEquals(1, service.listActions("telegram", "conv-1").size());
+        assertFalse(first.getId().equals(second.getId()));
+        assertTrue(service.get(first.getId()).isEmpty());
+        List<DelayedSessionAction> actions = service.listActions("telegram", "conv-1");
+        assertEquals(1, actions.size());
+        assertEquals(second.getId(), actions.get(0).getId());
+    }
+
+    @Test
+    void shouldDedupeEquivalentActionsWithoutExplicitKeyKeepingLatest() {
+        DelayedSessionAction first = service.schedule(DelayedSessionAction.builder()
+                .channelType("telegram")
+                .conversationKey("conv-1")
+                .transportChatId("chat-1")
+                .kind(DelayedActionKind.REMIND_LATER)
+                .deliveryMode(DelayedActionDeliveryMode.DIRECT_MESSAGE)
+                .runAt(NOW.plusSeconds(30))
+                .payload(Map.of("message", "Reminder"))
+                .build());
+
+        DelayedSessionAction second = service.schedule(DelayedSessionAction.builder()
+                .channelType("telegram")
+                .conversationKey("conv-1")
+                .transportChatId("chat-1")
+                .kind(DelayedActionKind.REMIND_LATER)
+                .deliveryMode(DelayedActionDeliveryMode.DIRECT_MESSAGE)
+                .runAt(NOW.plusSeconds(60))
+                .payload(Map.of("message", "Reminder"))
+                .build());
+
+        assertFalse(first.getId().equals(second.getId()));
+        assertTrue(service.get(first.getId()).isEmpty());
+        assertEquals(second.getId(), service.listActions("telegram", "conv-1").get(0).getId());
+    }
+
+    @Test
+    void shouldLimitActiveActionsPerSessionToThree() {
+        for (int index = 1; index <= 3; index++) {
+            service.schedule(DelayedSessionAction.builder()
+                    .channelType("telegram")
+                    .conversationKey("conv-1")
+                    .transportChatId("chat-1")
+                    .kind(DelayedActionKind.REMIND_LATER)
+                    .deliveryMode(DelayedActionDeliveryMode.DIRECT_MESSAGE)
+                    .runAt(NOW.plusSeconds(30 + index))
+                    .payload(Map.of("message", "Reminder " + index))
+                    .build());
+        }
+
+        IllegalStateException error = assertThrows(IllegalStateException.class, () -> service.schedule(
+                DelayedSessionAction.builder()
+                        .channelType("telegram")
+                        .conversationKey("conv-1")
+                        .transportChatId("chat-1")
+                        .kind(DelayedActionKind.REMIND_LATER)
+                        .deliveryMode(DelayedActionDeliveryMode.DIRECT_MESSAGE)
+                        .runAt(NOW.plusSeconds(90))
+                        .payload(Map.of("message", "Reminder 4"))
+                        .build()));
+
+        assertTrue(error.getMessage().contains("Maximum pending delayed actions"));
+        assertEquals(3, service.listActions("telegram", "conv-1").size());
+    }
+
+    @Test
+    void shouldClearActiveActionsForSession() {
+        DelayedSessionAction first = service.schedule(DelayedSessionAction.builder()
+                .channelType("telegram")
+                .conversationKey("conv-1")
+                .transportChatId("chat-1")
+                .kind(DelayedActionKind.REMIND_LATER)
+                .deliveryMode(DelayedActionDeliveryMode.DIRECT_MESSAGE)
+                .runAt(NOW.plusSeconds(30))
+                .payload(Map.of("message", "Reminder 1"))
+                .build());
+        DelayedSessionAction second = service.schedule(DelayedSessionAction.builder()
+                .channelType("telegram")
+                .conversationKey("conv-2")
+                .transportChatId("chat-2")
+                .kind(DelayedActionKind.REMIND_LATER)
+                .deliveryMode(DelayedActionDeliveryMode.DIRECT_MESSAGE)
+                .runAt(NOW.plusSeconds(30))
+                .payload(Map.of("message", "Reminder 2"))
+                .build());
+
+        int cleared = service.clearActiveActions("telegram", "conv-1");
+
+        assertEquals(1, cleared);
+        assertTrue(service.get(first.getId()).isEmpty());
+        assertEquals(second.getId(), service.listActions("telegram", "conv-2").get(0).getId());
     }
 
     @Test

--- a/src/test/java/me/golemcore/bot/domain/service/DelayedSessionActionServiceTest.java
+++ b/src/test/java/me/golemcore/bot/domain/service/DelayedSessionActionServiceTest.java
@@ -155,6 +155,58 @@ class DelayedSessionActionServiceTest {
     }
 
     @Test
+    void shouldAllowDuplicateReplacementWhenSessionIsAtActiveLimit() {
+        DelayedSessionAction first = service.schedule(DelayedSessionAction.builder()
+                .channelType("telegram")
+                .conversationKey("conv-1")
+                .transportChatId("chat-1")
+                .kind(DelayedActionKind.REMIND_LATER)
+                .deliveryMode(DelayedActionDeliveryMode.DIRECT_MESSAGE)
+                .runAt(NOW.plusSeconds(31))
+                .dedupeKey("same-key")
+                .payload(Map.of("message", "Reminder 1"))
+                .build());
+        service.schedule(DelayedSessionAction.builder()
+                .channelType("telegram")
+                .conversationKey("conv-1")
+                .transportChatId("chat-1")
+                .kind(DelayedActionKind.REMIND_LATER)
+                .deliveryMode(DelayedActionDeliveryMode.DIRECT_MESSAGE)
+                .runAt(NOW.plusSeconds(32))
+                .payload(Map.of("message", "Reminder 2"))
+                .build());
+        service.schedule(DelayedSessionAction.builder()
+                .channelType("telegram")
+                .conversationKey("conv-1")
+                .transportChatId("chat-1")
+                .kind(DelayedActionKind.REMIND_LATER)
+                .deliveryMode(DelayedActionDeliveryMode.DIRECT_MESSAGE)
+                .runAt(NOW.plusSeconds(33))
+                .payload(Map.of("message", "Reminder 3"))
+                .build());
+
+        DelayedSessionAction latest = service.schedule(DelayedSessionAction.builder()
+                .channelType("telegram")
+                .conversationKey("conv-1")
+                .transportChatId("chat-1")
+                .kind(DelayedActionKind.REMIND_LATER)
+                .deliveryMode(DelayedActionDeliveryMode.DIRECT_MESSAGE)
+                .runAt(NOW.plusSeconds(60))
+                .dedupeKey("same-key")
+                .payload(Map.of("message", "Reminder latest"))
+                .build());
+
+        List<DelayedSessionAction> actions = service.listActions("telegram", "conv-1");
+        assertEquals(3, actions.size());
+        assertTrue(service.get(first.getId()).isEmpty());
+        DelayedSessionAction deduped = actions.stream()
+                .filter(action -> "same-key".equals(action.getDedupeKey()))
+                .findFirst()
+                .orElseThrow();
+        assertEquals(latest.getId(), deduped.getId());
+    }
+
+    @Test
     void shouldClearActiveActionsForSession() {
         DelayedSessionAction first = service.schedule(DelayedSessionAction.builder()
                 .channelType("telegram")

--- a/src/test/java/me/golemcore/bot/domain/service/RuntimeConfigServiceTest.java
+++ b/src/test/java/me/golemcore/bot/domain/service/RuntimeConfigServiceTest.java
@@ -728,7 +728,7 @@ class RuntimeConfigServiceTest {
 
         assertTrue(service.isDelayedActionsEnabled());
         assertEquals(1, service.getDelayedActionsTickSeconds());
-        assertEquals(50, service.getDelayedActionsMaxPendingPerSession());
+        assertEquals(3, service.getDelayedActionsMaxPendingPerSession());
         assertEquals(java.time.Duration.ofDays(30), service.getDelayedActionsMaxDelay());
         assertEquals(4, service.getDelayedActionsDefaultMaxAttempts());
         assertEquals(java.time.Duration.ofMinutes(2), service.getDelayedActionsLeaseDuration());
@@ -752,7 +752,7 @@ class RuntimeConfigServiceTest {
 
         assertFalse(service.isDelayedActionsEnabled());
         assertEquals(9, service.getDelayedActionsTickSeconds());
-        assertEquals(12, service.getDelayedActionsMaxPendingPerSession());
+        assertEquals(3, service.getDelayedActionsMaxPendingPerSession());
         assertEquals(java.time.Duration.ofHours(6), service.getDelayedActionsMaxDelay());
         assertEquals(7, service.getDelayedActionsDefaultMaxAttempts());
         assertEquals(java.time.Duration.ofMinutes(5), service.getDelayedActionsLeaseDuration());
@@ -776,7 +776,7 @@ class RuntimeConfigServiceTest {
 
         assertTrue(service.isDelayedActionsEnabled());
         assertEquals(1, service.getDelayedActionsTickSeconds());
-        assertEquals(50, service.getDelayedActionsMaxPendingPerSession());
+        assertEquals(3, service.getDelayedActionsMaxPendingPerSession());
         assertEquals(java.time.Duration.ofDays(30), service.getDelayedActionsMaxDelay());
         assertEquals(4, service.getDelayedActionsDefaultMaxAttempts());
         assertEquals(java.time.Duration.ofMinutes(2), service.getDelayedActionsLeaseDuration());
@@ -803,7 +803,7 @@ class RuntimeConfigServiceTest {
         RuntimeConfig updated = service.getRuntimeConfig();
         assertTrue(updated.getDelayedActions().getEnabled());
         assertEquals(1, updated.getDelayedActions().getTickSeconds());
-        assertEquals(50, updated.getDelayedActions().getMaxPendingPerSession());
+        assertEquals(3, updated.getDelayedActions().getMaxPendingPerSession());
         assertEquals("PT720H", updated.getDelayedActions().getMaxDelay());
         assertEquals(4, updated.getDelayedActions().getDefaultMaxAttempts());
         assertEquals("PT2M", updated.getDelayedActions().getLeaseDuration());

--- a/src/test/java/me/golemcore/bot/domain/service/SessionRunCoordinatorDelayedActionsTest.java
+++ b/src/test/java/me/golemcore/bot/domain/service/SessionRunCoordinatorDelayedActionsTest.java
@@ -75,6 +75,24 @@ class SessionRunCoordinatorDelayedActionsTest {
     }
 
     @Test
+    void shouldClearDelayedActionsWhenStopIsRequested() {
+        SessionPort sessionPort = mock(SessionPort.class);
+        AgentLoop agentLoop = mock(AgentLoop.class);
+        RuntimeEventService runtimeEventService = mock(RuntimeEventService.class);
+        RuntimeConfigService runtimeConfigService = mock(RuntimeConfigService.class);
+        DelayedSessionActionService delayedActionService = mock(DelayedSessionActionService.class);
+
+        try (ExecutorService executor = Executors.newSingleThreadExecutor()) {
+            SessionRunCoordinator coordinator = new SessionRunCoordinator(sessionPort, agentLoop, executor,
+                    runtimeEventService, runtimeConfigService, delayedActionService, null);
+
+            coordinator.requestStop(CHANNEL_TYPE, CHAT_ID);
+
+            verify(delayedActionService).clearActiveActions(CHANNEL_TYPE, CHAT_ID);
+        }
+    }
+
+    @Test
     void shouldContinueProcessingInboundWhenDelayedCancellationFails() throws Exception {
         SessionPort sessionPort = mock(SessionPort.class);
         AgentLoop agentLoop = mock(AgentLoop.class);


### PR DESCRIPTION
## Summary

- Clear active delayed session actions when a regular /stop command is requested.
- Deduplicate active delayed actions by keeping only the latest matching task.
- Cap active delayed actions per session at three and update delayed action defaults/docs.
- Add unit coverage for delayed-action dedupe, active action cap, stop cleanup, and runtime config defaults.