### PR TITLE
fix(dashboard): mobile topbar, collapsible chat, a11y & input zoom

### DIFF
--- a/dashboard/.gitignore
+++ b/dashboard/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 node/
 dist/
+test-results/
+tests/mobile-audit/

--- a/dashboard/src/components/chat/ChatToolbar.tsx
+++ b/dashboard/src/components/chat/ChatToolbar.tsx
@@ -1,23 +1,29 @@
 import type { ReactElement } from 'react';
-import { FiLayout, FiMessageSquare, FiPlus } from 'react-icons/fi';
+import { FiChevronDown, FiChevronUp, FiLayout, FiMessageSquare, FiPlus } from 'react-icons/fi';
 
 interface ChatToolbarProps {
   chatSessionId: string;
   connected: boolean;
   panelOpen: boolean;
+  collapsed: boolean;
   onNewChat: () => void;
   onToggleContext: () => void;
+  onToggleCollapsed: () => void;
 }
 
 export function ChatToolbar({
   chatSessionId,
   connected,
   panelOpen,
+  collapsed,
   onNewChat,
   onToggleContext,
+  onToggleCollapsed,
 }: ChatToolbarProps): ReactElement {
+  const collapseLabel = collapsed ? 'Expand chat window' : 'Collapse chat window';
+  const CollapseIcon = collapsed ? FiChevronDown : FiChevronUp;
   return (
-    <div className="chat-toolbar">
+    <div className={`chat-toolbar${collapsed ? ' chat-toolbar--collapsed' : ''}`}>
       <div className="chat-toolbar-inner">
         <div className="chat-toolbar-main">
           <div className="chat-toolbar-title-group">
@@ -58,6 +64,20 @@ export function ChatToolbar({
               <FiLayout size={14} />
             </span>
             <span>{panelOpen ? 'Hide context' : 'Show context'}</span>
+          </button>
+          <button
+            type="button"
+            className="btn btn-sm btn-secondary chat-toolbar-btn chat-toolbar-btn--collapse"
+            onClick={onToggleCollapsed}
+            title={collapseLabel}
+            aria-label={collapseLabel}
+            aria-expanded={!collapsed}
+            aria-controls="chat-workspace-body"
+          >
+            <span className="chat-toolbar-btn-icon" aria-hidden="true">
+              <CollapseIcon size={14} />
+            </span>
+            <span>{collapsed ? 'Expand' : 'Collapse'}</span>
           </button>
         </div>
       </div>

--- a/dashboard/src/components/chat/ChatWindow.tsx
+++ b/dashboard/src/components/chat/ChatWindow.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactElement } from 'react';
 import { Offcanvas } from '../ui/tailwind-components';
 import { useChatSessionStore } from '../../store/chatSessionStore';
+import { useChatUiStore } from '../../store/chatUiStore';
 import { useContextPanelStore } from '../../store/contextPanelStore';
 import { useChatRuntimeStore } from '../../store/chatRuntimeStore';
 import { useCreateSession } from '../../hooks/useSessions';
@@ -67,6 +68,8 @@ export default function ChatWindow(): ReactElement {
     setGoals,
   } = useContextPanelStore();
   const { sessionState, loadEarlierMessages, reloadHistory } = useChatSessionHistory(chatSessionId);
+  const chatCollapsed = useChatUiStore((state) => state.collapsed);
+  const toggleChatCollapsed = useChatUiStore((state) => state.toggleCollapsed);
   const telemetry = useTelemetry();
   const [tier, setTier] = useState('balanced');
   const [tierForce, setTierForce] = useState(false);
@@ -278,40 +281,46 @@ export default function ChatWindow(): ReactElement {
   const messages = useMemo(() => sessionState.messages, [sessionState.messages]);
 
   return (
-    <div className="chat-page-layout">
+    <div className={`chat-page-layout${chatCollapsed ? ' chat-page-layout--collapsed' : ''}`}>
       <div className="chat-container">
         <ChatToolbar
           chatSessionId={chatSessionId}
           connected={isConnected}
           panelOpen={panelOpen}
+          collapsed={chatCollapsed}
           onNewChat={startNewConversation}
           onToggleContext={handleToggleContext}
+          onToggleCollapsed={toggleChatCollapsed}
         />
 
-        <ChatConversation
-          scrollRef={scrollRef}
-          historyLoading={sessionState.historyLoading}
-          historyError={sessionState.historyError}
-          isLoadingEarlier={isLoadingEarlier}
-          hasMoreHistory={sessionState.hasMoreHistory}
-          messages={messages}
-          typing={sessionState.typing}
-          progress={sessionState.progress}
-          modelsConfig={modelsConfig}
-          onScroll={handleScroll}
-          onRetryHistory={reloadHistory}
-          onLoadEarlierMessages={handleLoadEarlierMessages}
-          onRetryMessage={handleRetry}
-          onStarterPromptSelect={(text) => handleSend({ text, attachments: [] })}
-        />
+        {!chatCollapsed && (
+          <div id="chat-workspace-body" className="chat-workspace-body">
+            <ChatConversation
+              scrollRef={scrollRef}
+              historyLoading={sessionState.historyLoading}
+              historyError={sessionState.historyError}
+              isLoadingEarlier={isLoadingEarlier}
+              hasMoreHistory={sessionState.hasMoreHistory}
+              messages={messages}
+              typing={sessionState.typing}
+              progress={sessionState.progress}
+              modelsConfig={modelsConfig}
+              onScroll={handleScroll}
+              onRetryHistory={reloadHistory}
+              onLoadEarlierMessages={handleLoadEarlierMessages}
+              onRetryMessage={handleRetry}
+              onStarterPromptSelect={(text) => handleSend({ text, attachments: [] })}
+            />
 
-        <ChatInput
-          onSend={handleSend}
-          running={running}
-          onStop={() => {
-            stopSession(chatSessionId, clientInstanceId);
-          }}
-        />
+            <ChatInput
+              onSend={handleSend}
+              running={running}
+              onStop={() => {
+                stopSession(chatSessionId, clientInstanceId);
+              }}
+            />
+          </div>
+        )}
       </div>
 
       <ContextPanel

--- a/dashboard/src/store/chatUiStore.ts
+++ b/dashboard/src/store/chatUiStore.ts
@@ -1,0 +1,41 @@
+import { create } from 'zustand';
+
+const STORAGE_KEY = 'gc.chat.collapsed';
+
+function loadInitial(): boolean {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+  try {
+    return window.localStorage.getItem(STORAGE_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+function persist(value: boolean): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  try {
+    window.localStorage.setItem(STORAGE_KEY, value ? '1' : '0');
+  } catch {
+    // Ignore quota or privacy-mode failures; collapse state stays in memory.
+  }
+}
+
+interface ChatUiState {
+  collapsed: boolean;
+  toggleCollapsed: () => void;
+}
+
+export const useChatUiStore = create<ChatUiState>((set) => ({
+  collapsed: loadInitial(),
+  toggleCollapsed: (): void => {
+    set((state) => {
+      const next = !state.collapsed;
+      persist(next);
+      return { collapsed: next };
+    });
+  },
+}));

--- a/dashboard/src/styles/custom.scss
+++ b/dashboard/src/styles/custom.scss
@@ -314,7 +314,7 @@ textarea:focus-visible,
 }
 
 .topbar {
-  height: 64px;
+  height: var(--topbar-height);
   background-color: var(--gc-body-bg);
   border-bottom: 1px solid var(--gc-border-color);
   backdrop-filter: blur(10px);
@@ -1261,6 +1261,29 @@ textarea:focus-visible,
   justify-content: center;
   background-color: rgba(var(--gc-body-bg-rgb), 0.6);
   border: 1px solid rgba(var(--gc-border-color-rgb), 0.55);
+}
+
+.chat-workspace-body {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+}
+
+.chat-toolbar--collapsed {
+  padding: 0.55rem 1rem;
+
+  .chat-toolbar-subtitle,
+  .chat-toolbar-status {
+    display: none;
+  }
+}
+
+.chat-page-layout--collapsed {
+  .chat-container {
+    flex: 0 0 auto;
+    height: auto;
+  }
 }
 
 .chat-history-load-btn {
@@ -2642,6 +2665,21 @@ textarea:focus-visible,
 }
 
 @media (max-width: 767.98px) {
+  .topbar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 110;
+    height: calc(var(--topbar-height) + env(safe-area-inset-top, 0px));
+    padding-top: env(safe-area-inset-top, 0px);
+    box-shadow: 0 6px 16px rgba(15, 23, 42, 0.12);
+  }
+
+  .dashboard-shell-body {
+    padding-top: calc(var(--topbar-height) + env(safe-area-inset-top, 0px));
+  }
+
   .topbar-icon-btn,
   .topbar-action-btn,
   .topbar-update-btn {

--- a/dashboard/src/styles/responsive.scss
+++ b/dashboard/src/styles/responsive.scss
@@ -49,4 +49,19 @@
   .logs-detail-meta {
     align-items: flex-start;
   }
+
+  // iOS Safari zooms in when a focused input has font-size < 16px.
+  input[type='text'],
+  input[type='email'],
+  input[type='password'],
+  input[type='search'],
+  input[type='url'],
+  input[type='tel'],
+  input[type='number'],
+  input:not([type]),
+  textarea,
+  select,
+  .form-control {
+    font-size: 16px;
+  }
 }

--- a/dashboard/src/styles/tailwind.css
+++ b/dashboard/src/styles/tailwind.css
@@ -5,6 +5,7 @@
 @layer base {
   :root {
     --sidebar-width: 18rem;
+    --topbar-height: 64px;
     --font-sans: "Manrope", "Avenir Next", "Segoe UI", sans-serif;
     --font-display: "Space Grotesk", "Avenir Next", "Trebuchet MS", sans-serif;
     --font-mono: "JetBrains Mono", "SFMono-Regular", "SF Mono", monospace;

--- a/dashboard/tests/e2e/mobile-audit.playwright.ts
+++ b/dashboard/tests/e2e/mobile-audit.playwright.ts
@@ -1,0 +1,194 @@
+import { test, type Page } from '@playwright/test';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import { installDashboardApiMocks } from './dashboardMocks';
+
+interface AuditRoute {
+  slug: string;
+  url: string;
+}
+
+interface OverflowHit {
+  tag: string;
+  id: string;
+  classes: string;
+  text: string;
+  rect: { left: number; right: number; width: number };
+}
+
+interface AuditReport {
+  slug: string;
+  viewport: string;
+  url: string;
+  documentScrollHeight: number;
+  bodyScrollWidth: number;
+  innerWidth: number;
+  topbarBoundingTop: number | null;
+  topbarPosition: string | null;
+  topbarVisibleAfterScroll: boolean | null;
+  overflowHits: OverflowHit[];
+  tapTargetsTooSmall: number;
+}
+
+const ROUTES: AuditRoute[] = [
+  { slug: 'chat-root', url: '/' },
+  { slug: 'prompts', url: '/dashboard/prompts' },
+  { slug: 'webhooks', url: '/dashboard/webhooks' },
+  { slug: 'diagnostics', url: '/dashboard/diagnostics' },
+  { slug: 'logs', url: '/dashboard/logs' },
+  { slug: 'settings', url: '/dashboard/settings' },
+  { slug: 'sessions', url: '/dashboard/sessions' },
+  { slug: 'skills', url: '/dashboard/skills' },
+];
+
+const VIEWPORTS = [
+  { label: '375x667', width: 375, height: 667 },
+  { label: '414x896', width: 414, height: 896 },
+  { label: '768x1024', width: 768, height: 1024 },
+];
+
+const OUT_DIR = path.join(process.cwd(), 'tests', 'mobile-audit');
+
+async function gatherAudit(page: Page, slug: string, viewport: string, url: string): Promise<AuditReport> {
+  const metrics = await page.evaluate(() => {
+    const body = document.body;
+    const html = document.documentElement;
+    const topbar = document.querySelector<HTMLElement>('.topbar');
+    const topbarPosition = topbar != null ? window.getComputedStyle(topbar).position : null;
+    const topbarBoundingTop = topbar != null ? topbar.getBoundingClientRect().top : null;
+
+    const overflowHits: OverflowHit[] = [];
+    for (const el of Array.from(body.querySelectorAll<HTMLElement>('*'))) {
+      if (el.closest('.sidebar') != null) {
+        const sidebar = el.closest('.sidebar') as HTMLElement;
+        if (!sidebar.classList.contains('mobile-open')) {
+          continue;
+        }
+      }
+      const rect = el.getBoundingClientRect();
+      if (rect.width === 0 || rect.height === 0) {
+        continue;
+      }
+      if (rect.right > window.innerWidth + 1 || rect.left < -1) {
+        overflowHits.push({
+          tag: el.tagName,
+          id: el.id,
+          classes: el.className.toString().slice(0, 100),
+          text: (el.textContent ?? '').trim().slice(0, 60),
+          rect: { left: Math.round(rect.left), right: Math.round(rect.right), width: Math.round(rect.width) },
+        });
+        if (overflowHits.length >= 8) break;
+      }
+    }
+
+    let tapTargetsTooSmall = 0;
+    for (const btn of Array.from(document.querySelectorAll<HTMLElement>('button, a[href]'))) {
+      const rect = btn.getBoundingClientRect();
+      if (rect.width === 0 || rect.height === 0) continue;
+      if (rect.width < 36 || rect.height < 36) {
+        tapTargetsTooSmall += 1;
+      }
+    }
+
+    return {
+      documentScrollHeight: Math.max(body.scrollHeight, html.scrollHeight),
+      bodyScrollWidth: Math.max(body.scrollWidth, html.scrollWidth),
+      innerWidth: window.innerWidth,
+      topbarBoundingTop,
+      topbarPosition,
+      overflowHits,
+      tapTargetsTooSmall,
+    };
+  });
+
+  await page.evaluate(() => {
+    const main = document.querySelector<HTMLElement>('main#main-content, main.dashboard-main, main.dashboard-main-shell');
+    if (main != null) {
+      main.scrollTop = Math.min(main.scrollHeight, 400);
+    }
+    window.scrollTo(0, 400);
+  });
+  const topbarVisibleAfterScroll = await page.evaluate(() => {
+    const topbar = document.querySelector<HTMLElement>('.topbar');
+    if (topbar == null) return null;
+    const rect = topbar.getBoundingClientRect();
+    return rect.top >= -1 && rect.top <= 10;
+  });
+
+  return {
+    slug,
+    viewport,
+    url,
+    ...metrics,
+    topbarVisibleAfterScroll,
+  };
+}
+
+test.describe.configure({ mode: 'serial' });
+
+test.beforeAll(async () => {
+  await fs.mkdir(OUT_DIR, { recursive: true });
+});
+
+test('chat collapse toggle persists and hides conversation', async ({ browser }) => {
+  const context = await browser.newContext({
+    viewport: { width: 375, height: 667 },
+    isMobile: true,
+    hasTouch: true,
+  });
+  const page = await context.newPage();
+  await installDashboardApiMocks(page);
+  await page.goto('/', { waitUntil: 'networkidle' }).catch(() => {});
+  await page.waitForTimeout(400);
+
+  await page.getByRole('button', { name: /Collapse chat window/i }).click();
+  await page.waitForTimeout(150);
+  const shotCollapsed = path.join(OUT_DIR, 'chat-collapsed.png');
+  await page.screenshot({ path: shotCollapsed, fullPage: false });
+
+  const collapsedState = await page.evaluate(() => {
+    const toolbar = document.querySelector('.chat-toolbar');
+    const layout = document.querySelector('.chat-page-layout');
+    const input = document.querySelector('.chat-input-area');
+    return {
+      toolbarHasCollapsedClass: toolbar?.classList.contains('chat-toolbar--collapsed') ?? false,
+      layoutHasCollapsedClass: layout?.classList.contains('chat-page-layout--collapsed') ?? false,
+      inputPresent: input != null,
+    };
+  });
+
+  if (!collapsedState.toolbarHasCollapsedClass) {
+    throw new Error('chat-toolbar--collapsed class should be applied after click');
+  }
+  if (collapsedState.inputPresent) {
+    throw new Error('chat input should be hidden when collapsed');
+  }
+
+  await context.close();
+});
+
+for (const viewport of VIEWPORTS) {
+  test(`mobile audit @ ${viewport.label}`, async ({ browser }) => {
+    test.setTimeout(120_000);
+    const context = await browser.newContext({
+      viewport: { width: viewport.width, height: viewport.height },
+      isMobile: viewport.width < 768,
+      hasTouch: viewport.width < 768,
+    });
+    const page = await context.newPage();
+    await installDashboardApiMocks(page);
+
+    const reports: AuditReport[] = [];
+    for (const route of ROUTES) {
+      await page.goto(route.url, { waitUntil: 'networkidle' }).catch(() => {});
+      const report = await gatherAudit(page, route.slug, viewport.label, route.url);
+      reports.push(report);
+      const screenshotPath = path.join(OUT_DIR, `${viewport.label}-${route.slug}.png`);
+      await page.screenshot({ path: screenshotPath, fullPage: false });
+    }
+
+    const reportPath = path.join(OUT_DIR, `report-${viewport.label}.json`);
+    await fs.writeFile(reportPath, JSON.stringify(reports, null, 2));
+    await context.close();
+  });
+}


### PR DESCRIPTION
## Summary

Playwright-audited mobile dashboard pass that targets the issues reported against the mobile layout:

- **Topbar is now truly fixed on mobile.** The previous `position: sticky` sat inside `overflow-hidden` ancestors, so it degraded to a static flex child. Mobile override promotes it to `position: fixed` with `env(safe-area-inset-top)` padding + drop shadow; `.dashboard-shell-body` gets matching `padding-top` so content clears it.
- **Collapsible chat window.** New `chatUiStore` (Zustand, localStorage-persisted) backs a Collapse/Expand button in `ChatToolbar` that hides `ChatConversation` + `ChatInput` behind a new `#chat-workspace-body` region. `aria-controls` / `aria-expanded` wire the button to the region for screen readers.
- **iOS focus-zoom fix.** Mobile media query pins form control `font-size` to 16px so Safari no longer zooms in on input focus.
- **Shared `--topbar-height` token** lifted to `:root` in `tailwind.css` to keep topbar math in one place.
- **Playwright mobile audit** (`tests/e2e/mobile-audit.playwright.ts`) captures per-route metrics + screenshots across 375/414/768 viewports and verifies the collapse flow hides the conversation/input.

