### PR TITLE
test: expand PIT mutation scope to the full product

### DIFF
--- a/.github/workflows/pitests.yml
+++ b/.github/workflows/pitests.yml
@@ -8,9 +8,9 @@ on:
 
 env:
   PLUGIN_API_REPO_REF: 67cd0d10a997f494dcaf4686438e5c6bcfc8ac65
-  # Full-product baseline locked from run 24462559861: 65% mutation score,
-  # 83% line coverage. Raise as coverage grows toward the old 85% bar.
-  PITEST_MUTATION_THRESHOLD: 65
+  # Full-product baseline (post proto exclusion): ~71% mutation score.
+  # Threshold tracks the current gate; raise as coverage grows toward 85%.
+  PITEST_MUTATION_THRESHOLD: 70
 
 jobs:
   pitests:

--- a/.github/workflows/pitests.yml
+++ b/.github/workflows/pitests.yml
@@ -8,9 +8,9 @@ on:
 
 env:
   PLUGIN_API_REPO_REF: 67cd0d10a997f494dcaf4686438e5c6bcfc8ac65
-  # Baseline is 0 while full-product PIT scope is being stabilized; raise
-  # gradually as coverage grows to match the old domain-only 85% bar.
-  PITEST_MUTATION_THRESHOLD: 0
+  # Full-product baseline locked from run 24462559861: 65% mutation score,
+  # 83% line coverage. Raise as coverage grows toward the old 85% bar.
+  PITEST_MUTATION_THRESHOLD: 65
 
 jobs:
   pitests:

--- a/.github/workflows/pitests.yml
+++ b/.github/workflows/pitests.yml
@@ -8,9 +8,8 @@ on:
 
 env:
   PLUGIN_API_REPO_REF: 67cd0d10a997f494dcaf4686438e5c6bcfc8ac65
-  # Full-product baseline (post proto exclusion): ~71% mutation score.
-  # Threshold tracks the current gate; raise as coverage grows toward 85%.
-  PITEST_MUTATION_THRESHOLD: 70
+  # Full-product mutation gate. Keep this aligned with the required quality bar.
+  PITEST_MUTATION_THRESHOLD: 85
 
 jobs:
   pitests:

--- a/.github/workflows/pitests.yml
+++ b/.github/workflows/pitests.yml
@@ -8,7 +8,9 @@ on:
 
 env:
   PLUGIN_API_REPO_REF: 67cd0d10a997f494dcaf4686438e5c6bcfc8ac65
-  PITEST_MUTATION_THRESHOLD: 85
+  # Baseline is 0 while full-product PIT scope is being stabilized; raise
+  # gradually as coverage grows to match the old domain-only 85% bar.
+  PITEST_MUTATION_THRESHOLD: 0
 
 jobs:
   pitests:

--- a/pom.xml
+++ b/pom.xml
@@ -524,13 +524,19 @@
     </build>
 
     <profiles>
-        <!-- Mutation testing profile for CI-only focused checks. -->
+        <!-- Mutation testing profile. Opt-in via `./mvnw -P pitests test-compile
+             org.pitest:pitest-maven:mutationCoverage`, or via the "PIT Tests"
+             GitHub Actions workflow. Scoped to the full product — every
+             `me.golemcore.bot.*` class — so survivors surface across the whole
+             codebase rather than just a curated domain subset. The threshold
+             is informational (0) because the full-product baseline has not
+             been established yet; raise it in follow-ups as coverage grows. -->
         <profile>
             <id>pitests</id>
             <properties>
                 <pitest.version>1.23.0</pitest.version>
                 <pitest.junit5.plugin.version>1.2.3</pitest.junit5.plugin.version>
-                <pitest.mutationThreshold>85</pitest.mutationThreshold>
+                <pitest.mutationThreshold>0</pitest.mutationThreshold>
                 <pitest.threads>4</pitest.threads>
             </properties>
             <build>
@@ -548,39 +554,29 @@
                         </dependencies>
                         <configuration>
                             <!--
-                                Mutation testing is scoped to a curated subset of the domain
-                                module: the context pipeline layers, context resolvers, memory
-                                diagnostics/orchestrator, self-evolving run + promotion services,
-                                and the tool-loop conversation view. These packages form the
-                                deterministic core of the agent loop and have the highest
-                                existing test strength, so a stringent mutation threshold here
-                                provides meaningful regression protection without requiring the
-                                full domain module to clear the same bar in a single run.
+                                Full-product mutation scope: every class under
+                                `me.golemcore.bot` is mutated. The exclusions below are
+                                intentional:
 
-                                Classes excluded below either depend on Spring-wired
-                                infrastructure that mutation testing cannot easily exercise
-                                (e.g. RagLayer, AutoModeLayer) or are thin coordination layers
-                                whose logic is covered indirectly by integration tests.
+                                  * The application entrypoint and Spring `@Configuration`
+                                    classes carry no meaningful logic for PIT to mutate.
+                                  * Generated sources (MapStruct, Lombok @Builder helpers)
+                                    are wrapped in `*MapperImpl` / `*$Builder` and PIT
+                                    cannot drive them from unit tests.
                             -->
                             <targetClasses>
-                                <param>me.golemcore.bot.domain.context.layer.*</param>
-                                <param>me.golemcore.bot.domain.context.resolution.*</param>
-                                <param>me.golemcore.bot.domain.memory.diagnostics.*</param>
-                                <param>me.golemcore.bot.domain.memory.orchestrator.*</param>
-                                <param>me.golemcore.bot.domain.selfevolving.run.*</param>
-                                <param>me.golemcore.bot.domain.selfevolving.promotion.*</param>
-                                <param>me.golemcore.bot.domain.system.toolloop.view.*</param>
+                                <param>me.golemcore.bot.*</param>
                             </targetClasses>
                             <excludedClasses>
-                                <param>me.golemcore.bot.domain.context.layer.TierAwarenessLayer</param>
-                                <param>me.golemcore.bot.domain.context.layer.AutoModeLayer</param>
-                                <param>me.golemcore.bot.domain.context.layer.RagLayer</param>
-                                <param>me.golemcore.bot.domain.memory.orchestrator.MemoryContextOrchestrator</param>
-                                <param>me.golemcore.bot.domain.selfevolving.promotion.PromotionTargetResolver</param>
-                                <param>me.golemcore.bot.domain.system.toolloop.view.FlatteningToolMessageMasker</param>
+                                <param>me.golemcore.bot.BotApplication</param>
+                                <param>me.golemcore.bot.config.*</param>
+                                <param>me.golemcore.bot.*Config</param>
+                                <param>me.golemcore.bot.*Configuration</param>
+                                <param>me.golemcore.bot.*$*Builder</param>
+                                <param>me.golemcore.bot.*MapperImpl</param>
                             </excludedClasses>
                             <targetTests>
-                                <param>me.golemcore.bot.domain.*</param>
+                                <param>me.golemcore.bot.*</param>
                             </targetTests>
                             <threads>${pitest.threads}</threads>
                             <mutationThreshold>${pitest.mutationThreshold}</mutationThreshold>

--- a/pom.xml
+++ b/pom.xml
@@ -574,6 +574,12 @@
                                 <param>me.golemcore.bot.*Configuration</param>
                                 <param>me.golemcore.bot.*$*Builder</param>
                                 <param>me.golemcore.bot.*MapperImpl</param>
+                                <!-- Generated protobuf classes: not hand-written, PIT
+                                     should not mutate them. -->
+                                <param>me.golemcore.bot.proto.*</param>
+                                <param>me.golemcore.bot.proto.*$*</param>
+                                <param>me.golemcore.bot.adapter.inbound.web.proto.*</param>
+                                <param>me.golemcore.bot.adapter.inbound.web.proto.*$*</param>
                             </excludedClasses>
                             <targetTests>
                                 <param>me.golemcore.bot.*</param>

--- a/src/test/java/me/golemcore/bot/adapter/outbound/update/GitHubReleaseSourceAdapterTest.java
+++ b/src/test/java/me/golemcore/bot/adapter/outbound/update/GitHubReleaseSourceAdapterTest.java
@@ -756,7 +756,9 @@ class GitHubReleaseSourceAdapterTest {
                 public void cancel() {
                 }
             });
-            subscriber.onNext(List.of(ByteBuffer.wrap(payload)));
+            if (payload.length > 0) {
+                subscriber.onNext(List.of(ByteBuffer.wrap(payload)));
+            }
             subscriber.onComplete();
             T decodedBody = subscriber.getBody().toCompletableFuture().join();
 


### PR DESCRIPTION
## Summary

Expand the PIT mutation workflow from the previous curated domain subset to the full product (`me.golemcore.bot.*`), establish a baseline, and lock the gate at a realistic threshold.

## What changed

- **pitests profile**: `targetClasses` now covers `me.golemcore.bot.*`. Excludes `BotApplication`, Spring `@Configuration` classes, Lombok `@Builder` helpers, MapStruct `*MapperImpl`, and generated protobuf classes under `me.golemcore.bot.proto.*` / `me.golemcore.bot.adapter.inbound.web.proto.*` (2646 mutants that have no meaningful tests).
- **Workflow**: `.github/workflows/pitests.yml` stays manual-only (`workflow_dispatch`). Threshold env var set to `70`.
- **Test fix**: `GitHubReleaseSourceAdapterTest` stub HTTP client no longer calls `onNext` with an empty `ByteBuffer`. `ByteArraySubscriber` (used by `HttpResponse.BodyHandlers.ofString()`) asserts `hasRemaining` and PIT runs with assertions enabled (`-ea`), so the redirect tests were blocking PIT's green-suite preflight. Skipping `onNext` for zero-length payloads matches real HTTP client behaviour and unblocks the run.

## Baseline

Run [24466638840](https://github.com/alexk-dev/golemcore-bot/actions/runs/24466638840) (green):

| Metric | Value |
|---|---|
| Mutation score | **71%** (16282 / 22904) |
| Line coverage | 88% (37596 / 42608) |
| Test strength | 80% |
| Uncovered mutants | 2509 |

## Follow-ups

The 70% threshold locks in the current gate. Top-gap classes for incremental test additions to raise the bar toward 85%:

| Gap | Class |
|---:|---|
| 382 | `RuntimeConfigService` |
| 187 | `AgentLoop` |
| 177 | `PluginMarketplaceService` |
| 175 | `PluginManager` |
| 155 | `AutoModeService` |
| 131 | `Langchain4jAdapter` |

Raise `PITEST_MUTATION_THRESHOLD` as classes are addressed.

## Test plan

- [x] Reproduce PIT preflight failure locally
- [x] Confirm stub fix with `./mvnw -P pitests ... -DtargetClasses=.GitHubReleaseSourceAdapter`
- [x] Full-product PIT run green locally baseline
- [x] GH Actions `PIT Tests` workflow green on `test/pit-full-product`