### PR TITLE
refactor: split large runtime helpers

### DIFF
--- a/src/main/java/me/golemcore/bot/adapter/outbound/llm/Langchain4jAdapter.java
+++ b/src/main/java/me/golemcore/bot/adapter/outbound/llm/Langchain4jAdapter.java
@@ -27,11 +27,11 @@ import me.golemcore.bot.domain.model.Message;
 import me.golemcore.bot.domain.model.catalog.ModelCatalogEntry;
 import me.golemcore.bot.domain.model.RuntimeConfig;
 import me.golemcore.bot.domain.model.Secret;
-import me.golemcore.bot.domain.service.ToolArtifactService;
 import me.golemcore.bot.domain.service.RuntimeConfigService;
 import me.golemcore.bot.domain.system.LlmErrorPatterns;
 import me.golemcore.bot.port.outbound.ModelConfigPort;
 import me.golemcore.bot.port.outbound.LlmPort;
+import me.golemcore.bot.port.outbound.ToolArtifactReadPort;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.langchain4j.agent.tool.ToolSpecification;
 import dev.langchain4j.data.message.ChatMessage;
@@ -118,7 +118,6 @@ public class Langchain4jAdapter implements LlmProviderAdapter, LlmComponent {
 
     private final RuntimeConfigService runtimeConfigService;
     private final ModelConfigPort modelConfig;
-    private final ToolArtifactService toolArtifactService;
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final Langchain4jMessageConverter messageConverter;
     private final Langchain4jToolSchemaConverter toolSchemaConverter;
@@ -130,11 +129,10 @@ public class Langchain4jAdapter implements LlmProviderAdapter, LlmComponent {
     private final Map<String, StreamingChatModel> responsesStreamingModels = new java.util.concurrent.ConcurrentHashMap<>();
 
     public Langchain4jAdapter(RuntimeConfigService runtimeConfigService, ModelConfigPort modelConfig,
-            ToolArtifactService toolArtifactService) {
+            ToolArtifactReadPort toolArtifactReadPort) {
         this.runtimeConfigService = runtimeConfigService;
         this.modelConfig = modelConfig;
-        this.toolArtifactService = toolArtifactService;
-        this.messageConverter = new Langchain4jMessageConverter(toolArtifactService, objectMapper);
+        this.messageConverter = new Langchain4jMessageConverter(toolArtifactReadPort, objectMapper);
         this.toolSchemaConverter = new Langchain4jToolSchemaConverter();
         this.responseMapper = new Langchain4jResponseMapper(objectMapper);
     }

--- a/src/main/java/me/golemcore/bot/adapter/outbound/llm/Langchain4jAdapter.java
+++ b/src/main/java/me/golemcore/bot/adapter/outbound/llm/Langchain4jAdapter.java
@@ -34,51 +34,30 @@ import me.golemcore.bot.domain.service.RuntimeConfigService;
 import me.golemcore.bot.domain.system.LlmErrorPatterns;
 import me.golemcore.bot.port.outbound.ModelConfigPort;
 import me.golemcore.bot.port.outbound.LlmPort;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import dev.langchain4j.agent.tool.ToolExecutionRequest;
 import dev.langchain4j.agent.tool.ToolSpecification;
-import dev.langchain4j.data.image.Image;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
-import dev.langchain4j.data.message.Content;
-import dev.langchain4j.data.message.ImageContent;
 import dev.langchain4j.data.message.SystemMessage;
-import dev.langchain4j.data.message.TextContent;
-import dev.langchain4j.data.message.ToolExecutionResultMessage;
-import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.http.client.HttpClientBuilder;
 import dev.langchain4j.http.client.HttpClientBuilderLoader;
 import dev.langchain4j.model.anthropic.AnthropicChatModel;
 import dev.langchain4j.model.chat.ChatModel;
 import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.model.chat.request.ChatRequest;
-import dev.langchain4j.model.chat.request.json.JsonArraySchema;
-import dev.langchain4j.model.chat.request.json.JsonBooleanSchema;
-import dev.langchain4j.model.chat.request.json.JsonEnumSchema;
-import dev.langchain4j.model.chat.request.json.JsonIntegerSchema;
-import dev.langchain4j.model.chat.request.json.JsonNumberSchema;
-import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
-import dev.langchain4j.model.chat.request.json.JsonSchemaElement;
-import dev.langchain4j.model.chat.request.json.JsonStringSchema;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.model.googleai.GoogleAiGeminiChatModel;
 import dev.langchain4j.model.openai.OpenAiChatModel;
 import dev.langchain4j.model.openai.OpenAiResponsesStreamingChatModel;
 import dev.langchain4j.model.output.TokenUsage;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Flux;
 
 import java.time.Duration;
-import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Base64;
 import java.util.Collections;
-import java.util.Deque;
-import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -120,7 +99,6 @@ import java.util.concurrent.CompletableFuture;
  * @see me.golemcore.bot.infrastructure.config.ModelConfigService
  */
 @Component
-@RequiredArgsConstructor
 @Slf4j
 public class Langchain4jAdapter implements LlmProviderAdapter, LlmComponent {
 
@@ -133,13 +111,8 @@ public class Langchain4jAdapter implements LlmProviderAdapter, LlmComponent {
     private static final String API_TYPE_OPENAI = "openai";
     private static final String API_TYPE_ANTHROPIC = "anthropic";
     private static final String API_TYPE_GEMINI = "gemini";
-    private static final String GEMINI_THINKING_SIGNATURE_KEY = "thinking_signature";
-    private static final String TOOL_ATTACHMENTS_METADATA_KEY = "toolAttachments";
-    private static final String SYNTH_ID_PREFIX = "synth_call_";
-    private static final String SCHEMA_KEY_PROPERTIES = "properties";
     private static final java.util.regex.Pattern RESET_SECONDS_PATTERN = java.util.regex.Pattern
             .compile("\"reset_seconds\"\\s*:\\s*(\\d+)");
-    private static final String TOOL_ATTACHMENT_REOPEN_HINT = "Re-open the file with a tool if deeper inspection is needed.";
     private static final Set<String> RATE_LIMIT_MARKERS = Set.of(
             "rate_limit",
             "rate limit",
@@ -148,18 +121,28 @@ public class Langchain4jAdapter implements LlmProviderAdapter, LlmComponent {
             "model_cooldown",
             "cooling down");
 
-    private record MessageConversionResult(List<ChatMessage> messages, boolean hydratedToolImages) {
-    }
-
     private final RuntimeConfigService runtimeConfigService;
     private final ModelConfigPort modelConfig;
     private final ToolArtifactService toolArtifactService;
     private final ObjectMapper objectMapper = new ObjectMapper();
+    private final Langchain4jMessageConverter messageConverter;
+    private final Langchain4jToolSchemaConverter toolSchemaConverter;
+    private final Langchain4jResponseMapper responseMapper;
 
     private ChatModel chatModel;
     private String currentModel;
     private volatile boolean initialized = false;
     private final Map<String, StreamingChatModel> responsesStreamingModels = new java.util.concurrent.ConcurrentHashMap<>();
+
+    public Langchain4jAdapter(RuntimeConfigService runtimeConfigService, ModelConfigPort modelConfig,
+            ToolArtifactService toolArtifactService) {
+        this.runtimeConfigService = runtimeConfigService;
+        this.modelConfig = modelConfig;
+        this.toolArtifactService = toolArtifactService;
+        this.messageConverter = new Langchain4jMessageConverter(toolArtifactService, objectMapper);
+        this.toolSchemaConverter = new Langchain4jToolSchemaConverter();
+        this.responseMapper = new Langchain4jResponseMapper(objectMapper);
+    }
 
     @Override
     public synchronized void initialize() {
@@ -776,11 +759,10 @@ public class Langchain4jAdapter implements LlmProviderAdapter, LlmComponent {
         return this;
     }
 
-    private static final TypeReference<Map<String, Object>> MAP_TYPE_REF = new TypeReference<>() {
-    };
-
     private MessageConversionResult buildChatMessages(LlmRequest request) {
-        return convertMessages(request, isGeminiRequest(request));
+        return messageConverter.convertMessages(request.getSystemPrompt(), request.getMessages(),
+                isGeminiRequest(request),
+                isVisionCapableRequest(request), request.isDisableToolAttachmentHydration());
     }
 
     // Package-private for reflection-based adapter tests in the same package.
@@ -788,143 +770,10 @@ public class Langchain4jAdapter implements LlmProviderAdapter, LlmComponent {
         return buildChatMessages(request).messages();
     }
 
-    private MessageConversionResult convertMessages(LlmRequest request, boolean geminiApiType) {
-        return convertMessages(request.getSystemPrompt(), request.getMessages(), geminiApiType,
-                isVisionCapableRequest(request), request.isDisableToolAttachmentHydration());
-    }
-
     private List<ChatMessage> convertMessagesWithFlattenedToolHistory(LlmRequest request) {
-        return convertMessagesWithFlattenedToolHistory(request, isGeminiRequest(request));
-    }
-
-    private List<ChatMessage> convertMessagesWithFlattenedToolHistory(LlmRequest request, boolean geminiApiType) {
         List<Message> flattenedMessages = Message.flattenToolMessages(request.getMessages());
-        return convertMessages(request.getSystemPrompt(), flattenedMessages, geminiApiType,
+        return messageConverter.convertMessages(request.getSystemPrompt(), flattenedMessages, isGeminiRequest(request),
                 isVisionCapableRequest(request), request.isDisableToolAttachmentHydration()).messages();
-    }
-
-    private MessageConversionResult convertMessages(String systemPrompt, List<Message> requestMessages,
-            boolean geminiApiType, boolean visionCapableTarget, boolean disableToolAttachmentHydration) {
-        List<ChatMessage> messages = new ArrayList<>();
-        List<Message> normalizedMessages = normalizeMessagesForProvider(requestMessages, geminiApiType);
-        boolean hydratedToolImages = false;
-
-        // Add system message
-        if (systemPrompt != null && !systemPrompt.isBlank()) {
-            messages.add(SystemMessage.from(systemPrompt));
-        }
-
-        if (normalizedMessages == null) {
-            return new MessageConversionResult(messages, false);
-        }
-
-        // Synthetic ID generation: langchain4j serializes null-ID tool calls as
-        // legacy "function_call" and null-ID tool results as "role: function",
-        // both rejected by GPT-5.2+. Assign synthetic IDs where missing.
-        // Also track emitted tool call IDs to detect orphaned tool messages
-        // whose preceding assistant message was removed (e.g. by compaction).
-        int synthCounter = 0;
-        Deque<String> pendingSynthIds = new ArrayDeque<>();
-        Set<String> emittedToolCallIds = new HashSet<>();
-        int firstTrailingToolIndex = findFirstTrailingToolMessageIndex(normalizedMessages);
-
-        for (int index = 0; index < normalizedMessages.size(); index++) {
-            Message msg = normalizedMessages.get(index);
-            switch (msg.getRole()) {
-            case "user" -> messages.add(toUserMessage(msg));
-            case "assistant" -> {
-                if (msg.hasToolCalls()) {
-                    List<ToolExecutionRequest> toolRequests = new ArrayList<>();
-                    for (Message.ToolCall tc : msg.getToolCalls()) {
-                        String id = tc.getId();
-                        if (id == null || id.isBlank()) {
-                            synthCounter++;
-                            id = SYNTH_ID_PREFIX + synthCounter;
-                            pendingSynthIds.addLast(id);
-                        }
-                        emittedToolCallIds.add(id);
-                        toolRequests.add(ToolExecutionRequest.builder()
-                                .id(id)
-                                .name(tc.getName())
-                                .arguments(convertArgsToJson(tc.getArguments()))
-                                .build());
-                    }
-                    AiMessage.Builder aiMessageBuilder = AiMessage.builder()
-                            .toolExecutionRequests(toolRequests);
-                    if (msg.getContent() != null && !msg.getContent().isBlank()) {
-                        aiMessageBuilder.text(msg.getContent());
-                    }
-                    String thinkingSignature = geminiApiType ? extractGeminiThinkingSignature(msg) : null;
-                    if (thinkingSignature != null) {
-                        aiMessageBuilder.attributes(Map.of(GEMINI_THINKING_SIGNATURE_KEY, thinkingSignature));
-                    }
-                    messages.add(aiMessageBuilder.build());
-                } else {
-                    messages.add(AiMessage.from(nonNullText(msg.getContent())));
-                }
-            }
-            case "tool" -> {
-                String toolCallId = msg.getToolCallId();
-                if (toolCallId == null || toolCallId.isBlank()) {
-                    if (pendingSynthIds.isEmpty()) {
-                        synthCounter++;
-                        toolCallId = SYNTH_ID_PREFIX + synthCounter;
-                    } else {
-                        toolCallId = pendingSynthIds.pollFirst();
-                    }
-                }
-                if (emittedToolCallIds.contains(toolCallId)) {
-                    messages.add(ToolExecutionResultMessage.from(
-                            toolCallId,
-                            msg.getToolName(),
-                            nonNullText(msg.getContent())));
-                    boolean hydrateToolImages = shouldHydrateToolAttachments(index, firstTrailingToolIndex,
-                            visionCapableTarget, disableToolAttachmentHydration);
-                    UserMessage toolVisualContext = toToolAttachmentContextMessage(msg, hydrateToolImages);
-                    if (toolVisualContext != null) {
-                        messages.add(toolVisualContext);
-                        hydratedToolImages = hydratedToolImages || hasImageContent(toolVisualContext);
-                    }
-                } else {
-                    log.debug("[LLM] Converting orphaned tool message to text: tool={}",
-                            msg.getToolName());
-                    String toolText = "[Tool: " + nonNullText(msg.getToolName())
-                            + "]\n[Result: " + nonNullText(msg.getContent()) + "]";
-                    boolean hydrateToolImages = shouldHydrateToolAttachments(index, firstTrailingToolIndex,
-                            visionCapableTarget, disableToolAttachmentHydration);
-                    UserMessage orphanedToolContext = toToolAttachmentContextMessage(msg, hydrateToolImages);
-                    messages.add(orphanedToolContext != null ? orphanedToolContext : UserMessage.from(toolText));
-                    if (orphanedToolContext != null) {
-                        hydratedToolImages = hydratedToolImages || hasImageContent(orphanedToolContext);
-                    }
-                }
-            }
-            case "system" -> messages.add(SystemMessage.from(nonNullText(msg.getContent())));
-            default -> log.warn("Unknown message role: {}, treating as user message", msg.getRole());
-            }
-        }
-
-        return new MessageConversionResult(messages, hydratedToolImages);
-    }
-
-    private List<Message> normalizeMessagesForProvider(List<Message> requestMessages, boolean geminiApiType) {
-        if (!geminiApiType || requestMessages == null || requestMessages.isEmpty()) {
-            return requestMessages;
-        }
-
-        long missingSignatureCount = requestMessages.stream()
-                .filter(Message::isAssistantMessage)
-                .filter(Message::hasToolCalls)
-                .filter(msg -> extractGeminiThinkingSignature(msg) == null)
-                .count();
-        if (missingSignatureCount == 0) {
-            return requestMessages;
-        }
-
-        log.warn(
-                "[LLM] Flattening tool history for Gemini request because {} assistant tool-call message(s) are missing thinking_signature",
-                missingSignatureCount);
-        return Message.flattenToolMessages(requestMessages);
     }
 
     private boolean isGeminiRequest(LlmRequest request) {
@@ -941,17 +790,6 @@ public class Langchain4jAdapter implements LlmProviderAdapter, LlmComponent {
         return API_TYPE_GEMINI.equals(getApiType(getProviderConfig(provider)));
     }
 
-    private String extractGeminiThinkingSignature(Message msg) {
-        if (msg == null || msg.getMetadata() == null) {
-            return null;
-        }
-        Object value = msg.getMetadata().get(GEMINI_THINKING_SIGNATURE_KEY);
-        if (value instanceof String signature && !signature.isBlank()) {
-            return signature;
-        }
-        return null;
-    }
-
     private boolean isVisionCapableRequest(LlmRequest request) {
         String model = request != null && request.getModel() != null && !request.getModel().isBlank()
                 ? request.getModel()
@@ -962,539 +800,38 @@ public class Langchain4jAdapter implements LlmProviderAdapter, LlmComponent {
         return modelConfig.supportsVision(model);
     }
 
-    private String nonNullText(String text) {
-        return text != null ? text : "";
-    }
-
-    private int findFirstTrailingToolMessageIndex(List<Message> messages) {
-        if (messages == null || messages.isEmpty()) {
-            return -1;
-        }
-
-        int index = messages.size() - 1;
-        while (index >= 0) {
-            Message message = messages.get(index);
-            if (message == null || !"tool".equals(message.getRole())) {
-                break;
-            }
-            index--;
-        }
-
-        int firstTrailingToolIndex = index + 1;
-        return firstTrailingToolIndex < messages.size() ? firstTrailingToolIndex : -1;
-    }
-
-    private boolean shouldHydrateToolAttachments(int messageIndex, int firstTrailingToolIndex,
-            boolean visionCapableTarget, boolean disableToolAttachmentHydration) {
-        return visionCapableTarget
-                && !disableToolAttachmentHydration
-                && firstTrailingToolIndex >= 0
-                && messageIndex >= firstTrailingToolIndex;
-    }
-
     private boolean isUnsupportedFunctionRoleError(Throwable throwable) {
-        Throwable current = throwable;
-        while (current != null) {
-            String message = current.getMessage();
-            if (message != null) {
-                // Legacy function role rejected by newer models
-                if (message.contains("unsupported_value")
-                        && message.contains("does not support 'function'")) {
-                    return true;
-                }
-                // Orphaned tool message without preceding tool_calls
-                if (message.contains("role 'tool' must be a response to")
-                        && message.contains("tool_calls")) {
-                    return true;
-                }
-            }
-            current = current.getCause();
-        }
-        return false;
-    }
-
-    @SuppressWarnings("unchecked")
-    private UserMessage toUserMessage(Message msg) {
-        List<Content> contents = new ArrayList<>();
-
-        if (msg.getContent() != null && !msg.getContent().isBlank()) {
-            contents.add(TextContent.from(msg.getContent()));
-        }
-
-        Map<String, Object> metadata = msg.getMetadata();
-        if (metadata != null) {
-            Object attachmentsRaw = metadata.get("attachments");
-            if (attachmentsRaw instanceof List<?> attachments) {
-                for (Object attachmentObj : attachments) {
-                    if (!(attachmentObj instanceof Map<?, ?> attachmentMap)) {
-                        continue;
-                    }
-
-                    Object typeObj = attachmentMap.get("type");
-                    Object mimeObj = attachmentMap.get("mimeType");
-                    Object dataObj = attachmentMap.get("dataBase64");
-
-                    if (!(typeObj instanceof String type)
-                            || !(mimeObj instanceof String mimeType)
-                            || !(dataObj instanceof String base64Data)) {
-                        continue;
-                    }
-                    if (!"image".equals(type) || !mimeType.startsWith("image/") || base64Data.isBlank()) {
-                        continue;
-                    }
-
-                    Image image = Image.builder()
-                            .base64Data(base64Data)
-                            .mimeType(mimeType)
-                            .build();
-                    contents.add(ImageContent.from(image));
-                }
-            }
-        }
-
-        if (contents.isEmpty()) {
-            return UserMessage.from(msg.getContent() != null ? msg.getContent() : "");
-        }
-
-        return UserMessage.from(contents);
-    }
-
-    @SuppressWarnings("unchecked")
-    private UserMessage toToolAttachmentContextMessage(Message msg, boolean hydrateImages) {
-        if (msg == null || msg.getMetadata() == null) {
-            return null;
-        }
-
-        Object attachmentsRaw = msg.getMetadata().get(TOOL_ATTACHMENTS_METADATA_KEY);
-        if (!(attachmentsRaw instanceof List<?> attachments)) {
-            return null;
-        }
-
-        List<Content> contents = new ArrayList<>();
-        String text = buildToolAttachmentContextText(msg, attachments);
-        if (text != null && !text.isBlank()) {
-            contents.add(TextContent.from(text));
-        }
-
-        if (!hydrateImages || toolArtifactService == null) {
-            return contents.isEmpty() ? null : UserMessage.from(contents);
-        }
-
-        for (Object attachmentObj : attachments) {
-            if (!(attachmentObj instanceof Map<?, ?> attachmentMap)) {
-                continue;
-            }
-
-            Object typeObj = attachmentMap.get("type");
-            Object pathObj = attachmentMap.get("internalFilePath");
-            if (!(typeObj instanceof String type)
-                    || !(pathObj instanceof String internalFilePath)
-                    || !"image".equals(type)
-                    || internalFilePath.isBlank()) {
-                continue;
-            }
-
-            try {
-                var download = toolArtifactService.getDownload(internalFilePath);
-                String mimeType = download.getMimeType();
-                if (mimeType == null || !mimeType.startsWith("image/")) {
-                    continue;
-                }
-                String base64Data = Base64.getEncoder().encodeToString(download.getData());
-                Image image = Image.builder()
-                        .base64Data(base64Data)
-                        .mimeType(mimeType)
-                        .build();
-                contents.add(ImageContent.from(image));
-            } catch (RuntimeException ex) {
-                log.warn("[LLM] Failed to hydrate tool image attachment '{}': {}", internalFilePath, ex.getMessage());
-            }
-        }
-
-        if (contents.isEmpty()) {
-            return null;
-        }
-
-        return UserMessage.from(contents);
-    }
-
-    private String buildToolAttachmentContextText(Message msg, List<?> attachments) {
-        String toolName = msg.getToolName() != null && !msg.getToolName().isBlank()
-                ? msg.getToolName()
-                : "tool";
-        List<String> lines = new ArrayList<>();
-        lines.add("Tool artifact from " + toolName + " is available.");
-
-        boolean foundAttachment = false;
-        for (Object attachmentObj : attachments) {
-            if (!(attachmentObj instanceof Map<?, ?> attachmentMap)) {
-                continue;
-            }
-            String path = objectAsString(attachmentMap.get("internalFilePath"));
-            if (path == null || path.isBlank()) {
-                continue;
-            }
-            String name = objectAsString(attachmentMap.get("name"));
-            String mimeType = objectAsString(attachmentMap.get("mimeType"));
-            String displayName = name != null && !name.isBlank() ? name : path.substring(path.lastIndexOf('/') + 1);
-            StringBuilder line = new StringBuilder("- ").append(displayName);
-            if (mimeType != null && !mimeType.isBlank()) {
-                line.append(" (").append(mimeType).append(")");
-            }
-            line.append(" @ ").append(path);
-            lines.add(line.toString());
-            foundAttachment = true;
-        }
-
-        if (!foundAttachment) {
-            return null;
-        }
-
-        lines.add(TOOL_ATTACHMENT_REOPEN_HINT);
-        return String.join("\n", lines);
-    }
-
-    private String objectAsString(Object value) {
-        if (value instanceof String stringValue) {
-            return stringValue;
-        }
-        return null;
+        return Langchain4jMessageConverter.isUnsupportedFunctionRoleError(throwable);
     }
 
     private List<ToolSpecification> convertTools(LlmRequest request) {
-        if (request.getTools() == null || request.getTools().isEmpty()) {
-            return Collections.emptyList();
-        }
-
-        Map<String, ToolDefinition> uniqueTools = new LinkedHashMap<>();
-        for (ToolDefinition tool : request.getTools()) {
-            if (tool == null || tool.getName() == null || tool.getName().isBlank()) {
-                log.warn("[LLM] Dropping tool with blank name before request serialization");
-                continue;
-            }
-            ToolDefinition previous = uniqueTools.putIfAbsent(tool.getName(), tool);
-            if (previous != null) {
-                log.warn("[LLM] Dropping duplicate tool definition '{}' before request serialization", tool.getName());
-            }
-        }
-
-        List<ToolSpecification> tools = new ArrayList<>(uniqueTools.size());
-        for (ToolDefinition tool : uniqueTools.values()) {
-            tools.add(convertToolDefinition(tool));
-        }
-        return tools;
-    }
-
-    private ToolSpecification convertToolDefinition(ToolDefinition tool) {
-        ToolSpecification.Builder builder = ToolSpecification.builder()
-                .name(tool.getName())
-                .description(tool.getDescription());
-
-        // Convert input schema to JsonObjectSchema parameters
-        if (tool.getInputSchema() != null) {
-            Map<String, Object> schema = tool.getInputSchema();
-            Map<String, Object> properties = stringObjectMap(schema.get(SCHEMA_KEY_PROPERTIES),
-                    tool.getName(), SCHEMA_KEY_PROPERTIES);
-            List<String> required = stringList(schema.get("required"), tool.getName(), "required");
-            if (properties != null) {
-                JsonObjectSchema.Builder schemaBuilder = JsonObjectSchema.builder();
-                for (Map.Entry<String, Object> entry : properties.entrySet()) {
-                    String paramName = entry.getKey();
-                    Map<String, Object> paramSchema = stringObjectMap(entry.getValue(), tool.getName(),
-                            SCHEMA_KEY_PROPERTIES + "." + paramName);
-                    if (paramSchema == null) {
-                        log.warn("[LLM] Dropping invalid schema for tool '{}' param '{}'", tool.getName(), paramName);
-                        continue;
-                    }
-                    schemaBuilder.addProperty(paramName, toJsonSchemaElement(tool.getName(),
-                            SCHEMA_KEY_PROPERTIES + "." + paramName, paramSchema));
-                }
-                if (required != null && !required.isEmpty()) {
-                    schemaBuilder.required(required);
-                }
-                builder.parameters(schemaBuilder.build());
-            }
-        }
-
-        return builder.build();
-    }
-
-    private JsonSchemaElement toJsonSchemaElement(String toolName, String path, Map<String, Object> paramSchema) {
-        String type = stringValue(paramSchema.get("type"), toolName, path + ".type");
-        String description = stringValue(paramSchema.get("description"), toolName, path + ".description");
-        List<String> enumValues = stringList(paramSchema.get("enum"), toolName, path + ".enum");
-
-        // Enum values take priority
-        if (enumValues != null && !enumValues.isEmpty()) {
-            JsonEnumSchema.Builder builder = JsonEnumSchema.builder().enumValues(enumValues);
-            if (description != null && !description.isBlank()) {
-                builder.description(description);
-            }
-            return builder.build();
-        }
-
-        if (type == null) {
-            type = "string";
-        }
-
-        switch (type) {
-        case "string" -> {
-            JsonStringSchema.Builder builder = JsonStringSchema.builder();
-            if (description != null && !description.isBlank()) {
-                builder.description(description);
-            }
-            return builder.build();
-        }
-        case "integer" -> {
-            JsonIntegerSchema.Builder builder = JsonIntegerSchema.builder();
-            if (description != null && !description.isBlank()) {
-                builder.description(description);
-            }
-            return builder.build();
-        }
-        case "number" -> {
-            JsonNumberSchema.Builder builder = JsonNumberSchema.builder();
-            if (description != null && !description.isBlank()) {
-                builder.description(description);
-            }
-            return builder.build();
-        }
-        case "boolean" -> {
-            JsonBooleanSchema.Builder builder = JsonBooleanSchema.builder();
-            if (description != null && !description.isBlank()) {
-                builder.description(description);
-            }
-            return builder.build();
-        }
-        case "array" -> {
-            JsonArraySchema.Builder builder = JsonArraySchema.builder();
-            if (description != null && !description.isBlank()) {
-                builder.description(description);
-            }
-            if (paramSchema.containsKey("items")) {
-                Map<String, Object> items = stringObjectMap(paramSchema.get("items"), toolName, path + ".items");
-                if (items != null) {
-                    builder.items(toJsonSchemaElement(toolName, path + ".items", items));
-                }
-            }
-            return builder.build();
-        }
-        case "object" -> {
-            JsonObjectSchema.Builder builder = JsonObjectSchema.builder();
-            if (description != null && !description.isBlank()) {
-                builder.description(description);
-            }
-            if (paramSchema.containsKey(SCHEMA_KEY_PROPERTIES)) {
-                Map<String, Object> nestedProps = stringObjectMap(paramSchema.get(SCHEMA_KEY_PROPERTIES),
-                        toolName, path + "." + SCHEMA_KEY_PROPERTIES);
-                if (nestedProps != null) {
-                    for (Map.Entry<String, Object> entry : nestedProps.entrySet()) {
-                        Map<String, Object> nestedSchema = stringObjectMap(entry.getValue(), toolName,
-                                path + "." + SCHEMA_KEY_PROPERTIES + "." + entry.getKey());
-                        if (nestedSchema == null) {
-                            log.warn("[LLM] Dropping invalid nested schema for tool '{}' at {}", toolName,
-                                    path + "." + SCHEMA_KEY_PROPERTIES + "." + entry.getKey());
-                            continue;
-                        }
-                        builder.addProperty(entry.getKey(), toJsonSchemaElement(toolName,
-                                path + "." + SCHEMA_KEY_PROPERTIES + "." + entry.getKey(), nestedSchema));
-                    }
-                }
-            }
-            return builder.build();
-        }
-        default -> {
-            // Fallback to string for unknown types
-            JsonStringSchema.Builder builder = JsonStringSchema.builder();
-            if (description != null && !description.isBlank()) {
-                builder.description(description);
-            }
-            return builder.build();
-        }
-        }
-    }
-
-    @SuppressWarnings({
-            "unchecked",
-            "PMD.ReturnEmptyCollectionRatherThanNull"
-    })
-    private Map<String, Object> stringObjectMap(Object rawValue, String toolName, String path) {
-        if (!(rawValue instanceof Map<?, ?> rawMap)) {
-            if (rawValue != null) {
-                log.warn("[LLM] Invalid schema object for tool '{}' at {}: {}", toolName, path,
-                        rawValue.getClass().getSimpleName());
-            }
-            return null;
-        }
-        Map<String, Object> casted = new LinkedHashMap<>();
-        for (Map.Entry<?, ?> entry : rawMap.entrySet()) {
-            if (!(entry.getKey() instanceof String key)) {
-                log.warn("[LLM] Dropping non-string schema key for tool '{}' at {}", toolName, path);
-                continue;
-            }
-            casted.put(key, (Object) entry.getValue());
-        }
-        return casted;
-    }
-
-    @SuppressWarnings("PMD.ReturnEmptyCollectionRatherThanNull")
-    private List<String> stringList(Object rawValue, String toolName, String path) {
-        if (!(rawValue instanceof List<?> rawList)) {
-            if (rawValue != null) {
-                log.warn("[LLM] Invalid schema list for tool '{}' at {}: {}", toolName, path,
-                        rawValue.getClass().getSimpleName());
-            }
-            return null;
-        }
-        List<String> values = new ArrayList<>(rawList.size());
-        for (Object item : rawList) {
-            if (item instanceof String stringValue && !stringValue.isBlank()) {
-                values.add(stringValue);
-            } else {
-                log.warn("[LLM] Dropping non-string schema list item for tool '{}' at {}", toolName, path);
-            }
-        }
-        return values;
-    }
-
-    private String stringValue(Object rawValue, String toolName, String path) {
-        if (rawValue == null) {
-            return null;
-        }
-        if (rawValue instanceof String stringValue) {
-            return stringValue;
-        }
-        log.warn("[LLM] Invalid schema string for tool '{}' at {}: {}", toolName, path,
-                rawValue.getClass().getSimpleName());
-        return null;
+        return toolSchemaConverter.convertTools(request);
     }
 
     private LlmResponse convertResponse(ChatResponse response, boolean compatibilityFlatteningApplied,
             boolean geminiApiType) {
-        AiMessage aiMessage = response.aiMessage();
-
-        // Convert tool calls if present
-        List<Message.ToolCall> toolCalls = null;
-        if (aiMessage.hasToolExecutionRequests()) {
-            toolCalls = aiMessage.toolExecutionRequests().stream()
-                    .map(ter -> Message.ToolCall.builder()
-                            .id(ter.id())
-                            .name(ter.name())
-                            .arguments(parseJsonArgs(ter.arguments()))
-                            .build())
-                    .toList();
-            log.trace("Parsed {} tool calls from response", toolCalls.size());
-        }
-
-        LlmUsage usage = toLlmUsage(response.tokenUsage());
-
-        Map<String, Object> providerMetadata = extractProviderMetadata(aiMessage, geminiApiType);
-
-        return LlmResponse.builder()
-                .content(aiMessage.text())
-                .toolCalls(toolCalls)
-                .usage(usage)
-                .model(currentModel)
-                .finishReason(response.finishReason() != null ? response.finishReason().name() : "stop")
-                .providerMetadata(providerMetadata.isEmpty() ? null : providerMetadata)
-                .compatibilityFlatteningApplied(compatibilityFlatteningApplied)
-                .build();
+        return responseMapper.convertResponse(response, currentModel, compatibilityFlatteningApplied, geminiApiType);
     }
 
     private LlmResponse withProviderMetadata(LlmResponse response, Map<String, Object> extraMetadata) {
-        if (response == null || extraMetadata == null || extraMetadata.isEmpty()) {
-            return response;
-        }
-
-        Map<String, Object> merged = new LinkedHashMap<>();
-        if (response.getProviderMetadata() != null) {
-            merged.putAll(response.getProviderMetadata());
-        }
-        merged.putAll(extraMetadata);
-
-        return LlmResponse.builder()
-                .content(response.getContent())
-                .toolCalls(response.getToolCalls())
-                .usage(response.getUsage())
-                .model(response.getModel())
-                .finishReason(response.getFinishReason())
-                .providerMetadata(merged)
-                .compatibilityFlatteningApplied(response.isCompatibilityFlatteningApplied())
-                .build();
+        return Langchain4jResponseMapper.withProviderMetadata(response, extraMetadata);
     }
 
-    private LlmUsage toLlmUsage(TokenUsage tokenUsage) {
-        if (tokenUsage == null) {
-            return null;
-        }
-
-        Integer inputTokens = tokenUsage.inputTokenCount();
-        Integer outputTokens = tokenUsage.outputTokenCount();
-        Integer totalTokens = tokenUsage.totalTokenCount();
-        if (inputTokens == null && outputTokens == null && totalTokens == null) {
-            return null;
-        }
-
-        int safeInputTokens = safeTokenCount(inputTokens);
-        int safeOutputTokens = safeTokenCount(outputTokens);
-        int safeTotalTokens = totalTokens != null ? totalTokens : safeInputTokens + safeOutputTokens;
-
-        return LlmUsage.builder()
-                .inputTokens(safeInputTokens)
-                .outputTokens(safeOutputTokens)
-                .totalTokens(safeTotalTokens)
-                .build();
-    }
-
-    private int safeTokenCount(Integer value) {
-        return value != null ? value : 0;
-    }
-
-    private Map<String, Object> extractProviderMetadata(AiMessage aiMessage, boolean geminiApiType) {
-        if (!geminiApiType || aiMessage == null || !aiMessage.hasToolExecutionRequests()) {
-            return Collections.emptyMap();
-        }
-        String thinkingSignature = aiMessage.attribute(GEMINI_THINKING_SIGNATURE_KEY, String.class);
-        if (thinkingSignature == null || thinkingSignature.isBlank()) {
-            return Collections.emptyMap();
-        }
-        return Map.of(GEMINI_THINKING_SIGNATURE_KEY, thinkingSignature);
-    }
-
-    private boolean hasImageContent(UserMessage message) {
-        if (message == null || message.contents() == null) {
-            return false;
-        }
-        for (Content content : message.contents()) {
-            if (content.type() == dev.langchain4j.data.message.ContentType.IMAGE) {
-                return true;
+    private String convertArgsToJson(Object args) {
+        if (args instanceof Map<?, ?> rawMap) {
+            Map<String, Object> casted = new LinkedHashMap<>();
+            for (Map.Entry<?, ?> entry : rawMap.entrySet()) {
+                if (entry.getKey() instanceof String key) {
+                    casted.put(key, entry.getValue());
+                }
             }
+            return Langchain4jToolArgumentJson.toJson(casted, objectMapper);
         }
-        return false;
+        return Langchain4jToolArgumentJson.toJson(null, objectMapper);
     }
 
-    private String convertArgsToJson(Map<String, Object> args) {
-        if (args == null || args.isEmpty()) {
-            return "{}";
-        }
-        try {
-            return objectMapper.writeValueAsString(args);
-        } catch (Exception e) {
-            log.warn("Failed to serialize tool arguments: {}", e.getMessage());
-            return "{}";
-        }
-    }
-
-    private Map<String, Object> parseJsonArgs(String json) {
-        if (json == null || json.isBlank()) {
-            return Collections.emptyMap();
-        }
-        try {
-            return objectMapper.readValue(json, MAP_TYPE_REF);
-        } catch (Exception e) {
-            log.warn("Failed to parse tool arguments: {}", e.getMessage());
-            return Collections.emptyMap();
-        }
+    private Map<String, Object> parseJsonArgs(Object json) {
+        return Langchain4jToolArgumentJson.parse(json instanceof String stringValue ? stringValue : null, objectMapper);
     }
 
     protected void sleepBeforeRetry(long backoffMs) throws InterruptedException {

--- a/src/main/java/me/golemcore/bot/adapter/outbound/llm/Langchain4jAdapter.java
+++ b/src/main/java/me/golemcore/bot/adapter/outbound/llm/Langchain4jAdapter.java
@@ -23,12 +23,10 @@ import me.golemcore.bot.domain.model.LlmChunk;
 import me.golemcore.bot.domain.model.LlmProviderMetadataKeys;
 import me.golemcore.bot.domain.model.LlmRequest;
 import me.golemcore.bot.domain.model.LlmResponse;
-import me.golemcore.bot.domain.model.LlmUsage;
 import me.golemcore.bot.domain.model.Message;
 import me.golemcore.bot.domain.model.catalog.ModelCatalogEntry;
 import me.golemcore.bot.domain.model.RuntimeConfig;
 import me.golemcore.bot.domain.model.Secret;
-import me.golemcore.bot.domain.model.ToolDefinition;
 import me.golemcore.bot.domain.service.ToolArtifactService;
 import me.golemcore.bot.domain.service.RuntimeConfigService;
 import me.golemcore.bot.domain.system.LlmErrorPatterns;
@@ -36,9 +34,7 @@ import me.golemcore.bot.port.outbound.ModelConfigPort;
 import me.golemcore.bot.port.outbound.LlmPort;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.langchain4j.agent.tool.ToolSpecification;
-import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
-import dev.langchain4j.data.message.SystemMessage;
 import dev.langchain4j.http.client.HttpClientBuilder;
 import dev.langchain4j.http.client.HttpClientBuilderLoader;
 import dev.langchain4j.model.anthropic.AnthropicChatModel;
@@ -50,7 +46,6 @@ import dev.langchain4j.model.chat.response.StreamingChatResponseHandler;
 import dev.langchain4j.model.googleai.GoogleAiGeminiChatModel;
 import dev.langchain4j.model.openai.OpenAiChatModel;
 import dev.langchain4j.model.openai.OpenAiResponsesStreamingChatModel;
-import dev.langchain4j.model.output.TokenUsage;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Flux;
@@ -817,7 +812,7 @@ public class Langchain4jAdapter implements LlmProviderAdapter, LlmComponent {
         return Langchain4jResponseMapper.withProviderMetadata(response, extraMetadata);
     }
 
-    private String convertArgsToJson(Object args) {
+    String convertArgsToJson(Object args) {
         if (args instanceof Map<?, ?> rawMap) {
             Map<String, Object> casted = new LinkedHashMap<>();
             for (Map.Entry<?, ?> entry : rawMap.entrySet()) {
@@ -830,7 +825,7 @@ public class Langchain4jAdapter implements LlmProviderAdapter, LlmComponent {
         return Langchain4jToolArgumentJson.toJson(null, objectMapper);
     }
 
-    private Map<String, Object> parseJsonArgs(Object json) {
+    Map<String, Object> parseJsonArgs(Object json) {
         return Langchain4jToolArgumentJson.parse(json instanceof String stringValue ? stringValue : null, objectMapper);
     }
 

--- a/src/main/java/me/golemcore/bot/adapter/outbound/llm/Langchain4jMessageConverter.java
+++ b/src/main/java/me/golemcore/bot/adapter/outbound/llm/Langchain4jMessageConverter.java
@@ -1,0 +1,374 @@
+package me.golemcore.bot.adapter.outbound.llm;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.langchain4j.agent.tool.ToolExecutionRequest;
+import dev.langchain4j.data.image.Image;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
+import dev.langchain4j.data.message.Content;
+import dev.langchain4j.data.message.ImageContent;
+import dev.langchain4j.data.message.SystemMessage;
+import dev.langchain4j.data.message.TextContent;
+import dev.langchain4j.data.message.ToolExecutionResultMessage;
+import dev.langchain4j.data.message.UserMessage;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import me.golemcore.bot.domain.model.Message;
+import me.golemcore.bot.domain.model.ToolArtifactDownload;
+import me.golemcore.bot.domain.service.ToolArtifactService;
+
+@RequiredArgsConstructor
+@Slf4j
+class Langchain4jMessageConverter {
+
+    private static final String GEMINI_THINKING_SIGNATURE_KEY = "thinking_signature";
+    private static final String TOOL_ATTACHMENTS_METADATA_KEY = "toolAttachments";
+    private static final String SYNTH_ID_PREFIX = "synth_call_";
+    private static final String TOOL_ATTACHMENT_REOPEN_HINT = "Re-open the file with a tool if deeper inspection is needed.";
+
+    private final ToolArtifactService toolArtifactService;
+    private final ObjectMapper objectMapper;
+
+    MessageConversionResult convertMessages(String systemPrompt, List<Message> requestMessages,
+            boolean geminiApiType, boolean visionCapableTarget, boolean disableToolAttachmentHydration) {
+        List<ChatMessage> messages = new ArrayList<>();
+        List<Message> normalizedMessages = normalizeMessagesForProvider(requestMessages, geminiApiType);
+        boolean hydratedToolImages = false;
+
+        if (systemPrompt != null && !systemPrompt.isBlank()) {
+            messages.add(SystemMessage.from(systemPrompt));
+        }
+
+        if (normalizedMessages == null) {
+            return new MessageConversionResult(messages, false);
+        }
+
+        int synthCounter = 0;
+        Deque<String> pendingSynthIds = new ArrayDeque<>();
+        Set<String> emittedToolCallIds = new HashSet<>();
+        int firstTrailingToolIndex = findFirstTrailingToolMessageIndex(normalizedMessages);
+
+        for (int index = 0; index < normalizedMessages.size(); index++) {
+            Message msg = normalizedMessages.get(index);
+            switch (msg.getRole()) {
+            case "user" -> messages.add(toUserMessage(msg));
+            case "assistant" -> {
+                if (msg.hasToolCalls()) {
+                    List<ToolExecutionRequest> toolRequests = new ArrayList<>();
+                    for (Message.ToolCall tc : msg.getToolCalls()) {
+                        String id = tc.getId();
+                        if (id == null || id.isBlank()) {
+                            synthCounter++;
+                            id = SYNTH_ID_PREFIX + synthCounter;
+                            pendingSynthIds.addLast(id);
+                        }
+                        emittedToolCallIds.add(id);
+                        toolRequests.add(ToolExecutionRequest.builder()
+                                .id(id)
+                                .name(tc.getName())
+                                .arguments(Langchain4jToolArgumentJson.toJson(tc.getArguments(), objectMapper))
+                                .build());
+                    }
+                    AiMessage.Builder aiMessageBuilder = AiMessage.builder()
+                            .toolExecutionRequests(toolRequests);
+                    if (msg.getContent() != null && !msg.getContent().isBlank()) {
+                        aiMessageBuilder.text(msg.getContent());
+                    }
+                    String thinkingSignature = geminiApiType ? extractGeminiThinkingSignature(msg) : null;
+                    if (thinkingSignature != null) {
+                        aiMessageBuilder.attributes(Map.of(GEMINI_THINKING_SIGNATURE_KEY, thinkingSignature));
+                    }
+                    messages.add(aiMessageBuilder.build());
+                } else {
+                    messages.add(AiMessage.from(nonNullText(msg.getContent())));
+                }
+            }
+            case "tool" -> {
+                String toolCallId = msg.getToolCallId();
+                if (toolCallId == null || toolCallId.isBlank()) {
+                    if (pendingSynthIds.isEmpty()) {
+                        synthCounter++;
+                        toolCallId = SYNTH_ID_PREFIX + synthCounter;
+                    } else {
+                        toolCallId = pendingSynthIds.pollFirst();
+                    }
+                }
+                boolean hydrateToolImages = shouldHydrateToolAttachments(index, firstTrailingToolIndex,
+                        visionCapableTarget, disableToolAttachmentHydration);
+                if (emittedToolCallIds.contains(toolCallId)) {
+                    messages.add(ToolExecutionResultMessage.from(
+                            toolCallId,
+                            msg.getToolName(),
+                            nonNullText(msg.getContent())));
+                    UserMessage toolVisualContext = toToolAttachmentContextMessage(msg, hydrateToolImages);
+                    if (toolVisualContext != null) {
+                        messages.add(toolVisualContext);
+                        hydratedToolImages = hydratedToolImages || hasImageContent(toolVisualContext);
+                    }
+                } else {
+                    log.debug("[LLM] Converting orphaned tool message to text: tool={}", msg.getToolName());
+                    String toolText = "[Tool: " + nonNullText(msg.getToolName())
+                            + "]\n[Result: " + nonNullText(msg.getContent()) + "]";
+                    UserMessage orphanedToolContext = toToolAttachmentContextMessage(msg, hydrateToolImages);
+                    messages.add(orphanedToolContext != null ? orphanedToolContext : UserMessage.from(toolText));
+                    if (orphanedToolContext != null) {
+                        hydratedToolImages = hydratedToolImages || hasImageContent(orphanedToolContext);
+                    }
+                }
+            }
+            case "system" -> messages.add(SystemMessage.from(nonNullText(msg.getContent())));
+            default -> log.warn("Unknown message role: {}, treating as user message", msg.getRole());
+            }
+        }
+
+        return new MessageConversionResult(messages, hydratedToolImages);
+    }
+
+    static boolean isUnsupportedFunctionRoleError(Throwable throwable) {
+        Throwable current = throwable;
+        while (current != null) {
+            String message = current.getMessage();
+            if (message != null) {
+                if (message.contains("unsupported_value")
+                        && message.contains("does not support 'function'")) {
+                    return true;
+                }
+                if (message.contains("role 'tool' must be a response to")
+                        && message.contains("tool_calls")) {
+                    return true;
+                }
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+
+    private List<Message> normalizeMessagesForProvider(List<Message> requestMessages, boolean geminiApiType) {
+        if (!geminiApiType || requestMessages == null || requestMessages.isEmpty()) {
+            return requestMessages;
+        }
+
+        long missingSignatureCount = requestMessages.stream()
+                .filter(Message::isAssistantMessage)
+                .filter(Message::hasToolCalls)
+                .filter(msg -> extractGeminiThinkingSignature(msg) == null)
+                .count();
+        if (missingSignatureCount == 0) {
+            return requestMessages;
+        }
+
+        log.warn(
+                "[LLM] Flattening tool history for Gemini request because {} assistant tool-call message(s) are missing thinking_signature",
+                missingSignatureCount);
+        return Message.flattenToolMessages(requestMessages);
+    }
+
+    private String extractGeminiThinkingSignature(Message msg) {
+        if (msg == null || msg.getMetadata() == null) {
+            return null;
+        }
+        Object value = msg.getMetadata().get(GEMINI_THINKING_SIGNATURE_KEY);
+        if (value instanceof String signature && !signature.isBlank()) {
+            return signature;
+        }
+        return null;
+    }
+
+    private String nonNullText(String text) {
+        return text != null ? text : "";
+    }
+
+    private int findFirstTrailingToolMessageIndex(List<Message> messages) {
+        if (messages == null || messages.isEmpty()) {
+            return -1;
+        }
+
+        int index = messages.size() - 1;
+        while (index >= 0) {
+            Message message = messages.get(index);
+            if (message == null || !"tool".equals(message.getRole())) {
+                break;
+            }
+            index--;
+        }
+
+        int firstTrailingToolIndex = index + 1;
+        return firstTrailingToolIndex < messages.size() ? firstTrailingToolIndex : -1;
+    }
+
+    private boolean shouldHydrateToolAttachments(int messageIndex, int firstTrailingToolIndex,
+            boolean visionCapableTarget, boolean disableToolAttachmentHydration) {
+        return visionCapableTarget
+                && !disableToolAttachmentHydration
+                && firstTrailingToolIndex >= 0
+                && messageIndex >= firstTrailingToolIndex;
+    }
+
+    @SuppressWarnings("unchecked")
+    private UserMessage toUserMessage(Message msg) {
+        List<Content> contents = new ArrayList<>();
+
+        if (msg.getContent() != null && !msg.getContent().isBlank()) {
+            contents.add(TextContent.from(msg.getContent()));
+        }
+
+        Map<String, Object> metadata = msg.getMetadata();
+        if (metadata != null) {
+            Object attachmentsRaw = metadata.get("attachments");
+            if (attachmentsRaw instanceof List<?> attachments) {
+                for (Object attachmentObj : attachments) {
+                    if (!(attachmentObj instanceof Map<?, ?> attachmentMap)) {
+                        continue;
+                    }
+
+                    Object typeObj = attachmentMap.get("type");
+                    Object mimeObj = attachmentMap.get("mimeType");
+                    Object dataObj = attachmentMap.get("dataBase64");
+
+                    if (!(typeObj instanceof String type)
+                            || !(mimeObj instanceof String mimeType)
+                            || !(dataObj instanceof String base64Data)) {
+                        continue;
+                    }
+                    if (!"image".equals(type) || !mimeType.startsWith("image/") || base64Data.isBlank()) {
+                        continue;
+                    }
+
+                    Image image = Image.builder()
+                            .base64Data(base64Data)
+                            .mimeType(mimeType)
+                            .build();
+                    contents.add(ImageContent.from(image));
+                }
+            }
+        }
+
+        if (contents.isEmpty()) {
+            return UserMessage.from(msg.getContent() != null ? msg.getContent() : "");
+        }
+
+        return UserMessage.from(contents);
+    }
+
+    @SuppressWarnings("unchecked")
+    private UserMessage toToolAttachmentContextMessage(Message msg, boolean hydrateImages) {
+        if (msg == null || msg.getMetadata() == null) {
+            return null;
+        }
+
+        Object attachmentsRaw = msg.getMetadata().get(TOOL_ATTACHMENTS_METADATA_KEY);
+        if (!(attachmentsRaw instanceof List<?> attachments)) {
+            return null;
+        }
+
+        List<Content> contents = new ArrayList<>();
+        String text = buildToolAttachmentContextText(msg, attachments);
+        if (text != null && !text.isBlank()) {
+            contents.add(TextContent.from(text));
+        }
+
+        if (!hydrateImages || toolArtifactService == null) {
+            return contents.isEmpty() ? null : UserMessage.from(contents);
+        }
+
+        for (Object attachmentObj : attachments) {
+            if (!(attachmentObj instanceof Map<?, ?> attachmentMap)) {
+                continue;
+            }
+
+            Object typeObj = attachmentMap.get("type");
+            Object pathObj = attachmentMap.get("internalFilePath");
+            if (!(typeObj instanceof String type)
+                    || !(pathObj instanceof String internalFilePath)
+                    || !"image".equals(type)
+                    || internalFilePath.isBlank()) {
+                continue;
+            }
+
+            try {
+                ToolArtifactDownload download = toolArtifactService.getDownload(internalFilePath);
+                String mimeType = download.getMimeType();
+                if (mimeType == null || !mimeType.startsWith("image/")) {
+                    continue;
+                }
+                String base64Data = Base64.getEncoder().encodeToString(download.getData());
+                Image image = Image.builder()
+                        .base64Data(base64Data)
+                        .mimeType(mimeType)
+                        .build();
+                contents.add(ImageContent.from(image));
+            } catch (RuntimeException ex) {
+                log.warn("[LLM] Failed to hydrate tool image attachment '{}': {}", internalFilePath, ex.getMessage());
+            }
+        }
+
+        if (contents.isEmpty()) {
+            return null;
+        }
+
+        return UserMessage.from(contents);
+    }
+
+    private String buildToolAttachmentContextText(Message msg, List<?> attachments) {
+        String toolName = msg.getToolName() != null && !msg.getToolName().isBlank()
+                ? msg.getToolName()
+                : "tool";
+        List<String> lines = new ArrayList<>();
+        lines.add("Tool artifact from " + toolName + " is available.");
+
+        boolean foundAttachment = false;
+        for (Object attachmentObj : attachments) {
+            if (!(attachmentObj instanceof Map<?, ?> attachmentMap)) {
+                continue;
+            }
+            String path = objectAsString(attachmentMap.get("internalFilePath"));
+            if (path == null || path.isBlank()) {
+                continue;
+            }
+            String name = objectAsString(attachmentMap.get("name"));
+            String mimeType = objectAsString(attachmentMap.get("mimeType"));
+            String displayName = name != null && !name.isBlank() ? name : path.substring(path.lastIndexOf('/') + 1);
+            StringBuilder line = new StringBuilder("- ").append(displayName);
+            if (mimeType != null && !mimeType.isBlank()) {
+                line.append(" (").append(mimeType).append(")");
+            }
+            line.append(" @ ").append(path);
+            lines.add(line.toString());
+            foundAttachment = true;
+        }
+
+        if (!foundAttachment) {
+            return null;
+        }
+
+        lines.add(TOOL_ATTACHMENT_REOPEN_HINT);
+        return String.join("\n", lines);
+    }
+
+    private String objectAsString(Object value) {
+        if (value instanceof String stringValue) {
+            return stringValue;
+        }
+        return null;
+    }
+
+    private boolean hasImageContent(UserMessage message) {
+        if (message == null || message.contents() == null) {
+            return false;
+        }
+        for (Content content : message.contents()) {
+            if (content.type() == dev.langchain4j.data.message.ContentType.IMAGE) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/me/golemcore/bot/adapter/outbound/llm/Langchain4jMessageConverter.java
+++ b/src/main/java/me/golemcore/bot/adapter/outbound/llm/Langchain4jMessageConverter.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2026 Aleksei Kuleshov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contact: alex@kuleshov.tech
+ */
+
 package me.golemcore.bot.adapter.outbound.llm;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/main/java/me/golemcore/bot/adapter/outbound/llm/Langchain4jMessageConverter.java
+++ b/src/main/java/me/golemcore/bot/adapter/outbound/llm/Langchain4jMessageConverter.java
@@ -41,7 +41,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import me.golemcore.bot.domain.model.Message;
 import me.golemcore.bot.domain.model.ToolArtifactDownload;
-import me.golemcore.bot.domain.service.ToolArtifactService;
+import me.golemcore.bot.port.outbound.ToolArtifactReadPort;
 
 @RequiredArgsConstructor
 @Slf4j
@@ -52,7 +52,7 @@ class Langchain4jMessageConverter {
     private static final String SYNTH_ID_PREFIX = "synth_call_";
     private static final String TOOL_ATTACHMENT_REOPEN_HINT = "Re-open the file with a tool if deeper inspection is needed.";
 
-    private final ToolArtifactService toolArtifactService;
+    private final ToolArtifactReadPort toolArtifactReadPort;
     private final ObjectMapper objectMapper;
 
     MessageConversionResult convertMessages(String systemPrompt, List<Message> requestMessages,
@@ -293,7 +293,7 @@ class Langchain4jMessageConverter {
             contents.add(TextContent.from(text));
         }
 
-        if (!hydrateImages || toolArtifactService == null) {
+        if (!hydrateImages || toolArtifactReadPort == null) {
             return contents.isEmpty() ? null : UserMessage.from(contents);
         }
 
@@ -312,7 +312,7 @@ class Langchain4jMessageConverter {
             }
 
             try {
-                ToolArtifactDownload download = toolArtifactService.getDownload(internalFilePath);
+                ToolArtifactDownload download = toolArtifactReadPort.getDownload(internalFilePath);
                 String mimeType = download.getMimeType();
                 if (mimeType == null || !mimeType.startsWith("image/")) {
                     continue;

--- a/src/main/java/me/golemcore/bot/adapter/outbound/llm/Langchain4jResponseMapper.java
+++ b/src/main/java/me/golemcore/bot/adapter/outbound/llm/Langchain4jResponseMapper.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2026 Aleksei Kuleshov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contact: alex@kuleshov.tech
+ */
+
 package me.golemcore.bot.adapter.outbound.llm;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/main/java/me/golemcore/bot/adapter/outbound/llm/Langchain4jResponseMapper.java
+++ b/src/main/java/me/golemcore/bot/adapter/outbound/llm/Langchain4jResponseMapper.java
@@ -1,0 +1,111 @@
+package me.golemcore.bot.adapter.outbound.llm;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.model.output.TokenUsage;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import me.golemcore.bot.domain.model.LlmResponse;
+import me.golemcore.bot.domain.model.LlmUsage;
+import me.golemcore.bot.domain.model.Message;
+
+@RequiredArgsConstructor
+class Langchain4jResponseMapper {
+
+    private static final String GEMINI_THINKING_SIGNATURE_KEY = "thinking_signature";
+
+    private final ObjectMapper objectMapper;
+
+    LlmResponse convertResponse(ChatResponse response, String currentModel, boolean compatibilityFlatteningApplied,
+            boolean geminiApiType) {
+        AiMessage aiMessage = response.aiMessage();
+
+        List<Message.ToolCall> toolCalls = null;
+        if (aiMessage.hasToolExecutionRequests()) {
+            toolCalls = aiMessage.toolExecutionRequests().stream()
+                    .map(ter -> Message.ToolCall.builder()
+                            .id(ter.id())
+                            .name(ter.name())
+                            .arguments(Langchain4jToolArgumentJson.parse(ter.arguments(), objectMapper))
+                            .build())
+                    .toList();
+        }
+
+        LlmUsage usage = toLlmUsage(response.tokenUsage());
+        Map<String, Object> providerMetadata = extractProviderMetadata(aiMessage, geminiApiType);
+
+        return LlmResponse.builder()
+                .content(aiMessage.text())
+                .toolCalls(toolCalls)
+                .usage(usage)
+                .model(currentModel)
+                .finishReason(response.finishReason() != null ? response.finishReason().name() : "stop")
+                .providerMetadata(providerMetadata.isEmpty() ? null : providerMetadata)
+                .compatibilityFlatteningApplied(compatibilityFlatteningApplied)
+                .build();
+    }
+
+    static LlmResponse withProviderMetadata(LlmResponse response, Map<String, Object> extraMetadata) {
+        if (response == null || extraMetadata == null || extraMetadata.isEmpty()) {
+            return response;
+        }
+
+        Map<String, Object> merged = new LinkedHashMap<>();
+        if (response.getProviderMetadata() != null) {
+            merged.putAll(response.getProviderMetadata());
+        }
+        merged.putAll(extraMetadata);
+
+        return LlmResponse.builder()
+                .content(response.getContent())
+                .toolCalls(response.getToolCalls())
+                .usage(response.getUsage())
+                .model(response.getModel())
+                .finishReason(response.getFinishReason())
+                .providerMetadata(merged)
+                .compatibilityFlatteningApplied(response.isCompatibilityFlatteningApplied())
+                .build();
+    }
+
+    private LlmUsage toLlmUsage(TokenUsage tokenUsage) {
+        if (tokenUsage == null) {
+            return null;
+        }
+
+        Integer inputTokens = tokenUsage.inputTokenCount();
+        Integer outputTokens = tokenUsage.outputTokenCount();
+        Integer totalTokens = tokenUsage.totalTokenCount();
+        if (inputTokens == null && outputTokens == null && totalTokens == null) {
+            return null;
+        }
+
+        int safeInputTokens = safeTokenCount(inputTokens);
+        int safeOutputTokens = safeTokenCount(outputTokens);
+        int safeTotalTokens = totalTokens != null ? totalTokens : safeInputTokens + safeOutputTokens;
+
+        return LlmUsage.builder()
+                .inputTokens(safeInputTokens)
+                .outputTokens(safeOutputTokens)
+                .totalTokens(safeTotalTokens)
+                .build();
+    }
+
+    private int safeTokenCount(Integer value) {
+        return value != null ? value : 0;
+    }
+
+    private Map<String, Object> extractProviderMetadata(AiMessage aiMessage, boolean geminiApiType) {
+        if (!geminiApiType || aiMessage == null || !aiMessage.hasToolExecutionRequests()) {
+            return Collections.emptyMap();
+        }
+        String thinkingSignature = aiMessage.attribute(GEMINI_THINKING_SIGNATURE_KEY, String.class);
+        if (thinkingSignature == null || thinkingSignature.isBlank()) {
+            return Collections.emptyMap();
+        }
+        return Map.of(GEMINI_THINKING_SIGNATURE_KEY, thinkingSignature);
+    }
+}

--- a/src/main/java/me/golemcore/bot/adapter/outbound/llm/Langchain4jToolArgumentJson.java
+++ b/src/main/java/me/golemcore/bot/adapter/outbound/llm/Langchain4jToolArgumentJson.java
@@ -1,0 +1,41 @@
+package me.golemcore.bot.adapter.outbound.llm;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Collections;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+final class Langchain4jToolArgumentJson {
+
+    private static final TypeReference<Map<String, Object>> MAP_TYPE_REF = new TypeReference<>() {
+    };
+
+    private Langchain4jToolArgumentJson() {
+    }
+
+    static String toJson(Map<String, Object> args, ObjectMapper objectMapper) {
+        if (args == null || args.isEmpty()) {
+            return "{}";
+        }
+        try {
+            return objectMapper.writeValueAsString(args);
+        } catch (Exception e) {
+            log.warn("Failed to serialize tool arguments: {}", e.getMessage());
+            return "{}";
+        }
+    }
+
+    static Map<String, Object> parse(String json, ObjectMapper objectMapper) {
+        if (json == null || json.isBlank()) {
+            return Collections.emptyMap();
+        }
+        try {
+            return objectMapper.readValue(json, MAP_TYPE_REF);
+        } catch (Exception e) {
+            log.warn("Failed to parse tool arguments: {}", e.getMessage());
+            return Collections.emptyMap();
+        }
+    }
+}

--- a/src/main/java/me/golemcore/bot/adapter/outbound/llm/Langchain4jToolArgumentJson.java
+++ b/src/main/java/me/golemcore/bot/adapter/outbound/llm/Langchain4jToolArgumentJson.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2026 Aleksei Kuleshov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contact: alex@kuleshov.tech
+ */
+
 package me.golemcore.bot.adapter.outbound.llm;
 
 import com.fasterxml.jackson.core.type.TypeReference;

--- a/src/main/java/me/golemcore/bot/adapter/outbound/llm/Langchain4jToolSchemaConverter.java
+++ b/src/main/java/me/golemcore/bot/adapter/outbound/llm/Langchain4jToolSchemaConverter.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2026 Aleksei Kuleshov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contact: alex@kuleshov.tech
+ */
+
 package me.golemcore.bot.adapter.outbound.llm;
 
 import dev.langchain4j.agent.tool.ToolSpecification;

--- a/src/main/java/me/golemcore/bot/adapter/outbound/llm/Langchain4jToolSchemaConverter.java
+++ b/src/main/java/me/golemcore/bot/adapter/outbound/llm/Langchain4jToolSchemaConverter.java
@@ -1,0 +1,230 @@
+package me.golemcore.bot.adapter.outbound.llm;
+
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.model.chat.request.json.JsonArraySchema;
+import dev.langchain4j.model.chat.request.json.JsonBooleanSchema;
+import dev.langchain4j.model.chat.request.json.JsonEnumSchema;
+import dev.langchain4j.model.chat.request.json.JsonIntegerSchema;
+import dev.langchain4j.model.chat.request.json.JsonNumberSchema;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.chat.request.json.JsonSchemaElement;
+import dev.langchain4j.model.chat.request.json.JsonStringSchema;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import me.golemcore.bot.domain.model.LlmRequest;
+import me.golemcore.bot.domain.model.ToolDefinition;
+
+@Slf4j
+class Langchain4jToolSchemaConverter {
+
+    private static final String SCHEMA_KEY_PROPERTIES = "properties";
+
+    List<ToolSpecification> convertTools(LlmRequest request) {
+        if (request.getTools() == null || request.getTools().isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        Map<String, ToolDefinition> uniqueTools = new LinkedHashMap<>();
+        for (ToolDefinition tool : request.getTools()) {
+            if (tool == null || tool.getName() == null || tool.getName().isBlank()) {
+                log.warn("[LLM] Dropping tool with blank name before request serialization");
+                continue;
+            }
+            ToolDefinition previous = uniqueTools.putIfAbsent(tool.getName(), tool);
+            if (previous != null) {
+                log.warn("[LLM] Dropping duplicate tool definition '{}' before request serialization", tool.getName());
+            }
+        }
+
+        List<ToolSpecification> tools = new ArrayList<>(uniqueTools.size());
+        for (ToolDefinition tool : uniqueTools.values()) {
+            tools.add(convertToolDefinition(tool));
+        }
+        return tools;
+    }
+
+    private ToolSpecification convertToolDefinition(ToolDefinition tool) {
+        ToolSpecification.Builder builder = ToolSpecification.builder()
+                .name(tool.getName())
+                .description(tool.getDescription());
+
+        if (tool.getInputSchema() != null) {
+            Map<String, Object> schema = tool.getInputSchema();
+            Map<String, Object> properties = stringObjectMap(schema.get(SCHEMA_KEY_PROPERTIES),
+                    tool.getName(), SCHEMA_KEY_PROPERTIES);
+            List<String> required = stringList(schema.get("required"), tool.getName(), "required");
+            if (properties != null) {
+                JsonObjectSchema.Builder schemaBuilder = JsonObjectSchema.builder();
+                for (Map.Entry<String, Object> entry : properties.entrySet()) {
+                    String paramName = entry.getKey();
+                    Map<String, Object> paramSchema = stringObjectMap(entry.getValue(), tool.getName(),
+                            SCHEMA_KEY_PROPERTIES + "." + paramName);
+                    if (paramSchema == null) {
+                        log.warn("[LLM] Dropping invalid schema for tool '{}' param '{}'", tool.getName(), paramName);
+                        continue;
+                    }
+                    schemaBuilder.addProperty(paramName, toJsonSchemaElement(tool.getName(),
+                            SCHEMA_KEY_PROPERTIES + "." + paramName, paramSchema));
+                }
+                if (required != null && !required.isEmpty()) {
+                    schemaBuilder.required(required);
+                }
+                builder.parameters(schemaBuilder.build());
+            }
+        }
+
+        return builder.build();
+    }
+
+    private JsonSchemaElement toJsonSchemaElement(String toolName, String path, Map<String, Object> paramSchema) {
+        String type = stringValue(paramSchema.get("type"), toolName, path + ".type");
+        String description = stringValue(paramSchema.get("description"), toolName, path + ".description");
+        List<String> enumValues = stringList(paramSchema.get("enum"), toolName, path + ".enum");
+
+        if (enumValues != null && !enumValues.isEmpty()) {
+            JsonEnumSchema.Builder builder = JsonEnumSchema.builder().enumValues(enumValues);
+            if (description != null && !description.isBlank()) {
+                builder.description(description);
+            }
+            return builder.build();
+        }
+
+        if (type == null) {
+            type = "string";
+        }
+
+        switch (type) {
+        case "string" -> {
+            JsonStringSchema.Builder builder = JsonStringSchema.builder();
+            if (description != null && !description.isBlank()) {
+                builder.description(description);
+            }
+            return builder.build();
+        }
+        case "integer" -> {
+            JsonIntegerSchema.Builder builder = JsonIntegerSchema.builder();
+            if (description != null && !description.isBlank()) {
+                builder.description(description);
+            }
+            return builder.build();
+        }
+        case "number" -> {
+            JsonNumberSchema.Builder builder = JsonNumberSchema.builder();
+            if (description != null && !description.isBlank()) {
+                builder.description(description);
+            }
+            return builder.build();
+        }
+        case "boolean" -> {
+            JsonBooleanSchema.Builder builder = JsonBooleanSchema.builder();
+            if (description != null && !description.isBlank()) {
+                builder.description(description);
+            }
+            return builder.build();
+        }
+        case "array" -> {
+            JsonArraySchema.Builder builder = JsonArraySchema.builder();
+            if (description != null && !description.isBlank()) {
+                builder.description(description);
+            }
+            if (paramSchema.containsKey("items")) {
+                Map<String, Object> items = stringObjectMap(paramSchema.get("items"), toolName, path + ".items");
+                if (items != null) {
+                    builder.items(toJsonSchemaElement(toolName, path + ".items", items));
+                }
+            }
+            return builder.build();
+        }
+        case "object" -> {
+            JsonObjectSchema.Builder builder = JsonObjectSchema.builder();
+            if (description != null && !description.isBlank()) {
+                builder.description(description);
+            }
+            if (paramSchema.containsKey(SCHEMA_KEY_PROPERTIES)) {
+                Map<String, Object> nestedProps = stringObjectMap(paramSchema.get(SCHEMA_KEY_PROPERTIES),
+                        toolName, path + "." + SCHEMA_KEY_PROPERTIES);
+                if (nestedProps != null) {
+                    for (Map.Entry<String, Object> entry : nestedProps.entrySet()) {
+                        Map<String, Object> nestedSchema = stringObjectMap(entry.getValue(), toolName,
+                                path + "." + SCHEMA_KEY_PROPERTIES + "." + entry.getKey());
+                        if (nestedSchema == null) {
+                            log.warn("[LLM] Dropping invalid nested schema for tool '{}' at {}", toolName,
+                                    path + "." + SCHEMA_KEY_PROPERTIES + "." + entry.getKey());
+                            continue;
+                        }
+                        builder.addProperty(entry.getKey(), toJsonSchemaElement(toolName,
+                                path + "." + SCHEMA_KEY_PROPERTIES + "." + entry.getKey(), nestedSchema));
+                    }
+                }
+            }
+            return builder.build();
+        }
+        default -> {
+            JsonStringSchema.Builder builder = JsonStringSchema.builder();
+            if (description != null && !description.isBlank()) {
+                builder.description(description);
+            }
+            return builder.build();
+        }
+        }
+    }
+
+    @SuppressWarnings({
+            "unchecked",
+            "PMD.ReturnEmptyCollectionRatherThanNull"
+    })
+    private Map<String, Object> stringObjectMap(Object rawValue, String toolName, String path) {
+        if (!(rawValue instanceof Map<?, ?> rawMap)) {
+            if (rawValue != null) {
+                log.warn("[LLM] Invalid schema object for tool '{}' at {}: {}", toolName, path,
+                        rawValue.getClass().getSimpleName());
+            }
+            return null;
+        }
+        Map<String, Object> casted = new LinkedHashMap<>();
+        for (Map.Entry<?, ?> entry : rawMap.entrySet()) {
+            if (!(entry.getKey() instanceof String key)) {
+                log.warn("[LLM] Dropping non-string schema key for tool '{}' at {}", toolName, path);
+                continue;
+            }
+            casted.put(key, (Object) entry.getValue());
+        }
+        return casted;
+    }
+
+    @SuppressWarnings("PMD.ReturnEmptyCollectionRatherThanNull")
+    private List<String> stringList(Object rawValue, String toolName, String path) {
+        if (!(rawValue instanceof List<?> rawList)) {
+            if (rawValue != null) {
+                log.warn("[LLM] Invalid schema list for tool '{}' at {}: {}", toolName, path,
+                        rawValue.getClass().getSimpleName());
+            }
+            return null;
+        }
+        List<String> values = new ArrayList<>(rawList.size());
+        for (Object item : rawList) {
+            if (item instanceof String stringValue && !stringValue.isBlank()) {
+                values.add(stringValue);
+            } else {
+                log.warn("[LLM] Dropping non-string schema list item for tool '{}' at {}", toolName, path);
+            }
+        }
+        return values;
+    }
+
+    private String stringValue(Object rawValue, String toolName, String path) {
+        if (rawValue == null) {
+            return null;
+        }
+        if (rawValue instanceof String stringValue) {
+            return stringValue;
+        }
+        log.warn("[LLM] Invalid schema string for tool '{}' at {}: {}", toolName, path,
+                rawValue.getClass().getSimpleName());
+        return null;
+    }
+}

--- a/src/main/java/me/golemcore/bot/adapter/outbound/llm/MessageConversionResult.java
+++ b/src/main/java/me/golemcore/bot/adapter/outbound/llm/MessageConversionResult.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2026 Aleksei Kuleshov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contact: alex@kuleshov.tech
+ */
+
 package me.golemcore.bot.adapter.outbound.llm;
 
 import dev.langchain4j.data.message.ChatMessage;

--- a/src/main/java/me/golemcore/bot/adapter/outbound/llm/MessageConversionResult.java
+++ b/src/main/java/me/golemcore/bot/adapter/outbound/llm/MessageConversionResult.java
@@ -1,0 +1,6 @@
+package me.golemcore.bot.adapter.outbound.llm;
+
+import dev.langchain4j.data.message.ChatMessage;
+import java.util.List;
+
+record MessageConversionResult(List<ChatMessage>messages,boolean hydratedToolImages){}

--- a/src/main/java/me/golemcore/bot/domain/service/RuntimeConfigInviteCodeSupport.java
+++ b/src/main/java/me/golemcore/bot/domain/service/RuntimeConfigInviteCodeSupport.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2026 Aleksei Kuleshov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contact: alex@kuleshov.tech
+ */
+
 package me.golemcore.bot.domain.service;
 
 import java.security.SecureRandom;

--- a/src/main/java/me/golemcore/bot/domain/service/RuntimeConfigInviteCodeSupport.java
+++ b/src/main/java/me/golemcore/bot/domain/service/RuntimeConfigInviteCodeSupport.java
@@ -24,7 +24,6 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import me.golemcore.bot.domain.model.RuntimeConfig;
-import me.golemcore.bot.port.outbound.RuntimeConfigPersistencePort;
 
 @Slf4j
 final class RuntimeConfigInviteCodeSupport {
@@ -36,8 +35,7 @@ final class RuntimeConfigInviteCodeSupport {
     private RuntimeConfigInviteCodeSupport() {
     }
 
-    static RuntimeConfig.InviteCode generateInviteCode(RuntimeConfig cfg,
-            RuntimeConfigPersistencePort runtimeConfigPersistencePort) {
+    static RuntimeConfig.InviteCode generateInviteCode(RuntimeConfig cfg) {
         RuntimeConfig.InviteCode inviteCode = RuntimeConfig.InviteCode.builder()
                 .code(generateCode())
                 .used(false)
@@ -46,25 +44,21 @@ final class RuntimeConfigInviteCodeSupport {
 
         List<RuntimeConfig.InviteCode> inviteCodes = ensureMutableInviteCodes(cfg.getTelegram());
         inviteCodes.add(inviteCode);
-        runtimeConfigPersistencePort.persist(cfg);
 
         log.info("[RuntimeConfig] Generated invite code: {}", inviteCode.getCode());
         return inviteCode;
     }
 
-    static boolean revokeInviteCode(RuntimeConfig cfg, RuntimeConfigPersistencePort runtimeConfigPersistencePort,
-            String code) {
+    static boolean revokeInviteCode(RuntimeConfig cfg, String code) {
         List<RuntimeConfig.InviteCode> codes = ensureMutableInviteCodes(cfg.getTelegram());
         boolean removed = codes.removeIf(ic -> ic.getCode().equals(code));
         if (removed) {
-            runtimeConfigPersistencePort.persist(cfg);
             log.info("[RuntimeConfig] Revoked invite code: {}", code);
         }
         return removed;
     }
 
-    static boolean redeemInviteCode(RuntimeConfig cfg, RuntimeConfigPersistencePort runtimeConfigPersistencePort,
-            String code, String userId) {
+    static boolean redeemInviteCode(RuntimeConfig cfg, String code, String userId) {
         List<RuntimeConfig.InviteCode> codes = ensureMutableInviteCodes(cfg.getTelegram());
 
         List<String> allowed = ensureMutableAllowedUsers(cfg.getTelegram());
@@ -82,7 +76,6 @@ final class RuntimeConfigInviteCodeSupport {
                 if (!allowed.contains(userId)) {
                     allowed.add(userId);
                 }
-                runtimeConfigPersistencePort.persist(cfg);
                 log.info("[RuntimeConfig] Redeemed invite code {} for user {}", code, userId);
                 return true;
             }
@@ -90,8 +83,7 @@ final class RuntimeConfigInviteCodeSupport {
         return false;
     }
 
-    static boolean removeTelegramAllowedUser(RuntimeConfig cfg,
-            RuntimeConfigPersistencePort runtimeConfigPersistencePort, String userId) {
+    static boolean removeTelegramAllowedUser(RuntimeConfig cfg, String userId) {
         RuntimeConfig.TelegramConfig telegramConfig = cfg.getTelegram();
         List<String> allowedUsers = ensureMutableAllowedUsers(telegramConfig);
         if (allowedUsers.isEmpty()) {
@@ -100,7 +92,6 @@ final class RuntimeConfigInviteCodeSupport {
         boolean removed = allowedUsers.removeIf(existingUserId -> existingUserId.equals(userId));
         if (removed) {
             int revokedCodes = revokeActiveInviteCodes(telegramConfig);
-            runtimeConfigPersistencePort.persist(cfg);
             log.info("[RuntimeConfig] Removed telegram allowed user: {} (revoked {} active invite codes)",
                     userId, revokedCodes);
         }

--- a/src/main/java/me/golemcore/bot/domain/service/RuntimeConfigInviteCodeSupport.java
+++ b/src/main/java/me/golemcore/bot/domain/service/RuntimeConfigInviteCodeSupport.java
@@ -1,0 +1,151 @@
+package me.golemcore.bot.domain.service;
+
+import java.security.SecureRandom;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import me.golemcore.bot.domain.model.RuntimeConfig;
+import me.golemcore.bot.port.outbound.RuntimeConfigPersistencePort;
+
+@Slf4j
+final class RuntimeConfigInviteCodeSupport {
+
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+    private static final String INVITE_CHARS = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+    private static final int INVITE_CODE_LENGTH = 20;
+
+    private RuntimeConfigInviteCodeSupport() {
+    }
+
+    static RuntimeConfig.InviteCode generateInviteCode(RuntimeConfig cfg,
+            RuntimeConfigPersistencePort runtimeConfigPersistencePort) {
+        RuntimeConfig.InviteCode inviteCode = RuntimeConfig.InviteCode.builder()
+                .code(generateCode())
+                .used(false)
+                .createdAt(Instant.now())
+                .build();
+
+        List<RuntimeConfig.InviteCode> inviteCodes = ensureMutableInviteCodes(cfg.getTelegram());
+        inviteCodes.add(inviteCode);
+        runtimeConfigPersistencePort.persist(cfg);
+
+        log.info("[RuntimeConfig] Generated invite code: {}", inviteCode.getCode());
+        return inviteCode;
+    }
+
+    static boolean revokeInviteCode(RuntimeConfig cfg, RuntimeConfigPersistencePort runtimeConfigPersistencePort,
+            String code) {
+        List<RuntimeConfig.InviteCode> codes = ensureMutableInviteCodes(cfg.getTelegram());
+        boolean removed = codes.removeIf(ic -> ic.getCode().equals(code));
+        if (removed) {
+            runtimeConfigPersistencePort.persist(cfg);
+            log.info("[RuntimeConfig] Revoked invite code: {}", code);
+        }
+        return removed;
+    }
+
+    static boolean redeemInviteCode(RuntimeConfig cfg, RuntimeConfigPersistencePort runtimeConfigPersistencePort,
+            String code, String userId) {
+        List<RuntimeConfig.InviteCode> codes = ensureMutableInviteCodes(cfg.getTelegram());
+
+        List<String> allowed = ensureMutableAllowedUsers(cfg.getTelegram());
+        if (!allowed.isEmpty() && !allowed.contains(userId)) {
+            log.warn("[RuntimeConfig] Invite redemption denied for user {}: invited user already registered", userId);
+            return false;
+        }
+
+        for (RuntimeConfig.InviteCode ic : codes) {
+            if (ic.getCode().equals(code)) {
+                if (ic.isUsed()) {
+                    return false;
+                }
+                ic.setUsed(true);
+                if (!allowed.contains(userId)) {
+                    allowed.add(userId);
+                }
+                runtimeConfigPersistencePort.persist(cfg);
+                log.info("[RuntimeConfig] Redeemed invite code {} for user {}", code, userId);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static boolean removeTelegramAllowedUser(RuntimeConfig cfg,
+            RuntimeConfigPersistencePort runtimeConfigPersistencePort, String userId) {
+        RuntimeConfig.TelegramConfig telegramConfig = cfg.getTelegram();
+        List<String> allowedUsers = ensureMutableAllowedUsers(telegramConfig);
+        if (allowedUsers.isEmpty()) {
+            return false;
+        }
+        boolean removed = allowedUsers.removeIf(existingUserId -> existingUserId.equals(userId));
+        if (removed) {
+            int revokedCodes = revokeActiveInviteCodes(telegramConfig);
+            runtimeConfigPersistencePort.persist(cfg);
+            log.info("[RuntimeConfig] Removed telegram allowed user: {} (revoked {} active invite codes)",
+                    userId, revokedCodes);
+        }
+        return removed;
+    }
+
+    static List<String> ensureMutableAllowedUsers(RuntimeConfig.TelegramConfig telegramConfig) {
+        List<String> allowedUsers = telegramConfig.getAllowedUsers();
+        if (allowedUsers == null) {
+            List<String> mutableAllowedUsers = new ArrayList<>();
+            telegramConfig.setAllowedUsers(mutableAllowedUsers);
+            return mutableAllowedUsers;
+        }
+        if (!(allowedUsers instanceof ArrayList<?>)) {
+            List<String> mutableAllowedUsers = new ArrayList<>(allowedUsers);
+            telegramConfig.setAllowedUsers(mutableAllowedUsers);
+            return mutableAllowedUsers;
+        }
+        return allowedUsers;
+    }
+
+    static List<RuntimeConfig.InviteCode> ensureMutableInviteCodes(RuntimeConfig.TelegramConfig telegramConfig) {
+        List<RuntimeConfig.InviteCode> inviteCodes = telegramConfig.getInviteCodes();
+        if (inviteCodes == null) {
+            List<RuntimeConfig.InviteCode> mutableInviteCodes = new ArrayList<>();
+            telegramConfig.setInviteCodes(mutableInviteCodes);
+            return mutableInviteCodes;
+        }
+        if (!(inviteCodes instanceof ArrayList<?>)) {
+            List<RuntimeConfig.InviteCode> mutableInviteCodes = new ArrayList<>(inviteCodes);
+            telegramConfig.setInviteCodes(mutableInviteCodes);
+            return mutableInviteCodes;
+        }
+        return inviteCodes;
+    }
+
+    private static String generateCode() {
+        StringBuilder code = new StringBuilder(INVITE_CODE_LENGTH);
+        for (int i = 0; i < INVITE_CODE_LENGTH; i++) {
+            code.append(INVITE_CHARS.charAt(SECURE_RANDOM.nextInt(INVITE_CHARS.length())));
+        }
+        return code.toString();
+    }
+
+    private static int revokeActiveInviteCodes(RuntimeConfig.TelegramConfig telegramConfig) {
+        List<RuntimeConfig.InviteCode> inviteCodes = ensureMutableInviteCodes(telegramConfig);
+        if (inviteCodes.isEmpty()) {
+            return 0;
+        }
+
+        List<RuntimeConfig.InviteCode> retainedInviteCodes = new ArrayList<>(inviteCodes.size());
+        int revokedCount = 0;
+        for (RuntimeConfig.InviteCode inviteCode : inviteCodes) {
+            if (inviteCode != null && !inviteCode.isUsed()) {
+                revokedCount++;
+                continue;
+            }
+            retainedInviteCodes.add(inviteCode);
+        }
+
+        if (revokedCount > 0) {
+            telegramConfig.setInviteCodes(retainedInviteCodes);
+        }
+        return revokedCount;
+    }
+}

--- a/src/main/java/me/golemcore/bot/domain/service/RuntimeConfigService.java
+++ b/src/main/java/me/golemcore/bot/domain/service/RuntimeConfigService.java
@@ -1631,30 +1631,46 @@ public class RuntimeConfigService {
      * Generate a new single-use invite code.
      */
     public RuntimeConfig.InviteCode generateInviteCode() {
-        return RuntimeConfigInviteCodeSupport.generateInviteCode(getRuntimeConfig(), runtimeConfigPersistencePort);
+        RuntimeConfig cfg = getRuntimeConfig();
+        RuntimeConfig.InviteCode inviteCode = RuntimeConfigInviteCodeSupport.generateInviteCode(cfg);
+        runtimeConfigPersistencePort.persist(cfg);
+        return inviteCode;
     }
 
     /**
      * Revoke (remove) an invite code.
      */
     public boolean revokeInviteCode(String code) {
-        return RuntimeConfigInviteCodeSupport.revokeInviteCode(getRuntimeConfig(), runtimeConfigPersistencePort, code);
+        RuntimeConfig cfg = getRuntimeConfig();
+        boolean removed = RuntimeConfigInviteCodeSupport.revokeInviteCode(cfg, code);
+        if (removed) {
+            runtimeConfigPersistencePort.persist(cfg);
+        }
+        return removed;
     }
 
     /**
      * Redeem a single-use invite code, adding the user to allowed users.
      */
     public boolean redeemInviteCode(String code, String userId) {
-        return RuntimeConfigInviteCodeSupport.redeemInviteCode(getRuntimeConfig(), runtimeConfigPersistencePort,
-                code, userId);
+        RuntimeConfig cfg = getRuntimeConfig();
+        boolean redeemed = RuntimeConfigInviteCodeSupport.redeemInviteCode(cfg, code, userId);
+        if (redeemed) {
+            runtimeConfigPersistencePort.persist(cfg);
+        }
+        return redeemed;
     }
 
     /**
      * Remove a Telegram user from allowed users list.
      */
     public boolean removeTelegramAllowedUser(String userId) {
-        return RuntimeConfigInviteCodeSupport.removeTelegramAllowedUser(getRuntimeConfig(),
-                runtimeConfigPersistencePort, userId);
+        RuntimeConfig cfg = getRuntimeConfig();
+        boolean removed = RuntimeConfigInviteCodeSupport.removeTelegramAllowedUser(cfg, userId);
+        if (removed) {
+            runtimeConfigPersistencePort.persist(cfg);
+        }
+        return removed;
     }
 
     // ==================== Persistence ====================

--- a/src/main/java/me/golemcore/bot/domain/service/RuntimeConfigService.java
+++ b/src/main/java/me/golemcore/bot/domain/service/RuntimeConfigService.java
@@ -18,9 +18,7 @@ package me.golemcore.bot.domain.service;
  * Contact: alex@kuleshov.tech
  */
 
-import java.security.SecureRandom;
 import java.time.Duration;
-import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -59,9 +57,6 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class RuntimeConfigService {
 
-    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
-    private static final String INVITE_CHARS = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
-    private static final int INVITE_CODE_LENGTH = 20;
     private static final String REASONING_NONE = "none";
     private static final String DEFAULT_BALANCED_MODEL = null;
     private static final String DEFAULT_BALANCED_REASONING = REASONING_NONE;
@@ -1636,140 +1631,30 @@ public class RuntimeConfigService {
      * Generate a new single-use invite code.
      */
     public RuntimeConfig.InviteCode generateInviteCode() {
-        StringBuilder code = new StringBuilder(INVITE_CODE_LENGTH);
-        for (int i = 0; i < INVITE_CODE_LENGTH; i++) {
-            code.append(INVITE_CHARS.charAt(SECURE_RANDOM.nextInt(INVITE_CHARS.length())));
-        }
-
-        RuntimeConfig.InviteCode inviteCode = RuntimeConfig.InviteCode.builder()
-                .code(code.toString())
-                .used(false)
-                .createdAt(Instant.now())
-                .build();
-
-        RuntimeConfig cfg = getRuntimeConfig();
-        List<RuntimeConfig.InviteCode> inviteCodes = ensureMutableInviteCodes(cfg.getTelegram());
-        inviteCodes.add(inviteCode);
-        runtimeConfigPersistencePort.persist(cfg);
-
-        log.info("[RuntimeConfig] Generated invite code: {}", inviteCode.getCode());
-        return inviteCode;
+        return RuntimeConfigInviteCodeSupport.generateInviteCode(getRuntimeConfig(), runtimeConfigPersistencePort);
     }
 
     /**
      * Revoke (remove) an invite code.
      */
     public boolean revokeInviteCode(String code) {
-        RuntimeConfig cfg = getRuntimeConfig();
-        List<RuntimeConfig.InviteCode> codes = ensureMutableInviteCodes(cfg.getTelegram());
-        boolean removed = codes.removeIf(ic -> ic.getCode().equals(code));
-        if (removed) {
-            runtimeConfigPersistencePort.persist(cfg);
-            log.info("[RuntimeConfig] Revoked invite code: {}", code);
-        }
-        return removed;
+        return RuntimeConfigInviteCodeSupport.revokeInviteCode(getRuntimeConfig(), runtimeConfigPersistencePort, code);
     }
 
     /**
      * Redeem a single-use invite code, adding the user to allowed users.
      */
     public boolean redeemInviteCode(String code, String userId) {
-        RuntimeConfig cfg = getRuntimeConfig();
-        List<RuntimeConfig.InviteCode> codes = ensureMutableInviteCodes(cfg.getTelegram());
-
-        List<String> allowed = ensureMutableAllowedUsers(cfg.getTelegram());
-        if (!allowed.isEmpty() && !allowed.contains(userId)) {
-            log.warn("[RuntimeConfig] Invite redemption denied for user {}: invited user already registered", userId);
-            return false;
-        }
-
-        for (RuntimeConfig.InviteCode ic : codes) {
-            if (ic.getCode().equals(code)) {
-                if (ic.isUsed()) {
-                    return false;
-                }
-                ic.setUsed(true);
-                if (!allowed.contains(userId)) {
-                    allowed.add(userId);
-                }
-                runtimeConfigPersistencePort.persist(cfg);
-                log.info("[RuntimeConfig] Redeemed invite code {} for user {}", code, userId);
-                return true;
-            }
-        }
-        return false;
+        return RuntimeConfigInviteCodeSupport.redeemInviteCode(getRuntimeConfig(), runtimeConfigPersistencePort,
+                code, userId);
     }
 
     /**
      * Remove a Telegram user from allowed users list.
      */
     public boolean removeTelegramAllowedUser(String userId) {
-        RuntimeConfig cfg = getRuntimeConfig();
-        RuntimeConfig.TelegramConfig telegramConfig = cfg.getTelegram();
-        List<String> allowedUsers = ensureMutableAllowedUsers(telegramConfig);
-        if (allowedUsers.isEmpty()) {
-            return false;
-        }
-        boolean removed = allowedUsers.removeIf(existingUserId -> existingUserId.equals(userId));
-        if (removed) {
-            int revokedCodes = revokeActiveInviteCodes(telegramConfig);
-            runtimeConfigPersistencePort.persist(cfg);
-            log.info("[RuntimeConfig] Removed telegram allowed user: {} (revoked {} active invite codes)",
-                    userId, revokedCodes);
-        }
-        return removed;
-    }
-
-    private List<String> ensureMutableAllowedUsers(RuntimeConfig.TelegramConfig telegramConfig) {
-        List<String> allowedUsers = telegramConfig.getAllowedUsers();
-        if (allowedUsers == null) {
-            List<String> mutableAllowedUsers = new ArrayList<>();
-            telegramConfig.setAllowedUsers(mutableAllowedUsers);
-            return mutableAllowedUsers;
-        }
-        if (!(allowedUsers instanceof ArrayList<?>)) {
-            List<String> mutableAllowedUsers = new ArrayList<>(allowedUsers);
-            telegramConfig.setAllowedUsers(mutableAllowedUsers);
-            return mutableAllowedUsers;
-        }
-        return allowedUsers;
-    }
-
-    private List<RuntimeConfig.InviteCode> ensureMutableInviteCodes(RuntimeConfig.TelegramConfig telegramConfig) {
-        List<RuntimeConfig.InviteCode> inviteCodes = telegramConfig.getInviteCodes();
-        if (inviteCodes == null) {
-            List<RuntimeConfig.InviteCode> mutableInviteCodes = new ArrayList<>();
-            telegramConfig.setInviteCodes(mutableInviteCodes);
-            return mutableInviteCodes;
-        }
-        if (!(inviteCodes instanceof ArrayList<?>)) {
-            List<RuntimeConfig.InviteCode> mutableInviteCodes = new ArrayList<>(inviteCodes);
-            telegramConfig.setInviteCodes(mutableInviteCodes);
-            return mutableInviteCodes;
-        }
-        return inviteCodes;
-    }
-
-    private int revokeActiveInviteCodes(RuntimeConfig.TelegramConfig telegramConfig) {
-        List<RuntimeConfig.InviteCode> inviteCodes = ensureMutableInviteCodes(telegramConfig);
-        if (inviteCodes.isEmpty()) {
-            return 0;
-        }
-
-        List<RuntimeConfig.InviteCode> retainedInviteCodes = new ArrayList<>(inviteCodes.size());
-        int revokedCount = 0;
-        for (RuntimeConfig.InviteCode inviteCode : inviteCodes) {
-            if (inviteCode != null && !inviteCode.isUsed()) {
-                revokedCount++;
-                continue;
-            }
-            retainedInviteCodes.add(inviteCode);
-        }
-
-        if (revokedCount > 0) {
-            telegramConfig.setInviteCodes(retainedInviteCodes);
-        }
-        return revokedCount;
+        return RuntimeConfigInviteCodeSupport.removeTelegramAllowedUser(getRuntimeConfig(),
+                runtimeConfigPersistencePort, userId);
     }
 
     // ==================== Persistence ====================
@@ -1801,8 +1686,8 @@ public class RuntimeConfigService {
         }
         if (cfg.getTelegram() != null) {
             cfg.getTelegram().setAuthMode("invite_only");
-            ensureMutableAllowedUsers(cfg.getTelegram());
-            ensureMutableInviteCodes(cfg.getTelegram());
+            RuntimeConfigInviteCodeSupport.ensureMutableAllowedUsers(cfg.getTelegram());
+            RuntimeConfigInviteCodeSupport.ensureMutableInviteCodes(cfg.getTelegram());
         }
         if (cfg.getTools() == null) {
             cfg.setTools(RuntimeConfig.ToolsConfig.builder().build());

--- a/src/main/java/me/golemcore/bot/domain/service/ToolArtifactService.java
+++ b/src/main/java/me/golemcore/bot/domain/service/ToolArtifactService.java
@@ -3,6 +3,7 @@ package me.golemcore.bot.domain.service;
 import me.golemcore.bot.domain.model.ToolArtifact;
 import me.golemcore.bot.domain.model.ToolArtifactDownload;
 import lombok.RequiredArgsConstructor;
+import me.golemcore.bot.port.outbound.ToolArtifactReadPort;
 import me.golemcore.bot.port.outbound.WorkspaceFilePort;
 import org.springframework.stereotype.Service;
 
@@ -21,7 +22,7 @@ import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
-public class ToolArtifactService {
+public class ToolArtifactService implements ToolArtifactReadPort {
 
     private static final String TOOL_ARTIFACTS_DIR = ".golemcore/tool-artifacts";
     private static final int MAX_FILENAME_LENGTH = 120;
@@ -71,6 +72,7 @@ public class ToolArtifactService {
         }
     }
 
+    @Override
     public ToolArtifactDownload getDownload(String relativePath) {
         if (relativePath == null || relativePath.isBlank()) {
             throw new IllegalArgumentException("Path is required");

--- a/src/main/java/me/golemcore/bot/port/outbound/ToolArtifactReadPort.java
+++ b/src/main/java/me/golemcore/bot/port/outbound/ToolArtifactReadPort.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 Aleksei Kuleshov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contact: alex@kuleshov.tech
+ */
+
+package me.golemcore.bot.port.outbound;
+
+import me.golemcore.bot.domain.model.ToolArtifactDownload;
+
+/**
+ * Outbound port for reading stored tool artifacts.
+ */
+public interface ToolArtifactReadPort {
+
+    ToolArtifactDownload getDownload(String relativePath);
+}

--- a/src/test/java/me/golemcore/bot/adapter/outbound/llm/Langchain4jAdapterTest.java
+++ b/src/test/java/me/golemcore/bot/adapter/outbound/llm/Langchain4jAdapterTest.java
@@ -9,9 +9,9 @@ import me.golemcore.bot.domain.model.Secret;
 import me.golemcore.bot.domain.model.ToolDefinition;
 import me.golemcore.bot.domain.model.catalog.ModelCatalogEntry;
 import me.golemcore.bot.domain.service.RuntimeConfigService;
-import me.golemcore.bot.domain.service.ToolArtifactService;
 import me.golemcore.bot.domain.model.ToolArtifactDownload;
 import me.golemcore.bot.port.outbound.ModelConfigPort;
+import me.golemcore.bot.port.outbound.ToolArtifactReadPort;
 import dev.langchain4j.data.message.AiMessage;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.Content;
@@ -87,14 +87,14 @@ class Langchain4jAdapterTest {
 
     private ModelConfigPort modelConfig;
     private RuntimeConfigService runtimeConfigService;
-    private ToolArtifactService toolArtifactService;
+    private ToolArtifactReadPort toolArtifactReadPort;
     private Langchain4jAdapter adapter;
 
     @BeforeEach
     void setUp() {
         modelConfig = mock(ModelConfigPort.class);
         runtimeConfigService = mock(RuntimeConfigService.class);
-        toolArtifactService = mock(ToolArtifactService.class);
+        toolArtifactReadPort = mock(ToolArtifactReadPort.class);
         when(modelConfig.supportsTemperature(anyString())).thenReturn(true);
         when(modelConfig.supportsVision(anyString())).thenReturn(false);
         when(modelConfig.getProvider(anyString())).thenReturn(OPENAI);
@@ -108,7 +108,7 @@ class Langchain4jAdapterTest {
         when(runtimeConfigService.getLlmProviderConfig(anyString()))
                 .thenReturn(RuntimeConfig.LlmProviderConfig.builder().legacyApi(true).build());
 
-        adapter = new Langchain4jAdapter(runtimeConfigService, modelConfig, toolArtifactService) {
+        adapter = new Langchain4jAdapter(runtimeConfigService, modelConfig, toolArtifactReadPort) {
             @Override
             protected void sleepBeforeRetry(long backoffMs) {
                 // No-op for deterministic fast retry tests.
@@ -702,7 +702,7 @@ class Langchain4jAdapterTest {
         ChatModel mockModel = mock(ChatModel.class);
         injectChatModel(mockModel, "openai/gpt-4.1");
         when(modelConfig.supportsVision("openai/gpt-4.1")).thenReturn(true);
-        when(toolArtifactService.getDownload(".golemcore/tool-artifacts/session/pinchtab/capture.png"))
+        when(toolArtifactReadPort.getDownload(".golemcore/tool-artifacts/session/pinchtab/capture.png"))
                 .thenReturn(ToolArtifactDownload.builder()
                         .path(".golemcore/tool-artifacts/session/pinchtab/capture.png")
                         .filename("capture.png")
@@ -977,7 +977,7 @@ class Langchain4jAdapterTest {
     @Test
     void shouldInjectToolImageAsMultimodalContextForVisionModels() {
         when(modelConfig.supportsVision("openai/gpt-4.1")).thenReturn(true);
-        when(toolArtifactService.getDownload(".golemcore/tool-artifacts/session/pinchtab/capture.png"))
+        when(toolArtifactReadPort.getDownload(".golemcore/tool-artifacts/session/pinchtab/capture.png"))
                 .thenReturn(ToolArtifactDownload.builder()
                         .path(".golemcore/tool-artifacts/session/pinchtab/capture.png")
                         .filename("capture.png")
@@ -1075,7 +1075,7 @@ class Langchain4jAdapterTest {
     @Test
     void shouldIgnoreBrokenToolImageAttachmentDownload() {
         when(modelConfig.supportsVision("openai/gpt-4.1")).thenReturn(true);
-        when(toolArtifactService.getDownload(".golemcore/tool-artifacts/session/pinchtab/missing.png"))
+        when(toolArtifactReadPort.getDownload(".golemcore/tool-artifacts/session/pinchtab/missing.png"))
                 .thenThrow(new IllegalArgumentException("File not found"));
 
         Message assistantMsg = Message.builder()


### PR DESCRIPTION
## Summary

- Split `Langchain4jAdapter` message conversion, tool schema conversion, tool argument JSON handling, and response mapping into focused package-private helpers while preserving the adapter reflection-based test entry points.
- Moved runtime invite-code mutation and persistence details out of `RuntimeConfigService` into `RuntimeConfigInviteCodeSupport`, leaving the service as the public facade.
- Reduced the main LLM adapter from about 1500 lines to about 840 lines, and trimmed the runtime config service invite-code block without changing behavior.

