### PR TITLE
test: harden qa coverage

### DIFF
--- a/src/main/java/me/golemcore/bot/adapter/outbound/llm/Langchain4jToolSchemaConverter.java
+++ b/src/main/java/me/golemcore/bot/adapter/outbound/llm/Langchain4jToolSchemaConverter.java
@@ -162,6 +162,10 @@ class Langchain4jToolSchemaConverter {
             if (description != null && !description.isBlank()) {
                 builder.description(description);
             }
+            List<String> required = stringList(paramSchema.get("required"), toolName, path + ".required");
+            if (required != null && !required.isEmpty()) {
+                builder.required(required);
+            }
             if (paramSchema.containsKey(SCHEMA_KEY_PROPERTIES)) {
                 Map<String, Object> nestedProps = stringObjectMap(paramSchema.get(SCHEMA_KEY_PROPERTIES),
                         toolName, path + "." + SCHEMA_KEY_PROPERTIES);

--- a/src/main/java/me/golemcore/bot/domain/memory/retrieval/MemoryCandidateScorer.java
+++ b/src/main/java/me/golemcore/bot/domain/memory/retrieval/MemoryCandidateScorer.java
@@ -179,7 +179,7 @@ public class MemoryCandidateScorer {
         }
         String normalized = activeSkill.toLowerCase(Locale.ROOT);
         for (String tag : tags) {
-            if (normalized.equals(tag)) {
+            if (tag != null && normalized.equals(tag.toLowerCase(Locale.ROOT))) {
                 return 0.10;
             }
         }

--- a/src/main/java/me/golemcore/bot/domain/model/Plan.java
+++ b/src/main/java/me/golemcore/bot/domain/model/Plan.java
@@ -63,6 +63,9 @@ public class Plan {
 
     @JsonIgnore
     public long getCompletedStepCount() {
+        if (steps == null) {
+            return 0;
+        }
         return steps.stream()
                 .filter(s -> s.getStatus() == PlanStep.StepStatus.COMPLETED)
                 .count();
@@ -70,6 +73,9 @@ public class Plan {
 
     @JsonIgnore
     public long getFailedStepCount() {
+        if (steps == null) {
+            return 0;
+        }
         return steps.stream()
                 .filter(s -> s.getStatus() == PlanStep.StepStatus.FAILED)
                 .count();

--- a/src/main/java/me/golemcore/bot/domain/service/ConversationKeyValidator.java
+++ b/src/main/java/me/golemcore/bot/domain/service/ConversationKeyValidator.java
@@ -97,7 +97,7 @@ public final class ConversationKeyValidator {
         return Comparator.comparing(
                 (AgentSession session) -> session.getUpdatedAt() != null ? session.getUpdatedAt()
                         : session.getCreatedAt(),
-                Comparator.nullsLast(Comparator.naturalOrder()))
+                Comparator.nullsFirst(Comparator.naturalOrder()))
                 .reversed();
     }
 

--- a/src/main/java/me/golemcore/bot/domain/service/DashboardFileMetadataSupport.java
+++ b/src/main/java/me/golemcore/bot/domain/service/DashboardFileMetadataSupport.java
@@ -14,6 +14,8 @@ final class DashboardFileMetadataSupport {
     private static final long MAX_EDITABLE_FILE_SIZE = 1024L * 1024L * 2L;
     private static final Set<String> DEFAULT_IGNORED_DIRECTORIES = Set.of(
             ".git", ".gradle", ".idea", "build", "dist", "node_modules", "target");
+    private static final Set<String> GENERIC_BINARY_MIME_TYPES = Set.of(
+            "application/macbinary", "application/octet-stream", "application/x-macbinary");
     private static final Map<String, String> TEXT_EXTENSION_MIME_TYPES = Map.ofEntries(
             Map.entry(".css", "text/css"),
             Map.entry(".go", "text/x-go"),
@@ -93,8 +95,8 @@ final class DashboardFileMetadataSupport {
             String requestedMimeType) {
         String mimeType = workspacePathService.resolveMimeType(path, requestedMimeType);
         String filename = requireFileName(workspacePathService, path);
-        if ("application/octet-stream".equals(mimeType)) {
-            return findTextMimeType(filename, mimeType);
+        if (GENERIC_BINARY_MIME_TYPES.contains(mimeType)) {
+            return findTextMimeType(filename, "application/octet-stream");
         }
         return mimeType;
     }

--- a/src/main/java/me/golemcore/bot/domain/service/MemoryScopeSupport.java
+++ b/src/main/java/me/golemcore/bot/domain/service/MemoryScopeSupport.java
@@ -53,7 +53,8 @@ public final class MemoryScopeSupport {
             return GLOBAL_SCOPE;
         }
 
-        if (candidate.startsWith(SESSION_PREFIX)) {
+        String candidateLower = candidate.toLowerCase(Locale.ROOT);
+        if (candidateLower.startsWith(SESSION_PREFIX)) {
             String[] parts = candidate.split(":", 3);
             if (parts.length != 3) {
                 return GLOBAL_SCOPE;
@@ -74,7 +75,7 @@ public final class MemoryScopeSupport {
             return SESSION_PREFIX + normalizedChannel + ":" + conversationKey;
         }
 
-        if (candidate.startsWith(GOAL_PREFIX)) {
+        if (candidateLower.startsWith(GOAL_PREFIX)) {
             String[] parts = candidate.split(":", 4);
             if (parts.length != 4) {
                 return GLOBAL_SCOPE;
@@ -100,7 +101,7 @@ public final class MemoryScopeSupport {
             return GOAL_PREFIX + normalizedChannel + ":" + conversationKey + ":" + goalId;
         }
 
-        if (candidate.startsWith(TASK_PREFIX)) {
+        if (candidateLower.startsWith(TASK_PREFIX)) {
             String[] parts = candidate.split(":", 2);
             if (parts.length != 2) {
                 return GLOBAL_SCOPE;

--- a/src/main/java/me/golemcore/bot/domain/service/ToolExecutionTraceExtractor.java
+++ b/src/main/java/me/golemcore/bot/domain/service/ToolExecutionTraceExtractor.java
@@ -139,7 +139,7 @@ public class ToolExecutionTraceExtractor {
     private String extractGenericAction(String toolName, Map<String, Object> arguments, Map<String, Object> details) {
         StringJoiner joiner = new StringJoiner(", ");
         arguments.forEach((key, value) -> {
-            if (joiner.length() > 0 || details.size() >= 3) {
+            if (details.size() >= 3) {
                 return;
             }
             String normalized = safeString(value);

--- a/src/main/java/me/golemcore/bot/tools/DateTimeTool.java
+++ b/src/main/java/me/golemcore/bot/tools/DateTimeTool.java
@@ -69,7 +69,12 @@ public class DateTimeTool implements ToolComponent {
     public CompletableFuture<ToolResult> execute(Map<String, Object> parameters) {
         return CompletableFuture.supplyAsync(() -> {
             try {
-                String timezoneStr = (String) parameters.get("timezone");
+                Map<String, Object> safeParameters = parameters != null ? parameters : Map.of();
+                Object timezoneValue = safeParameters.get("timezone");
+                if (timezoneValue != null && !(timezoneValue instanceof String)) {
+                    return ToolResult.failure("Invalid timezone: " + timezoneValue);
+                }
+                String timezoneStr = timezoneValue instanceof String timezone ? timezone : null;
                 ZoneId zoneId;
 
                 if (timezoneStr != null && !timezoneStr.isBlank()) {

--- a/src/main/java/me/golemcore/bot/tools/FileSystemTool.java
+++ b/src/main/java/me/golemcore/bot/tools/FileSystemTool.java
@@ -208,8 +208,9 @@ public class FileSystemTool implements ToolComponent {
             }
 
             try {
-                String operation = (String) parameters.get(PARAM_OPERATION);
-                String pathStr = (String) parameters.get(PARAM_PATH);
+                Map<String, Object> safeParameters = parameters != null ? parameters : Map.of();
+                String operation = stringParam(safeParameters, PARAM_OPERATION);
+                String pathStr = stringParam(safeParameters, PARAM_PATH);
                 log.info("[FileSystem] Operation: {}, Path: {}", operation, pathStr);
 
                 if (operation == null || pathStr == null) {
@@ -233,7 +234,7 @@ public class FileSystemTool implements ToolComponent {
 
                 ToolResult result = switch (operation) {
                 case "read_file" -> readFile(resolvedPath);
-                case "write_file" -> writeFile(resolvedPath, parameters);
+                case "write_file" -> writeFile(resolvedPath, safeParameters);
                 case "list_directory" -> listDirectory(resolvedPath);
                 case "create_directory" -> createDirectory(resolvedPath);
                 case "delete" -> delete(resolvedPath);
@@ -250,6 +251,16 @@ public class FileSystemTool implements ToolComponent {
                 return ToolResult.failure("Error: " + e.getMessage());
             }
         });
+    }
+
+    private static String stringParam(Map<String, Object> params, String name) {
+        Object value = params.get(name);
+        return value instanceof String stringValue ? stringValue : null;
+    }
+
+    private static boolean booleanParam(Map<String, Object> params, String name) {
+        Object value = params.get(name);
+        return value instanceof Boolean booleanValue && booleanValue;
     }
 
     private Path resolveSafePath(String pathStr) {
@@ -308,13 +319,12 @@ public class FileSystemTool implements ToolComponent {
     }
 
     private ToolResult writeFile(Path path, Map<String, Object> params) {
-        String content = (String) params.get(PARAM_CONTENT);
+        String content = stringParam(params, PARAM_CONTENT);
         if (content == null) {
             return ToolResult.failure("Missing content for write_file operation");
         }
 
-        Boolean append = (Boolean) params.get(PARAM_APPEND);
-        boolean shouldAppend = append != null && append;
+        boolean shouldAppend = booleanParam(params, PARAM_APPEND);
 
         try {
             // Ensure parent directory exists

--- a/src/main/java/me/golemcore/bot/tools/ShellTool.java
+++ b/src/main/java/me/golemcore/bot/tools/ShellTool.java
@@ -207,7 +207,8 @@ public class ShellTool implements ToolComponent {
             }
 
             try {
-                String command = (String) parameters.get(PARAM_COMMAND);
+                Map<String, Object> safeParameters = parameters != null ? parameters : Map.of();
+                String command = stringParam(safeParameters, PARAM_COMMAND);
                 if (command == null || command.isBlank()) {
                     log.warn("[Shell] Missing command parameter");
                     return ToolResult.failure("Missing required parameter: command");
@@ -224,16 +225,18 @@ public class ShellTool implements ToolComponent {
 
                 // Parse timeout
                 int timeout = defaultTimeout;
-                Object timeoutObj = parameters.get("timeout");
-                if (timeoutObj != null) {
-                    timeout = Math.min(((Number) timeoutObj).intValue(), maxTimeout);
+                Object timeoutObj = safeParameters.get("timeout");
+                if (timeoutObj instanceof Number timeoutNumber) {
+                    timeout = Math.min(timeoutNumber.intValue(), maxTimeout);
                     timeout = Math.max(timeout, 1);
+                } else if (timeoutObj != null) {
+                    return ToolResult.failure("Invalid timeout parameter");
                 }
                 log.debug("[Shell] Timeout: {}s", timeout);
 
                 // Resolve working directory
                 Path workDir = workspaceRoot;
-                String workdirStr = (String) parameters.get("workdir");
+                String workdirStr = stringParam(safeParameters, "workdir");
                 if (workdirStr != null && !workdirStr.isBlank()) {
                     workDir = workspaceRoot.resolve(workdirStr).normalize();
                     if (!workDir.startsWith(workspaceRoot)) {
@@ -274,6 +277,11 @@ public class ShellTool implements ToolComponent {
                 return ToolResult.failure("Error: " + e.getMessage());
             }
         }, executor);
+    }
+
+    private static String stringParam(Map<String, Object> params, String name) {
+        Object value = params.get(name);
+        return value instanceof String stringValue ? stringValue : null;
     }
 
     private String truncate(String text, int maxLen) {

--- a/src/main/java/me/golemcore/bot/tools/SkillTransitionTool.java
+++ b/src/main/java/me/golemcore/bot/tools/SkillTransitionTool.java
@@ -89,11 +89,12 @@ public class SkillTransitionTool implements ToolComponent {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public CompletableFuture<ToolResult> execute(Map<String, Object> parameters) {
         // Must run on calling thread to access AgentContextHolder (ThreadLocal)
-        String targetSkill = (String) parameters.get("target_skill");
-        String reason = (String) parameters.get("reason");
+        Object rawTargetSkill = parameters != null ? parameters.get("target_skill") : null;
+        Object rawReason = parameters != null ? parameters.get("reason") : null;
+        String targetSkill = rawTargetSkill instanceof String targetSkillValue ? targetSkillValue : null;
+        String reason = rawReason instanceof String reasonValue ? reasonValue : null;
 
         if (targetSkill == null || targetSkill.isBlank()) {
             return CompletableFuture.completedFuture(ToolResult.failure("target_skill is required"));

--- a/src/main/java/me/golemcore/bot/tools/TierTool.java
+++ b/src/main/java/me/golemcore/bot/tools/TierTool.java
@@ -84,7 +84,8 @@ public class TierTool implements ToolComponent {
 
     @Override
     public CompletableFuture<ToolResult> execute(Map<String, Object> parameters) {
-        String tier = ModelTierCatalog.normalizeTierId((String) parameters.get("tier"));
+        Object rawTier = parameters != null ? parameters.get("tier") : null;
+        String tier = rawTier instanceof String tierValue ? ModelTierCatalog.normalizeTierId(tierValue) : null;
 
         if (tier == null || tier.isBlank()) {
             return CompletableFuture.completedFuture(ToolResult.failure("tier is required"));

--- a/src/test/java/me/golemcore/bot/adapter/outbound/llm/Langchain4jToolSchemaConverterTest.java
+++ b/src/test/java/me/golemcore/bot/adapter/outbound/llm/Langchain4jToolSchemaConverterTest.java
@@ -1,0 +1,88 @@
+package me.golemcore.bot.adapter.outbound.llm;
+
+import dev.langchain4j.agent.tool.ToolSpecification;
+import dev.langchain4j.model.chat.request.json.JsonArraySchema;
+import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
+import dev.langchain4j.model.chat.request.json.JsonSchemaElement;
+import dev.langchain4j.model.chat.request.json.JsonStringSchema;
+import me.golemcore.bot.domain.model.LlmRequest;
+import me.golemcore.bot.domain.model.ToolDefinition;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+class Langchain4jToolSchemaConverterTest {
+
+    private final Langchain4jToolSchemaConverter converter = new Langchain4jToolSchemaConverter();
+
+    @Test
+    void shouldPreserveTopLevelAndNestedRequiredFields() {
+        ToolDefinition tool = ToolDefinition.builder()
+                .name("emit_signal")
+                .description("Emit a lifecycle signal")
+                .inputSchema(Map.of(
+                        "type", "object",
+                        "required", List.of("signal_type", "summary"),
+                        "properties", Map.of(
+                                "signal_type", Map.of(
+                                        "type", "string",
+                                        "description", "Signal type"),
+                                "summary", Map.of(
+                                        "type", "string",
+                                        "description", "Summary"),
+                                "evidence_refs", Map.of(
+                                        "type", "array",
+                                        "items", Map.of(
+                                                "type", "object",
+                                                "required", List.of("kind", "ref"),
+                                                "properties", Map.of(
+                                                        "kind", Map.of("type", "string"),
+                                                        "ref", Map.of("type", "string")))))))
+                .build();
+
+        ToolSpecification specification = converter.convertTools(LlmRequest.builder()
+                .tools(List.of(tool))
+                .build()).getFirst();
+
+        JsonObjectSchema parameters = specification.parameters();
+        assertEquals(List.of("signal_type", "summary"), parameters.required());
+        assertInstanceOf(JsonStringSchema.class, parameters.properties().get("signal_type"));
+
+        JsonArraySchema evidenceRefs = assertInstanceOf(JsonArraySchema.class,
+                parameters.properties().get("evidence_refs"));
+        JsonObjectSchema evidenceItem = assertInstanceOf(JsonObjectSchema.class, evidenceRefs.items());
+        assertEquals(List.of("kind", "ref"), evidenceItem.required());
+        assertEquals(Set.of("kind", "ref"), evidenceItem.properties().keySet());
+    }
+
+    @Test
+    void shouldDropInvalidNestedPropertiesWithoutDroppingValidSiblings() {
+        ToolDefinition tool = ToolDefinition.builder()
+                .name("configure")
+                .description("Configure runtime")
+                .inputSchema(Map.of(
+                        "type", "object",
+                        "properties", Map.of(
+                                "config", Map.of(
+                                        "type", "object",
+                                        "properties", Map.of(
+                                                "valid", Map.of("type", "string"),
+                                                "invalid", "not-a-schema-map")))))
+                .build();
+
+        ToolSpecification specification = converter.convertTools(LlmRequest.builder()
+                .tools(List.of(tool))
+                .build()).getFirst();
+
+        JsonObjectSchema config = assertInstanceOf(JsonObjectSchema.class,
+                specification.parameters().properties().get("config"));
+        Map<String, JsonSchemaElement> nestedProperties = config.properties();
+        assertEquals(List.of("valid"), nestedProperties.keySet().stream().toList());
+        assertInstanceOf(JsonStringSchema.class, nestedProperties.get("valid"));
+    }
+}

--- a/src/test/java/me/golemcore/bot/domain/memory/retrieval/MemoryCandidateScorerTest.java
+++ b/src/test/java/me/golemcore/bot/domain/memory/retrieval/MemoryCandidateScorerTest.java
@@ -1,0 +1,69 @@
+package me.golemcore.bot.domain.memory.retrieval;
+
+import me.golemcore.bot.domain.memory.model.MemoryRetrievalPlan;
+import me.golemcore.bot.domain.model.MemoryItem;
+import me.golemcore.bot.domain.model.MemoryQuery;
+import me.golemcore.bot.domain.model.MemoryScoredItem;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MemoryCandidateScorerTest {
+
+    private static final Instant TIMESTAMP = Instant.parse("2026-04-16T00:00:00Z");
+
+    private final MemoryCandidateScorer scorer = new MemoryCandidateScorer();
+
+    @Test
+    void shouldApplySkillTagBoostCaseInsensitively() {
+        MemoryRetrievalPlan plan = plan("code review", "QA-Review");
+        MemoryItem matchingSkill = item("matching-skill", "code review checklist", List.of("qa-review"));
+        MemoryItem unrelatedSkill = item("unrelated-skill", "code review checklist", List.of("docs"));
+
+        List<MemoryScoredItem> scored = scorer.score(plan, List.of(unrelatedSkill, matchingSkill));
+
+        assertEquals(List.of("matching-skill", "unrelated-skill"),
+                scored.stream().map(candidate -> candidate.getItem().getId()).toList());
+        assertTrue(scored.get(0).getScore() > scored.get(1).getScore());
+    }
+
+    @Test
+    void shouldUseUpdatedAtAsTieBreakerWhenScoresAreEqual() {
+        MemoryRetrievalPlan plan = plan("release notes", null);
+        MemoryItem older = item("older", "release notes", List.of());
+        older.setUpdatedAt(Instant.parse("2026-04-15T00:00:00Z"));
+        MemoryItem newer = item("newer", "release notes", List.of());
+        newer.setUpdatedAt(Instant.parse("2026-04-16T00:00:00Z"));
+
+        List<MemoryScoredItem> scored = scorer.score(plan, List.of(older, newer));
+
+        assertEquals(List.of("newer", "older"),
+                scored.stream().map(candidate -> candidate.getItem().getId()).toList());
+    }
+
+    private MemoryRetrievalPlan plan(String queryText, String activeSkill) {
+        return MemoryRetrievalPlan.builder()
+                .query(MemoryQuery.builder()
+                        .queryText(queryText)
+                        .activeSkill(activeSkill)
+                        .build())
+                .build();
+    }
+
+    private MemoryItem item(String id, String content, List<String> tags) {
+        return MemoryItem.builder()
+                .id(id)
+                .type(MemoryItem.Type.PROJECT_FACT)
+                .content(content)
+                .tags(tags)
+                .confidence(0.80)
+                .salience(0.70)
+                .createdAt(TIMESTAMP)
+                .updatedAt(TIMESTAMP)
+                .build();
+    }
+}

--- a/src/test/java/me/golemcore/bot/domain/model/PlanTest.java
+++ b/src/test/java/me/golemcore/bot/domain/model/PlanTest.java
@@ -1,0 +1,32 @@
+package me.golemcore.bot.domain.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class PlanTest {
+
+    @Test
+    void shouldTreatMissingStepsAsEmptyForCounters() {
+        Plan plan = Plan.builder()
+                .steps(null)
+                .build();
+
+        assertEquals(0, plan.getCompletedStepCount());
+        assertEquals(0, plan.getFailedStepCount());
+    }
+
+    @Test
+    void shouldCountCompletedAndFailedSteps() {
+        Plan plan = Plan.builder()
+                .steps(List.of(
+                        PlanStep.builder().status(PlanStep.StepStatus.COMPLETED).build(),
+                        PlanStep.builder().status(PlanStep.StepStatus.FAILED).build(),
+                        PlanStep.builder().status(PlanStep.StepStatus.PENDING).build()))
+                .build();
+
+        assertEquals(1, plan.getCompletedStepCount());
+        assertEquals(1, plan.getFailedStepCount());
+    }
+}

--- a/src/test/java/me/golemcore/bot/domain/service/ActiveSessionPointerServiceTest.java
+++ b/src/test/java/me/golemcore/bot/domain/service/ActiveSessionPointerServiceTest.java
@@ -8,8 +8,10 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -143,7 +145,7 @@ class ActiveSessionPointerServiceTest {
     }
 
     @Test
-    void shouldSerializeConcurrentWritesToPointerRegistry() {
+    void shouldSerializeConcurrentWritesToPointerRegistry() throws InterruptedException {
         TrackingStoragePort trackingStoragePort = new TrackingStoragePort();
         service = new ActiveSessionPointerService(trackingStoragePort, new ObjectMapper());
         String pointerKey = service.buildWebPointerKey("admin", "client-1");
@@ -152,9 +154,11 @@ class ActiveSessionPointerServiceTest {
             CompletableFuture<Void> first = CompletableFuture.runAsync(
                     () -> service.setActiveConversationKey(pointerKey, "session-1"),
                     executor);
+            assertTrue(trackingStoragePort.awaitWriteStarted());
             CompletableFuture<Void> second = CompletableFuture.runAsync(
                     () -> service.setActiveConversationKey(pointerKey, "session-2"),
                     executor);
+            trackingStoragePort.releaseWrites();
 
             assertDoesNotThrow(() -> CompletableFuture.allOf(first, second).join());
             assertEquals(1, trackingStoragePort.maxConcurrentWrites());
@@ -167,6 +171,8 @@ class ActiveSessionPointerServiceTest {
 
         private final AtomicInteger concurrentWrites = new AtomicInteger();
         private final AtomicInteger maxConcurrentWritesCounter = new AtomicInteger();
+        private final CountDownLatch firstWriteStarted = new CountDownLatch(1);
+        private final CountDownLatch writesMayContinue = new CountDownLatch(1);
 
         @Override
         public CompletableFuture<Void> putObject(String directory, String path, byte[] content) {
@@ -214,7 +220,10 @@ class ActiveSessionPointerServiceTest {
                 int active = concurrentWrites.incrementAndGet();
                 maxConcurrentWritesCounter.accumulateAndGet(active, Math::max);
                 try {
-                    Thread.sleep(75);
+                    firstWriteStarted.countDown();
+                    if (!writesMayContinue.await(2, TimeUnit.SECONDS)) {
+                        throw new IllegalStateException("Timed out waiting to release pointer write");
+                    }
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                     throw new RuntimeException(e);
@@ -231,6 +240,14 @@ class ActiveSessionPointerServiceTest {
 
         int maxConcurrentWrites() {
             return maxConcurrentWritesCounter.get();
+        }
+
+        boolean awaitWriteStarted() throws InterruptedException {
+            return firstWriteStarted.await(1, TimeUnit.SECONDS);
+        }
+
+        void releaseWrites() {
+            writesMayContinue.countDown();
         }
     }
 }

--- a/src/test/java/me/golemcore/bot/domain/service/ConversationKeyValidatorTest.java
+++ b/src/test/java/me/golemcore/bot/domain/service/ConversationKeyValidatorTest.java
@@ -1,0 +1,63 @@
+package me.golemcore.bot.domain.service;
+
+import me.golemcore.bot.domain.model.AgentSession;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ConversationKeyValidatorTest {
+
+    @Test
+    void shouldNormalizeAndValidateStrictConversationKeys() {
+        assertTrue(ConversationKeyValidator.isStrictConversationKey(" abcDEF_12 "));
+        assertFalse(ConversationKeyValidator.isStrictConversationKey("short"));
+        assertFalse(ConversationKeyValidator.isStrictConversationKey("invalid.key"));
+
+        assertEquals("abcDEF_12", ConversationKeyValidator.normalizeStrictOrThrow(" abcDEF_12 "));
+        assertThrows(IllegalArgumentException.class,
+                () -> ConversationKeyValidator.normalizeStrictOrThrow("invalid.key"));
+    }
+
+    @Test
+    void shouldAllowExistingLegacyKeyOnlyForActivation() {
+        assertEquals("abc", ConversationKeyValidator.normalizeForActivationOrThrow(" abc ", key -> true));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> ConversationKeyValidator.normalizeForActivationOrThrow("abc", key -> false));
+    }
+
+    @Test
+    void shouldSortRecentSessionsByUpdatedThenCreatedKeepingMissingTimestampsLast() {
+        AgentSession newestUpdated = session("newest-updated",
+                Instant.parse("2026-04-16T10:00:00Z"),
+                Instant.parse("2026-04-16T11:00:00Z"));
+        AgentSession newestCreated = session("newest-created",
+                Instant.parse("2026-04-16T10:30:00Z"),
+                null);
+        AgentSession olderUpdated = session("older-updated",
+                Instant.parse("2026-04-16T08:00:00Z"),
+                Instant.parse("2026-04-16T09:00:00Z"));
+        AgentSession missingTimestamp = session("missing-timestamp", null, null);
+
+        List<AgentSession> sorted = List.of(missingTimestamp, olderUpdated, newestCreated, newestUpdated).stream()
+                .sorted(ConversationKeyValidator.byRecentActivity())
+                .toList();
+
+        assertEquals(List.of("newest-updated", "newest-created", "older-updated", "missing-timestamp"),
+                sorted.stream().map(AgentSession::getId).toList());
+    }
+
+    private AgentSession session(String id, Instant createdAt, Instant updatedAt) {
+        return AgentSession.builder()
+                .id(id)
+                .createdAt(createdAt)
+                .updatedAt(updatedAt)
+                .build();
+    }
+}

--- a/src/test/java/me/golemcore/bot/domain/service/HiveSdlcServiceTest.java
+++ b/src/test/java/me/golemcore/bot/domain/service/HiveSdlcServiceTest.java
@@ -1,6 +1,7 @@
 package me.golemcore.bot.domain.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -9,7 +10,11 @@ import static org.mockito.Mockito.when;
 import java.util.List;
 import java.util.Optional;
 import me.golemcore.bot.domain.model.HiveSessionState;
+import me.golemcore.bot.domain.model.hive.HiveCardDetail;
 import me.golemcore.bot.domain.model.hive.HiveCardSearchRequest;
+import me.golemcore.bot.domain.model.hive.HiveCreateCardRequest;
+import me.golemcore.bot.domain.model.hive.HiveRequestReviewRequest;
+import me.golemcore.bot.domain.model.hive.HiveThreadMessage;
 import me.golemcore.bot.port.outbound.HiveGatewayPort;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -33,18 +38,43 @@ class HiveSdlcServiceTest {
     void shouldDelegateCardSearchUsingStoredHiveSession() {
         HiveCardSearchRequest request = new HiveCardSearchRequest(null, "board-1", null, null, null, null, null,
                 false);
-        when(runtimeConfigService.isHiveEnabled()).thenReturn(true);
-        when(hiveSessionStateStore.load()).thenReturn(Optional.of(HiveSessionState.builder()
-                .serverUrl("https://hive.example.com")
-                .golemId("golem-1")
-                .accessToken("access")
-                .build()));
+        arrangeConnectedHiveSession();
         when(hiveGatewayPort.searchCards("https://hive.example.com", "golem-1", "access", request))
                 .thenReturn(List.of());
 
         assertEquals(0, service.searchCards(request).size());
 
         verify(hiveGatewayPort).searchCards("https://hive.example.com", "golem-1", "access", request);
+    }
+
+    @Test
+    void shouldDelegateCardMutationsUsingStoredHiveSession() {
+        arrangeConnectedHiveSession();
+        HiveCardDetail card = cardDetail();
+        HiveThreadMessage message = threadMessage();
+        HiveCreateCardRequest createRequest = new HiveCreateCardRequest("svc-1", "board-1", "Title",
+                "Description", null, "todo", "task", null, null, null, null, null, null, null, null, false);
+        HiveRequestReviewRequest reviewRequest = new HiveRequestReviewRequest(List.of("reviewer-1"), null, 1);
+        when(hiveGatewayPort.getCard("https://hive.example.com", "golem-1", "access", "card-1"))
+                .thenReturn(card);
+        when(hiveGatewayPort.createCard("https://hive.example.com", "golem-1", "access", createRequest))
+                .thenReturn(card);
+        when(hiveGatewayPort.postThreadMessage("https://hive.example.com", "golem-1", "access", "thread-1",
+                "please review")).thenReturn(message);
+        when(hiveGatewayPort.requestReview("https://hive.example.com", "golem-1", "access", "card-1",
+                reviewRequest)).thenReturn(card);
+
+        assertSame(card, service.getCard("card-1"));
+        assertSame(card, service.createCard(createRequest));
+        assertSame(message, service.postThreadMessage("thread-1", "please review"));
+        assertSame(card, service.requestReview("card-1", reviewRequest));
+
+        verify(hiveGatewayPort).getCard("https://hive.example.com", "golem-1", "access", "card-1");
+        verify(hiveGatewayPort).createCard("https://hive.example.com", "golem-1", "access", createRequest);
+        verify(hiveGatewayPort).postThreadMessage("https://hive.example.com", "golem-1", "access", "thread-1",
+                "please review");
+        verify(hiveGatewayPort).requestReview("https://hive.example.com", "golem-1", "access", "card-1",
+                reviewRequest);
     }
 
     @Test
@@ -64,5 +94,39 @@ class HiveSdlcServiceTest {
         IllegalStateException error = assertThrows(IllegalStateException.class, () -> service.getCard("card-1"));
 
         assertEquals("Hive session is not connected", error.getMessage());
+    }
+
+    @Test
+    void shouldRejectSdlcOperationsWhenHiveSessionCredentialsAreIncomplete() {
+        when(runtimeConfigService.isHiveEnabled()).thenReturn(true);
+        when(hiveSessionStateStore.load()).thenReturn(Optional.of(HiveSessionState.builder()
+                .serverUrl("https://hive.example.com")
+                .golemId("golem-1")
+                .accessToken(" ")
+                .build()));
+
+        IllegalStateException error = assertThrows(IllegalStateException.class, () -> service.getCard("card-1"));
+
+        assertEquals("Hive access token is missing", error.getMessage());
+    }
+
+    private void arrangeConnectedHiveSession() {
+        when(runtimeConfigService.isHiveEnabled()).thenReturn(true);
+        when(hiveSessionStateStore.load()).thenReturn(Optional.of(HiveSessionState.builder()
+                .serverUrl("https://hive.example.com")
+                .golemId("golem-1")
+                .accessToken("access")
+                .build()));
+    }
+
+    private HiveCardDetail cardDetail() {
+        return new HiveCardDetail("card-1", "svc-1", "board-1", "task", null, null, List.of(), null, List.of(),
+                null, null, null, null, null, "thread-1", "Title", "Description", null, "todo", null, null, 1,
+                false, null, null, null, null);
+    }
+
+    private HiveThreadMessage threadMessage() {
+        return new HiveThreadMessage("message-1", "thread-1", "card-1", null, null, null, "comment", "golem",
+                "golem-1", "Golem", "please review", null);
     }
 }

--- a/src/test/java/me/golemcore/bot/domain/service/MemoryScopeSupportTest.java
+++ b/src/test/java/me/golemcore/bot/domain/service/MemoryScopeSupportTest.java
@@ -1,10 +1,13 @@
 package me.golemcore.bot.domain.service;
 
 import me.golemcore.bot.domain.model.AgentSession;
+import me.golemcore.bot.domain.model.AutoRunKind;
 import me.golemcore.bot.domain.model.ContextAttributes;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -56,5 +59,23 @@ class MemoryScopeSupportTest {
         String scope = MemoryScopeSupport.resolveScopeFromSessionOrGlobal(session);
 
         assertEquals(MemoryScopeSupport.GLOBAL_SCOPE, scope);
+    }
+
+    @Test
+    void shouldNormalizeScopePrefixesCaseInsensitively() {
+        assertEquals("session:web:Conv_123",
+                MemoryScopeSupport.normalizeScopeOrGlobal(" SESSION:WEB:Conv_123 "));
+        assertEquals("goal:web:Conv_123:Goal-1",
+                MemoryScopeSupport.normalizeScopeOrGlobal(" GOAL:WEB:Conv_123:Goal-1 "));
+        assertEquals("task:Task-1", MemoryScopeSupport.normalizeScopeOrGlobal(" TASK:Task-1 "));
+    }
+
+    @Test
+    void shouldBuildScopeChainFromCaseInsensitiveSessionScope() {
+        List<String> chain = MemoryScopeSupport.buildScopeChain(" SESSION:WEB:Conv_123 ",
+                AutoRunKind.GOAL_RUN.name().toLowerCase(Locale.ROOT), "Goal-1", "Task-1");
+
+        assertEquals(List.of("task:Task-1", "goal:web:Conv_123:Goal-1", "session:web:Conv_123", "global"),
+                chain);
     }
 }

--- a/src/test/java/me/golemcore/bot/domain/service/ToolExecutionTraceExtractorTest.java
+++ b/src/test/java/me/golemcore/bot/domain/service/ToolExecutionTraceExtractorTest.java
@@ -1,0 +1,101 @@
+package me.golemcore.bot.domain.service;
+
+import me.golemcore.bot.domain.model.Message;
+import me.golemcore.bot.domain.model.ToolExecutionTrace;
+import me.golemcore.bot.domain.model.ToolResult;
+import me.golemcore.bot.domain.system.toolloop.ToolExecutionOutcome;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ToolExecutionTraceExtractorTest {
+
+    private final ToolExecutionTraceExtractor extractor = new ToolExecutionTraceExtractor();
+
+    @Test
+    void shouldCaptureThreeGenericArgumentsWithoutLeakingMore() {
+        Map<String, Object> arguments = new LinkedHashMap<>();
+        arguments.put("alpha", "one");
+        arguments.put("beta", "two");
+        arguments.put("gamma", "three");
+        arguments.put("delta", "four");
+
+        ToolExecutionTrace trace = extractor.extract(toolCall("custom_tool", arguments),
+                success("ok", Map.of()), 42);
+
+        assertEquals("tool", trace.family());
+        assertTrue(trace.success());
+        assertEquals(42, trace.durationMs());
+        assertEquals("used custom_tool (alpha=\"one\", beta=\"two\", gamma=\"three\")", trace.action());
+        assertEquals("one", trace.details().get("alpha"));
+        assertEquals("two", trace.details().get("beta"));
+        assertEquals("three", trace.details().get("gamma"));
+        assertFalse(trace.details().containsKey("delta"));
+        assertEquals("custom_tool", trace.details().get("tool"));
+    }
+
+    @Test
+    void shouldPreferResultWorkdirAndExitCodeForShellTraces() {
+        ToolExecutionTrace trace = extractor.extract(toolCall("shell", Map.of("command", "  ./mvnw   test  ")),
+                success("failed", Map.of("workdir", "/workspace/project", "exitCode", 1)), 350);
+
+        assertEquals("shell", trace.family());
+        assertTrue(trace.success());
+        assertEquals("ran `./mvnw test` in /workspace/project", trace.action());
+        assertEquals("./mvnw test", trace.details().get("command"));
+        assertEquals("/workspace/project", trace.details().get("workdir"));
+        assertEquals(1, trace.details().get("exitCode"));
+    }
+
+    @Test
+    void shouldNormalizeSearchAndBrowseFamilies() {
+        ToolExecutionTrace search = extractor.extract(
+                toolCall("perplexity_search", Map.of("question", "release notes")),
+                success("ok", Map.of()), 10);
+        ToolExecutionTrace browse = extractor.extract(
+                toolCall("firecrawl_fetch", Map.of("url", "https://example.test")),
+                failure(), 12);
+
+        assertEquals("search", search.family());
+        assertEquals("searched for \"release notes\"", search.action());
+        assertTrue(search.success());
+        assertEquals("browse", browse.family());
+        assertEquals("checked https://example.test", browse.action());
+        assertFalse(browse.success());
+    }
+
+    @Test
+    void shouldIgnoreNonMapResultDataAndUseSafeDefaults() {
+        ToolExecutionTrace trace = extractor.extract(null,
+                new ToolExecutionOutcome("call-1", "ignored", ToolResult.success("ok", "not-a-map"), "ok", false,
+                        null),
+                0);
+
+        assertEquals("tool", trace.toolName());
+        assertEquals("tool", trace.family());
+        assertEquals("used tool", trace.action());
+        assertTrue(trace.success());
+        assertEquals("tool", trace.details().get("tool"));
+    }
+
+    private Message.ToolCall toolCall(String name, Map<String, Object> arguments) {
+        return Message.ToolCall.builder()
+                .id("call-1")
+                .name(name)
+                .arguments(arguments)
+                .build();
+    }
+
+    private ToolExecutionOutcome success(String output, Object data) {
+        return new ToolExecutionOutcome("call-1", "tool", ToolResult.success(output, data), output, false, null);
+    }
+
+    private ToolExecutionOutcome failure() {
+        return new ToolExecutionOutcome("call-1", "tool", ToolResult.failure("boom"), "boom", false, null);
+    }
+}

--- a/src/test/java/me/golemcore/bot/tools/DateTimeToolTest.java
+++ b/src/test/java/me/golemcore/bot/tools/DateTimeToolTest.java
@@ -62,6 +62,17 @@ class DateTimeToolTest {
     }
 
     @Test
+    void execute_withNonStringTimezone() throws ExecutionException, InterruptedException {
+        Map<String, Object> params = Map.of(TIMEZONE, 123);
+
+        ToolResult result = dateTimeTool.execute(params).get();
+
+        assertFalse(result.isSuccess());
+        assertTrue(result.getError().contains("Invalid timezone"));
+        assertFalse(result.getError().contains("ClassCastException"));
+    }
+
+    @Test
     void execute_withDifferentTimezones() throws ExecutionException, InterruptedException {
         String[] timezones = { "America/New_York", "Europe/London", "Asia/Tokyo" };
 

--- a/src/test/java/me/golemcore/bot/tools/FileSystemToolTest.java
+++ b/src/test/java/me/golemcore/bot/tools/FileSystemToolTest.java
@@ -211,6 +211,23 @@ class FileSystemToolTest {
     }
 
     @Test
+    void nonStringOperationOrPathReturnValidationFailure() throws Exception {
+        ToolResult result1 = tool.execute(Map.of(
+                OPERATION, 123,
+                PATH, TEST_TXT)).get();
+        assertFalse(result1.isSuccess());
+        assertTrue(result1.getError().contains("Missing required parameters"));
+        assertFalse(result1.getError().contains("ClassCastException"));
+
+        ToolResult result2 = tool.execute(Map.of(
+                OPERATION, READ_FILE,
+                PATH, 123)).get();
+        assertFalse(result2.isSuccess());
+        assertTrue(result2.getError().contains("Missing required parameters"));
+        assertFalse(result2.getError().contains("ClassCastException"));
+    }
+
+    @Test
     void disabledTool() throws Exception {
         BotProperties disabledProps = createTestProperties(tempDir.toString());
         // enabled is now controlled via RuntimeConfigService
@@ -347,6 +364,18 @@ class FileSystemToolTest {
                 PATH, TEST_TXT)).get();
         assertFalse(result.isSuccess());
         assertTrue(result.getError().contains("Missing content"));
+    }
+
+    @Test
+    void shouldFailWriteWithNonStringContent() throws Exception {
+        ToolResult result = tool.execute(Map.of(
+                OPERATION, WRITE_FILE,
+                PATH, TEST_TXT,
+                CONTENT, 123)).get();
+
+        assertFalse(result.isSuccess());
+        assertTrue(result.getError().contains("Missing content"));
+        assertFalse(result.getError().contains("ClassCastException"));
     }
 
     @Test

--- a/src/test/java/me/golemcore/bot/tools/ShellToolTest.java
+++ b/src/test/java/me/golemcore/bot/tools/ShellToolTest.java
@@ -190,6 +190,30 @@ class ShellToolTest {
     }
 
     @Test
+    void nonStringCommandReturnsValidationFailure() throws Exception {
+        Map<String, Object> params = Map.of(COMMAND, 123);
+
+        ToolResult result = tool.execute(params).get();
+
+        assertFalse(result.isSuccess());
+        assertTrue(result.getError().contains("Missing required parameter: command"));
+        assertFalse(result.getError().contains("ClassCastException"));
+    }
+
+    @Test
+    void nonNumericTimeoutReturnsValidationFailure() throws Exception {
+        Map<String, Object> params = Map.of(
+                COMMAND, "echo ok",
+                TIMEOUT, "slow");
+
+        ToolResult result = tool.execute(params).get();
+
+        assertFalse(result.isSuccess());
+        assertTrue(result.getError().contains("Invalid timeout parameter"));
+        assertFalse(result.getError().contains("ClassCastException"));
+    }
+
+    @Test
     @DisabledOnOs(OS.WINDOWS)
     void commandWithExitCode() throws Exception {
         Map<String, Object> params = Map.of(

--- a/src/test/java/me/golemcore/bot/tools/SkillTransitionToolTest.java
+++ b/src/test/java/me/golemcore/bot/tools/SkillTransitionToolTest.java
@@ -146,6 +146,17 @@ class SkillTransitionToolTest {
     }
 
     @Test
+    void nonStringTargetSkill() throws Exception {
+        setUpAgentContext();
+
+        ToolResult result = tool.execute(Map.of(
+                TARGET_SKILL, 123)).get();
+
+        assertFalse(result.isSuccess());
+        assertTrue(result.getError().contains(TARGET_SKILL));
+    }
+
+    @Test
     void noAgentContext() throws Exception {
         // Don't set up context — AgentContextHolder is empty
         Skill targetSkill = Skill.builder()

--- a/src/test/java/me/golemcore/bot/tools/TierToolTest.java
+++ b/src/test/java/me/golemcore/bot/tools/TierToolTest.java
@@ -98,6 +98,14 @@ class TierToolTest {
     }
 
     @Test
+    void shouldRejectNonStringTier() {
+        ToolResult result = tool.execute(Map.of(PARAM_TIER, 123)).join();
+
+        assertNotNull(result.getError());
+        assertTrue(result.getError().contains("required"));
+    }
+
+    @Test
     void shouldRejectWhenTierForceEnabled() {
         when(preferencesService.getPreferences()).thenReturn(
                 UserPreferences.builder().modelTier("smart").tierForce(true).build());


### PR DESCRIPTION
## Summary
- harden QA coverage around conversation sorting, memory scoring, scope normalization, tool trace extraction, Langchain4j schema conversion, and dashboard MIME handling
- add TDD coverage and fixes for malformed tool parameters so tools return validation failures instead of `ClassCastException`
- remove timing-dependent concurrency behavior in the active session pointer test and expand Hive SDLC delegation coverage

