### PR TITLE
fix(prompts): coerce null description from YAML to empty string

### DIFF
--- a/src/main/java/me/golemcore/bot/application/prompts/PromptManagementFacade.java
+++ b/src/main/java/me/golemcore/bot/application/prompts/PromptManagementFacade.java
@@ -118,7 +118,7 @@ public class PromptManagementFacade {
     private String buildFileContent(PromptSectionDraft request) {
         StringBuilder sb = new StringBuilder();
         sb.append("---\n");
-        if (request.description() != null) {
+        if (request.description() != null && !request.description().isBlank()) {
             sb.append("description: ").append(request.description()).append("\n");
         }
         sb.append("order: ").append(request.order()).append("\n");

--- a/src/main/java/me/golemcore/bot/domain/service/PromptSectionService.java
+++ b/src/main/java/me/golemcore/bot/domain/service/PromptSectionService.java
@@ -328,11 +328,17 @@ public class PromptSectionService {
                 // coerce to empty string so the API string contract holds.
                 Object rawDescription = yaml.get("description");
                 description = rawDescription == null ? "" : rawDescription.toString();
-                if (yaml.containsKey("order")) {
-                    order = ((Number) yaml.get("order")).intValue();
+                // Bare `order:` / `enabled:` round-trip as null through YAML; treat them as
+                // absent
+                // so one empty key does not abort parsing and silently drop the remaining
+                // fields.
+                Object rawOrder = yaml.get("order");
+                if (rawOrder instanceof Number orderNumber) {
+                    order = orderNumber.intValue();
                 }
-                if (yaml.containsKey("enabled")) {
-                    enabled = (Boolean) yaml.get("enabled");
+                Object rawEnabled = yaml.get("enabled");
+                if (rawEnabled instanceof Boolean enabledFlag) {
+                    enabled = enabledFlag;
                 }
             } catch (IOException | RuntimeException e) {
                 log.warn("Failed to parse prompt section frontmatter: {}", file, e);

--- a/src/main/java/me/golemcore/bot/domain/service/PromptSectionService.java
+++ b/src/main/java/me/golemcore/bot/domain/service/PromptSectionService.java
@@ -324,14 +324,12 @@ public class PromptSectionService {
                 @SuppressWarnings("unchecked")
                 Map<String, Object> yaml = yamlMapper.readValue(frontmatter, Map.class);
 
-                // YAML treats `description:` (no value) as a key mapped to null;
-                // coerce to empty string so the API string contract holds.
+                // Bare `description:` parses as null; coerce to empty string so the API
+                // contract holds.
                 Object rawDescription = yaml.get("description");
                 description = rawDescription == null ? "" : rawDescription.toString();
-                // Bare `order:` / `enabled:` round-trip as null through YAML; treat them as
-                // absent
-                // so one empty key does not abort parsing and silently drop the remaining
-                // fields.
+                // Bare or mistyped `order:` / `enabled:` must not abort the try and drop later
+                // keys.
                 Object rawOrder = yaml.get("order");
                 if (rawOrder instanceof Number orderNumber) {
                     order = orderNumber.intValue();

--- a/src/main/java/me/golemcore/bot/domain/service/PromptSectionService.java
+++ b/src/main/java/me/golemcore/bot/domain/service/PromptSectionService.java
@@ -324,7 +324,10 @@ public class PromptSectionService {
                 @SuppressWarnings("unchecked")
                 Map<String, Object> yaml = yamlMapper.readValue(frontmatter, Map.class);
 
-                description = (String) yaml.getOrDefault("description", "");
+                // YAML treats `description:` (no value) as a key mapped to null;
+                // coerce to empty string so the API string contract holds.
+                Object rawDescription = yaml.get("description");
+                description = rawDescription == null ? "" : rawDescription.toString();
                 if (yaml.containsKey("order")) {
                     order = ((Number) yaml.get("order")).intValue();
                 }

--- a/src/test/java/me/golemcore/bot/application/prompts/PromptManagementFacadeTest.java
+++ b/src/test/java/me/golemcore/bot/application/prompts/PromptManagementFacadeTest.java
@@ -3,12 +3,15 @@ package me.golemcore.bot.application.prompts;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import org.mockito.ArgumentCaptor;
 
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -60,6 +63,25 @@ class PromptManagementFacadeTest {
         assertEquals("custom", result.getName());
         verify(storagePort).putText(eq("prompts"), eq("CUSTOM.md"), anyString());
         verify(promptSectionService).reload();
+    }
+
+    @Test
+    void shouldOmitBlankDescriptionFromFileContent() {
+        // A bare `description:` line round-trips through YAML as null, which breaks the
+        // API string contract.
+        // Skip the line entirely for null or blank descriptions so the file never
+        // serializes to that shape.
+        PromptSectionDraft request = new PromptSectionDraft("custom", "   ", 40, true, "Custom body");
+        when(promptSectionService.getSection("custom")).thenReturn(
+                Optional.empty(),
+                Optional.of(PromptSection.builder().name("custom").build()));
+
+        facade.createSection(request);
+
+        ArgumentCaptor<String> fileContent = ArgumentCaptor.forClass(String.class);
+        verify(storagePort).putText(eq("prompts"), eq("CUSTOM.md"), fileContent.capture());
+        assertFalse(fileContent.getValue().contains("description:"),
+                "blank description must not be written to frontmatter");
     }
 
     @Test

--- a/src/test/java/me/golemcore/bot/domain/service/PromptSectionServiceTest.java
+++ b/src/test/java/me/golemcore/bot/domain/service/PromptSectionServiceTest.java
@@ -131,6 +131,45 @@ class PromptSectionServiceTest {
     }
 
     @Test
+    void reload_frontmatterWithBareOrderKeepsDefaultAndAppliesLaterKeys() {
+        // A bare `order:` parses as null. The loader must not let that abort parsing
+        // and drop
+        // later keys in the same frontmatter — the section should default order and
+        // still apply
+        // the remaining fields.
+        String content = "---\ndescription: Foo\norder:\nenabled: false\n---\nBody.";
+
+        when(storagePort.listObjects(PROMPTS_DIR, ""))
+                .thenReturn(CompletableFuture.completedFuture(List.of(IDENTITY_FILE)));
+        when(storagePort.getText(PROMPTS_DIR, IDENTITY_FILE))
+                .thenReturn(CompletableFuture.completedFuture(content));
+
+        service.reload();
+
+        PromptSection section = service.getSection(IDENTITY_NAME).orElseThrow();
+        assertEquals("Foo", section.getDescription());
+        assertEquals(100, section.getOrder());
+        assertFalse(section.isEnabled());
+    }
+
+    @Test
+    void reload_frontmatterWithBareEnabledKeepsDefaultAndAppliesLaterKeys() {
+        String content = "---\ndescription: Foo\nenabled:\norder: 55\n---\nBody.";
+
+        when(storagePort.listObjects(PROMPTS_DIR, ""))
+                .thenReturn(CompletableFuture.completedFuture(List.of(IDENTITY_FILE)));
+        when(storagePort.getText(PROMPTS_DIR, IDENTITY_FILE))
+                .thenReturn(CompletableFuture.completedFuture(content));
+
+        service.reload();
+
+        PromptSection section = service.getSection(IDENTITY_NAME).orElseThrow();
+        assertEquals("Foo", section.getDescription());
+        assertEquals(55, section.getOrder());
+        assertTrue(section.isEnabled());
+    }
+
+    @Test
     void reload_noFrontmatter() {
         when(storagePort.listObjects(PROMPTS_DIR, ""))
                 .thenReturn(CompletableFuture.completedFuture(List.of("CUSTOM.md")));

--- a/src/test/java/me/golemcore/bot/domain/service/PromptSectionServiceTest.java
+++ b/src/test/java/me/golemcore/bot/domain/service/PromptSectionServiceTest.java
@@ -98,6 +98,39 @@ class PromptSectionServiceTest {
     }
 
     @Test
+    void reload_frontmatterWithEmptyDescriptionDefaultsToEmptyString() {
+        // YAML parses `description:` (no value) as a key whose value is null.
+        // The loader must coerce that to an empty string so API consumers can trust the
+        // string contract.
+        String content = "---\ndescription:\norder: 10\n---\nBody.";
+
+        when(storagePort.listObjects(PROMPTS_DIR, ""))
+                .thenReturn(CompletableFuture.completedFuture(List.of(IDENTITY_FILE)));
+        when(storagePort.getText(PROMPTS_DIR, IDENTITY_FILE))
+                .thenReturn(CompletableFuture.completedFuture(content));
+
+        service.reload();
+
+        PromptSection section = service.getSection(IDENTITY_NAME).orElseThrow();
+        assertEquals("", section.getDescription());
+    }
+
+    @Test
+    void reload_frontmatterWithExplicitNullDescriptionDefaultsToEmptyString() {
+        String content = "---\ndescription: ~\norder: 10\n---\nBody.";
+
+        when(storagePort.listObjects(PROMPTS_DIR, ""))
+                .thenReturn(CompletableFuture.completedFuture(List.of(IDENTITY_FILE)));
+        when(storagePort.getText(PROMPTS_DIR, IDENTITY_FILE))
+                .thenReturn(CompletableFuture.completedFuture(content));
+
+        service.reload();
+
+        PromptSection section = service.getSection(IDENTITY_NAME).orElseThrow();
+        assertEquals("", section.getDescription());
+    }
+
+    @Test
     void reload_noFrontmatter() {
         when(storagePort.listObjects(PROMPTS_DIR, ""))
                 .thenReturn(CompletableFuture.completedFuture(List.of("CUSTOM.md")));

--- a/src/test/java/me/golemcore/bot/domain/service/PromptSectionServiceTest.java
+++ b/src/test/java/me/golemcore/bot/domain/service/PromptSectionServiceTest.java
@@ -132,11 +132,8 @@ class PromptSectionServiceTest {
 
     @Test
     void reload_frontmatterWithBareOrderKeepsDefaultAndAppliesLaterKeys() {
-        // A bare `order:` parses as null. The loader must not let that abort parsing
-        // and drop
-        // later keys in the same frontmatter — the section should default order and
-        // still apply
-        // the remaining fields.
+        // Bare `order:` parses as null; it must not abort the try and drop `enabled`
+        // after it.
         String content = "---\ndescription: Foo\norder:\nenabled: false\n---\nBody.";
 
         when(storagePort.listObjects(PROMPTS_DIR, ""))
@@ -153,8 +150,8 @@ class PromptSectionServiceTest {
     }
 
     @Test
-    void reload_frontmatterWithBareEnabledKeepsDefaultAndAppliesLaterKeys() {
-        String content = "---\ndescription: Foo\nenabled:\norder: 55\n---\nBody.";
+    void reload_frontmatterWithBareEnabledDefaultsToTrue() {
+        String content = "---\ndescription: Foo\norder: 55\nenabled:\n---\nBody.";
 
         when(storagePort.listObjects(PROMPTS_DIR, ""))
                 .thenReturn(CompletableFuture.completedFuture(List.of(IDENTITY_FILE)));


### PR DESCRIPTION
## Summary

- Webui Prompts page crashed with `TypeError: Cannot read properties of null (reading 'length')` whenever a prompt section's frontmatter stored a bare `description:` line. YAML parsed that key as null, the DTO faithfully serialized it, and `PromptsSidebarParts.tsx:137` dereferenced `.length` on the null.
- Root cause was a write/read mismatch: creating a prompt from the UI sent `description: ''`, which `PromptManagementFacade.buildFileContent` happily serialized as `description: \n`. On the next reload YAML reparsed it as null.
- Fixed both sides of the round-trip: facade now skips the description line when the draft value is blank, and `PromptSectionService.parseSection` coerces a null YAML value back to an empty string so the API string contract always holds.
