### PR TITLE
fix(update): prefer newer image over stale current jar

### DIFF
--- a/src/main/java/me/golemcore/bot/adapter/inbound/runtime/UpdateRuntimeCleanupLifecycle.java
+++ b/src/main/java/me/golemcore/bot/adapter/inbound/runtime/UpdateRuntimeCleanupLifecycle.java
@@ -1,6 +1,7 @@
 package me.golemcore.bot.adapter.inbound.runtime;
 
 import lombok.RequiredArgsConstructor;
+import me.golemcore.bot.port.outbound.UpdateVersionPort;
 import me.golemcore.bot.domain.service.UpdateRuntimeCleanupService;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
@@ -11,9 +12,10 @@ import org.springframework.stereotype.Component;
 public class UpdateRuntimeCleanupLifecycle {
 
     private final UpdateRuntimeCleanupService updateRuntimeCleanupService;
+    private final UpdateVersionPort updateVersionPort;
 
     @EventListener(ApplicationReadyEvent.class)
     public void onApplicationReady() {
-        updateRuntimeCleanupService.cleanupAfterSuccessfulStartup();
+        updateRuntimeCleanupService.cleanupAfterSuccessfulStartup(updateVersionPort.currentVersion());
     }
 }

--- a/src/main/java/me/golemcore/bot/adapter/inbound/runtime/UpdateRuntimeCleanupLifecycle.java
+++ b/src/main/java/me/golemcore/bot/adapter/inbound/runtime/UpdateRuntimeCleanupLifecycle.java
@@ -1,12 +1,21 @@
 package me.golemcore.bot.adapter.inbound.runtime;
 
 import lombok.RequiredArgsConstructor;
-import me.golemcore.bot.port.outbound.UpdateVersionPort;
 import me.golemcore.bot.domain.service.UpdateRuntimeCleanupService;
+import me.golemcore.bot.port.outbound.UpdateVersionPort;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
+/**
+ * Triggers runtime-update cleanup only after the application has started
+ * successfully.
+ *
+ * <p>
+ * The lifecycle passes the version of the runtime that actually booted so
+ * cleanup can safely discard stale markers that still point to an older jar.
+ * </p>
+ */
 @Component
 @RequiredArgsConstructor
 public class UpdateRuntimeCleanupLifecycle {

--- a/src/main/java/me/golemcore/bot/application/update/UpdateVersionSupport.java
+++ b/src/main/java/me/golemcore/bot/application/update/UpdateVersionSupport.java
@@ -2,5 +2,9 @@ package me.golemcore.bot.application.update;
 
 import me.golemcore.bot.domain.service.RuntimeVersionSupport;
 
+/**
+ * Package-local compatibility wrapper that keeps the update module using the
+ * shared runtime version helper without changing existing callers.
+ */
 final class UpdateVersionSupport extends RuntimeVersionSupport {
 }

--- a/src/main/java/me/golemcore/bot/application/update/UpdateVersionSupport.java
+++ b/src/main/java/me/golemcore/bot/application/update/UpdateVersionSupport.java
@@ -3,24 +3,4 @@ package me.golemcore.bot.application.update;
 import me.golemcore.bot.domain.service.RuntimeVersionSupport;
 
 final class UpdateVersionSupport extends RuntimeVersionSupport {
-
-    @Override
-    public String extractVersionFromAssetName(String assetName) {
-        return super.extractVersionFromAssetName(assetName);
-    }
-
-    @Override
-    public String normalizeVersion(String version) {
-        return super.normalizeVersion(version);
-    }
-
-    @Override
-    public boolean isRemoteVersionNewer(String candidateVersion, String currentVersion) {
-        return super.isRemoteVersionNewer(candidateVersion, currentVersion);
-    }
-
-    @Override
-    public int compareVersions(String left, String right) {
-        return super.compareVersions(left, right);
-    }
 }

--- a/src/main/java/me/golemcore/bot/application/update/UpdateVersionSupport.java
+++ b/src/main/java/me/golemcore/bot/application/update/UpdateVersionSupport.java
@@ -1,216 +1,26 @@
 package me.golemcore.bot.application.update;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import me.golemcore.bot.domain.service.RuntimeVersionSupport;
 
-final class UpdateVersionSupport {
+final class UpdateVersionSupport extends RuntimeVersionSupport {
 
-    private static final Pattern SEMVER_PATTERN = Pattern
-            .compile("^(\\d++)\\.(\\d++)\\.(\\d++)(?:-([0-9A-Za-z.-]++))?$");
-
-    String extractVersionFromAssetName(String assetName) {
-        if (assetName == null || assetName.isBlank()) {
-            return null;
-        }
-        int length = assetName.length();
-        for (int index = 0; index < length; index++) {
-            char current = assetName.charAt(index);
-            if (!isAsciiDigit(current)) {
-                continue;
-            }
-            if (index > 0 && isAsciiDigit(assetName.charAt(index - 1))) {
-                continue;
-            }
-
-            String candidate = readVersionCandidate(assetName, index);
-            if (candidate != null) {
-                return normalizeVersion(candidate);
-            }
-        }
-        return null;
+    @Override
+    public String extractVersionFromAssetName(String assetName) {
+        return super.extractVersionFromAssetName(assetName);
     }
 
-    String normalizeVersion(String version) {
-        if (version == null || version.isBlank()) {
-            return version;
-        }
-        String normalized = version.trim();
-        if (normalized.startsWith("v") || normalized.startsWith("V")) {
-            normalized = normalized.substring(1);
-        }
-        if (normalized.endsWith(".jar")) {
-            normalized = normalized.substring(0, normalized.length() - ".jar".length());
-        }
-        if (normalized.endsWith("-exec")) {
-            String withoutClassifier = normalized.substring(0, normalized.length() - "-exec".length());
-            Matcher matcher = SEMVER_PATTERN.matcher(withoutClassifier);
-            if (matcher.matches()) {
-                normalized = withoutClassifier;
-            }
-        }
-        return normalized;
+    @Override
+    public String normalizeVersion(String version) {
+        return super.normalizeVersion(version);
     }
 
-    boolean isRemoteVersionNewer(String remoteVersion, String currentVersion) {
-        return compareVersions(remoteVersion, currentVersion) > 0;
+    @Override
+    public boolean isRemoteVersionNewer(String candidateVersion, String currentVersion) {
+        return super.isRemoteVersionNewer(candidateVersion, currentVersion);
     }
 
-    int compareVersions(String left, String right) {
-        Semver leftSemver = parseSemver(left);
-        Semver rightSemver = parseSemver(right);
-
-        if (leftSemver == null || rightSemver == null) {
-            return normalizeVersion(left).compareTo(normalizeVersion(right));
-        }
-        if (leftSemver.major() != rightSemver.major()) {
-            return Integer.compare(leftSemver.major(), rightSemver.major());
-        }
-        if (leftSemver.minor() != rightSemver.minor()) {
-            return Integer.compare(leftSemver.minor(), rightSemver.minor());
-        }
-        if (leftSemver.patch() != rightSemver.patch()) {
-            return Integer.compare(leftSemver.patch(), rightSemver.patch());
-        }
-
-        String leftPrerelease = leftSemver.preRelease();
-        String rightPrerelease = rightSemver.preRelease();
-        if (leftPrerelease == null && rightPrerelease == null) {
-            return 0;
-        }
-        if (leftPrerelease == null) {
-            return 1;
-        }
-        if (rightPrerelease == null) {
-            return -1;
-        }
-        return comparePrerelease(leftPrerelease, rightPrerelease);
-    }
-
-    private String readVersionCandidate(String value, int start) {
-        int length = value.length();
-        int majorEnd = consumeDigits(value, start);
-        if (majorEnd == start || majorEnd >= length || value.charAt(majorEnd) != '.') {
-            return null;
-        }
-
-        int minorStart = majorEnd + 1;
-        int minorEnd = consumeDigits(value, minorStart);
-        if (minorEnd == minorStart || minorEnd >= length || value.charAt(minorEnd) != '.') {
-            return null;
-        }
-
-        int patchStart = minorEnd + 1;
-        int patchEnd = consumeDigits(value, patchStart);
-        if (patchEnd == patchStart) {
-            return null;
-        }
-
-        int versionEnd = patchEnd;
-        if (patchEnd < length && value.charAt(patchEnd) == '-') {
-            int prereleaseStart = patchEnd + 1;
-            if (prereleaseStart < length && isSemverPrereleaseStartChar(value.charAt(prereleaseStart))) {
-                int prereleaseEnd = consumePrereleaseChars(value, prereleaseStart);
-                if (prereleaseEnd > prereleaseStart) {
-                    versionEnd = prereleaseEnd;
-                }
-            }
-        }
-
-        return value.substring(start, versionEnd);
-    }
-
-    private int consumeDigits(String value, int start) {
-        int cursor = start;
-        int length = value.length();
-        while (cursor < length && isAsciiDigit(value.charAt(cursor))) {
-            cursor++;
-        }
-        return cursor;
-    }
-
-    private int consumePrereleaseChars(String value, int start) {
-        int cursor = start;
-        int length = value.length();
-        while (cursor < length && isSemverPrereleaseChar(value.charAt(cursor))) {
-            cursor++;
-        }
-        return cursor;
-    }
-
-    private int comparePrerelease(String left, String right) {
-        String[] leftParts = left.split("\\.");
-        String[] rightParts = right.split("\\.");
-        int max = Math.max(leftParts.length, rightParts.length);
-        for (int index = 0; index < max; index++) {
-            if (index >= leftParts.length) {
-                return -1;
-            }
-            if (index >= rightParts.length) {
-                return 1;
-            }
-
-            String leftPart = leftParts[index];
-            String rightPart = rightParts[index];
-            boolean leftNumeric = leftPart.matches("\\d+");
-            boolean rightNumeric = rightPart.matches("\\d+");
-            if (leftNumeric && rightNumeric) {
-                int comparison = Integer.compare(Integer.parseInt(leftPart), Integer.parseInt(rightPart));
-                if (comparison != 0) {
-                    return comparison;
-                }
-                continue;
-            }
-            if (leftNumeric) {
-                return -1;
-            }
-            if (rightNumeric) {
-                return 1;
-            }
-
-            int comparison = leftPart.compareTo(rightPart);
-            if (comparison != 0) {
-                return comparison;
-            }
-        }
-        return 0;
-    }
-
-    private Semver parseSemver(String version) {
-        if (version == null || version.isBlank()) {
-            return null;
-        }
-        String normalized = normalizeVersion(version);
-        int plusIndex = normalized.indexOf('+');
-        if (plusIndex >= 0) {
-            normalized = normalized.substring(0, plusIndex);
-        }
-        Matcher matcher = SEMVER_PATTERN.matcher(normalized);
-        if (!matcher.matches()) {
-            return null;
-        }
-        return new Semver(
-                Integer.parseInt(matcher.group(1)),
-                Integer.parseInt(matcher.group(2)),
-                Integer.parseInt(matcher.group(3)),
-                matcher.group(4));
-    }
-
-    private boolean isAsciiDigit(char value) {
-        return value >= '0' && value <= '9';
-    }
-
-    private boolean isAsciiLetter(char value) {
-        return (value >= 'a' && value <= 'z') || (value >= 'A' && value <= 'Z');
-    }
-
-    private boolean isSemverPrereleaseChar(char value) {
-        return isAsciiDigit(value) || isAsciiLetter(value) || value == '.' || value == '-';
-    }
-
-    private boolean isSemverPrereleaseStartChar(char value) {
-        return isAsciiDigit(value) || isAsciiLetter(value);
-    }
-
-    private record Semver(int major, int minor, int patch, String preRelease) {
+    @Override
+    public int compareVersions(String left, String right) {
+        return super.compareVersions(left, right);
     }
 }

--- a/src/main/java/me/golemcore/bot/domain/service/RuntimeVersionSupport.java
+++ b/src/main/java/me/golemcore/bot/domain/service/RuntimeVersionSupport.java
@@ -1,0 +1,266 @@
+package me.golemcore.bot.domain.service;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Shared runtime-version helpers used by update, launcher, and cleanup flows.
+ */
+public class RuntimeVersionSupport {
+
+    private static final Pattern SEMVER_PATTERN = Pattern
+            .compile("^(\\d++)\\.(\\d++)\\.(\\d++)(?:-([0-9A-Za-z.-]++))?$");
+
+    /**
+     * Extract the semantic version embedded in a runtime asset name such as
+     * {@code bot-0.4.2.jar} or {@code bot-0.4.2-rc.1-exec.jar}.
+     *
+     * @param assetName
+     *            runtime asset file name
+     * @return normalized version or {@code null} when the file name does not
+     *         contain a supported semantic version
+     */
+    public String extractVersionFromAssetName(String assetName) {
+        if (assetName == null || assetName.isBlank()) {
+            return null;
+        }
+        int length = assetName.length();
+        for (int index = 0; index < length; index++) {
+            char current = assetName.charAt(index);
+            if (!isAsciiDigit(current)) {
+                continue;
+            }
+            if (index > 0 && isAsciiDigit(assetName.charAt(index - 1))) {
+                continue;
+            }
+
+            String candidate = readVersionCandidate(assetName, index);
+            if (candidate != null) {
+                return normalizeVersion(candidate);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Normalize raw runtime version strings for comparison.
+     *
+     * @param version
+     *            raw version string
+     * @return normalized semantic version, or the original blank/null value
+     */
+    public String normalizeVersion(String version) {
+        if (version == null || version.isBlank()) {
+            return version;
+        }
+        String normalized = version.trim();
+        if (normalized.startsWith("v") || normalized.startsWith("V")) {
+            normalized = normalized.substring(1);
+        }
+        if (normalized.endsWith(".jar")) {
+            normalized = normalized.substring(0, normalized.length() - ".jar".length());
+        }
+        if (normalized.endsWith("-exec")) {
+            String withoutClassifier = normalized.substring(0, normalized.length() - "-exec".length());
+            Matcher matcher = SEMVER_PATTERN.matcher(withoutClassifier);
+            if (matcher.matches()) {
+                normalized = withoutClassifier;
+            }
+        }
+        return normalized;
+    }
+
+    /**
+     * Check whether the supplied version string can be treated as semantic version
+     * by the shared comparison rules.
+     *
+     * @param version
+     *            raw or normalized version string
+     * @return {@code true} when the version parses as semantic version
+     */
+    public boolean isSemanticVersion(String version) {
+        return parseSemver(version) != null;
+    }
+
+    /**
+     * Check whether the candidate version is newer than the current version.
+     *
+     * @param candidateVersion
+     *            candidate runtime version
+     * @param currentVersion
+     *            currently active runtime version
+     * @return {@code true} when the candidate is strictly newer
+     */
+    public boolean isRemoteVersionNewer(String candidateVersion, String currentVersion) {
+        return compareVersions(candidateVersion, currentVersion) > 0;
+    }
+
+    /**
+     * Compare two semantic versions.
+     *
+     * @param left
+     *            left-side version
+     * @param right
+     *            right-side version
+     * @return positive when {@code left > right}, negative when
+     *         {@code left < right}, zero when equal
+     */
+    public int compareVersions(String left, String right) {
+        Semver leftSemver = parseSemver(left);
+        Semver rightSemver = parseSemver(right);
+
+        if (leftSemver == null || rightSemver == null) {
+            return normalizeVersion(left).compareTo(normalizeVersion(right));
+        }
+        if (leftSemver.major() != rightSemver.major()) {
+            return Integer.compare(leftSemver.major(), rightSemver.major());
+        }
+        if (leftSemver.minor() != rightSemver.minor()) {
+            return Integer.compare(leftSemver.minor(), rightSemver.minor());
+        }
+        if (leftSemver.patch() != rightSemver.patch()) {
+            return Integer.compare(leftSemver.patch(), rightSemver.patch());
+        }
+
+        String leftPrerelease = leftSemver.preRelease();
+        String rightPrerelease = rightSemver.preRelease();
+        if (leftPrerelease == null && rightPrerelease == null) {
+            return 0;
+        }
+        if (leftPrerelease == null) {
+            return 1;
+        }
+        if (rightPrerelease == null) {
+            return -1;
+        }
+        return comparePrerelease(leftPrerelease, rightPrerelease);
+    }
+
+    private String readVersionCandidate(String value, int start) {
+        int length = value.length();
+        int majorEnd = consumeDigits(value, start);
+        if (majorEnd == start || majorEnd >= length || value.charAt(majorEnd) != '.') {
+            return null;
+        }
+
+        int minorStart = majorEnd + 1;
+        int minorEnd = consumeDigits(value, minorStart);
+        if (minorEnd == minorStart || minorEnd >= length || value.charAt(minorEnd) != '.') {
+            return null;
+        }
+
+        int patchStart = minorEnd + 1;
+        int patchEnd = consumeDigits(value, patchStart);
+        if (patchEnd == patchStart) {
+            return null;
+        }
+
+        int versionEnd = patchEnd;
+        if (patchEnd < length && value.charAt(patchEnd) == '-') {
+            int prereleaseStart = patchEnd + 1;
+            if (prereleaseStart < length && isSemverPrereleaseStartChar(value.charAt(prereleaseStart))) {
+                int prereleaseEnd = consumePrereleaseChars(value, prereleaseStart);
+                if (prereleaseEnd > prereleaseStart) {
+                    versionEnd = prereleaseEnd;
+                }
+            }
+        }
+
+        return value.substring(start, versionEnd);
+    }
+
+    private int consumeDigits(String value, int start) {
+        int cursor = start;
+        int length = value.length();
+        while (cursor < length && isAsciiDigit(value.charAt(cursor))) {
+            cursor++;
+        }
+        return cursor;
+    }
+
+    private int consumePrereleaseChars(String value, int start) {
+        int cursor = start;
+        int length = value.length();
+        while (cursor < length && isSemverPrereleaseChar(value.charAt(cursor))) {
+            cursor++;
+        }
+        return cursor;
+    }
+
+    private int comparePrerelease(String left, String right) {
+        String[] leftParts = left.split("\\.");
+        String[] rightParts = right.split("\\.");
+        int max = Math.max(leftParts.length, rightParts.length);
+        for (int index = 0; index < max; index++) {
+            if (index >= leftParts.length) {
+                return -1;
+            }
+            if (index >= rightParts.length) {
+                return 1;
+            }
+
+            String leftPart = leftParts[index];
+            String rightPart = rightParts[index];
+            boolean leftNumeric = leftPart.matches("\\d+");
+            boolean rightNumeric = rightPart.matches("\\d+");
+            if (leftNumeric && rightNumeric) {
+                int comparison = Integer.compare(Integer.parseInt(leftPart), Integer.parseInt(rightPart));
+                if (comparison != 0) {
+                    return comparison;
+                }
+                continue;
+            }
+            if (leftNumeric) {
+                return -1;
+            }
+            if (rightNumeric) {
+                return 1;
+            }
+
+            int comparison = leftPart.compareTo(rightPart);
+            if (comparison != 0) {
+                return comparison;
+            }
+        }
+        return 0;
+    }
+
+    private Semver parseSemver(String version) {
+        if (version == null || version.isBlank()) {
+            return null;
+        }
+        String normalized = normalizeVersion(version);
+        int plusIndex = normalized.indexOf('+');
+        if (plusIndex >= 0) {
+            normalized = normalized.substring(0, plusIndex);
+        }
+        Matcher matcher = SEMVER_PATTERN.matcher(normalized);
+        if (!matcher.matches()) {
+            return null;
+        }
+        return new Semver(
+                Integer.parseInt(matcher.group(1)),
+                Integer.parseInt(matcher.group(2)),
+                Integer.parseInt(matcher.group(3)),
+                matcher.group(4));
+    }
+
+    private boolean isAsciiDigit(char value) {
+        return value >= '0' && value <= '9';
+    }
+
+    private boolean isAsciiLetter(char value) {
+        return (value >= 'a' && value <= 'z') || (value >= 'A' && value <= 'Z');
+    }
+
+    private boolean isSemverPrereleaseChar(char value) {
+        return isAsciiDigit(value) || isAsciiLetter(value) || value == '.' || value == '-';
+    }
+
+    private boolean isSemverPrereleaseStartChar(char value) {
+        return isAsciiDigit(value) || isAsciiLetter(value);
+    }
+
+    private record Semver(int major, int minor, int patch, String preRelease) {
+    }
+}

--- a/src/main/java/me/golemcore/bot/domain/service/UpdateRuntimeCleanupService.java
+++ b/src/main/java/me/golemcore/bot/domain/service/UpdateRuntimeCleanupService.java
@@ -48,13 +48,13 @@ public class UpdateRuntimeCleanupService {
 
         if (shouldDropStaleMarker(currentAsset, runningVersion)) {
             deleteIfExists(currentMarker);
-            deleteIfExists(jarsDir.resolve(currentAsset));
+            deleteAssetJarIfSafe(jarsDir, currentAsset);
             currentAsset = null;
         }
 
         if (shouldDropStaleMarker(stagedAsset, runningVersion)) {
             deleteIfExists(stagedMarker);
-            deleteIfExists(jarsDir.resolve(stagedAsset));
+            deleteAssetJarIfSafe(jarsDir, stagedAsset);
             stagedAsset = null;
         }
 
@@ -96,6 +96,30 @@ public class UpdateRuntimeCleanupService {
             return false;
         }
         return runtimeVersionSupport.compareVersions(runningVersion, assetVersion) > 0;
+    }
+
+    private void deleteAssetJarIfSafe(Path jarsDir, String assetName) {
+        Path assetPath = resolveAssetPath(jarsDir, assetName);
+        if (assetPath == null) {
+            return;
+        }
+        deleteIfExists(assetPath);
+    }
+
+    private Path resolveAssetPath(Path jarsDir, String assetName) {
+        if (!isValidAssetName(assetName)) {
+            return null;
+        }
+        Path normalizedJarsDir = jarsDir.toAbsolutePath().normalize();
+        Path assetPath = normalizedJarsDir.resolve(assetName).toAbsolutePath().normalize();
+        return assetPath.startsWith(normalizedJarsDir) ? assetPath : null;
+    }
+
+    private boolean isValidAssetName(String assetName) {
+        if (assetName == null || assetName.isBlank()) {
+            return false;
+        }
+        return !assetName.contains("/") && !assetName.contains("\\") && !assetName.contains("..");
     }
 
     private boolean shouldDeleteJar(Path path, Set<String> retainedAssets) {

--- a/src/main/java/me/golemcore/bot/domain/service/UpdateRuntimeCleanupService.java
+++ b/src/main/java/me/golemcore/bot/domain/service/UpdateRuntimeCleanupService.java
@@ -1,12 +1,12 @@
 package me.golemcore.bot.domain.service;
 
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import me.golemcore.bot.port.outbound.UpdateSettingsPort;
 import me.golemcore.bot.port.outbound.WorkspaceFilePort;
 import org.springframework.stereotype.Service;
@@ -22,9 +22,15 @@ public class UpdateRuntimeCleanupService {
 
     private final UpdateSettingsPort settingsPort;
     private final WorkspaceFilePort workspaceFilePort;
+    private final RuntimeVersionSupport runtimeVersionSupport = new RuntimeVersionSupport();
 
     @SuppressWarnings("PMD.NullAssignment")
     public void cleanupAfterSuccessfulStartup() {
+        cleanupAfterSuccessfulStartup(null);
+    }
+
+    @SuppressWarnings("PMD.NullAssignment")
+    public void cleanupAfterSuccessfulStartup(String runningVersion) {
         if (!settingsPort.update().enabled()) {
             return;
         }
@@ -39,6 +45,18 @@ public class UpdateRuntimeCleanupService {
         Path stagedMarker = updatesDir.resolve(STAGED_MARKER_NAME);
         String currentAsset = readMarker(currentMarker);
         String stagedAsset = readMarker(stagedMarker);
+
+        if (shouldDropStaleMarker(currentAsset, runningVersion)) {
+            deleteIfExists(currentMarker);
+            deleteIfExists(jarsDir.resolve(currentAsset));
+            currentAsset = null;
+        }
+
+        if (shouldDropStaleMarker(stagedAsset, runningVersion)) {
+            deleteIfExists(stagedMarker);
+            deleteIfExists(jarsDir.resolve(stagedAsset));
+            stagedAsset = null;
+        }
 
         if (currentAsset != null && currentAsset.equals(stagedAsset)) {
             deleteIfExists(stagedMarker);
@@ -63,6 +81,21 @@ public class UpdateRuntimeCleanupService {
         } catch (IOException e) {
             log.warn("[update] failed to cleanup old runtime jars: {}", e.getMessage());
         }
+    }
+
+    private boolean shouldDropStaleMarker(String assetName, String runningVersion) {
+        if (assetName == null || runningVersion == null || runningVersion.isBlank()) {
+            return false;
+        }
+        String assetVersion = runtimeVersionSupport.extractVersionFromAssetName(assetName);
+        if (assetVersion == null) {
+            return false;
+        }
+        if (!runtimeVersionSupport.isSemanticVersion(runtimeVersionSupport.normalizeVersion(runningVersion))
+                || !runtimeVersionSupport.isSemanticVersion(assetVersion)) {
+            return false;
+        }
+        return runtimeVersionSupport.compareVersions(runningVersion, assetVersion) > 0;
     }
 
     private boolean shouldDeleteJar(Path path, Set<String> retainedAssets) {

--- a/src/main/java/me/golemcore/bot/domain/service/UpdateRuntimeCleanupService.java
+++ b/src/main/java/me/golemcore/bot/domain/service/UpdateRuntimeCleanupService.java
@@ -11,6 +11,17 @@ import me.golemcore.bot.port.outbound.UpdateSettingsPort;
 import me.golemcore.bot.port.outbound.WorkspaceFilePort;
 import org.springframework.stereotype.Service;
 
+/**
+ * Cleans up runtime update artifacts after a successful startup.
+ *
+ * <p>
+ * The service keeps the currently active runtime jar and any still-relevant
+ * staged candidate, while deleting obsolete jars left behind by previous
+ * updates. When the process is already running from a newer bundled image, it
+ * also clears stale persisted markers that would otherwise keep forcing an
+ * older jar on the next restart.
+ * </p>
+ */
 @Service
 @RequiredArgsConstructor
 @Slf4j
@@ -24,11 +35,30 @@ public class UpdateRuntimeCleanupService {
     private final WorkspaceFilePort workspaceFilePort;
     private final RuntimeVersionSupport runtimeVersionSupport = new RuntimeVersionSupport();
 
+    /**
+     * Run startup cleanup without comparing against an explicitly supplied running
+     * version.
+     */
     @SuppressWarnings("PMD.NullAssignment")
     public void cleanupAfterSuccessfulStartup() {
         cleanupAfterSuccessfulStartup(null);
     }
 
+    /**
+     * Remove obsolete runtime jars and clear stale marker files after a successful
+     * startup.
+     *
+     * <p>
+     * When {@code runningVersion} is present and strictly newer than a marker
+     * target, the stale marker and its jar are removed. Equal versions are kept
+     * intentionally so variant A behavior remains intact: a same-version persisted
+     * jar continues to win over the bundled image on future restarts.
+     * </p>
+     *
+     * @param runningVersion
+     *            normalized version of the runtime that actually started, or
+     *            {@code null} when the caller only wants generic cleanup
+     */
     @SuppressWarnings("PMD.NullAssignment")
     public void cleanupAfterSuccessfulStartup(String runningVersion) {
         if (!settingsPort.update().enabled()) {
@@ -83,6 +113,10 @@ public class UpdateRuntimeCleanupService {
         }
     }
 
+    /**
+     * Decide whether a persisted marker points to an older runtime than the one
+     * that has already started successfully.
+     */
     private boolean shouldDropStaleMarker(String assetName, String runningVersion) {
         if (assetName == null || runningVersion == null || runningVersion.isBlank()) {
             return false;
@@ -98,6 +132,10 @@ public class UpdateRuntimeCleanupService {
         return runtimeVersionSupport.compareVersions(runningVersion, assetVersion) > 0;
     }
 
+    /**
+     * Delete a jar only when the marker asset name resolves safely under the
+     * runtime jars directory.
+     */
     private void deleteAssetJarIfSafe(Path jarsDir, String assetName) {
         Path assetPath = resolveAssetPath(jarsDir, assetName);
         if (assetPath == null) {
@@ -106,6 +144,10 @@ public class UpdateRuntimeCleanupService {
         deleteIfExists(assetPath);
     }
 
+    /**
+     * Resolve a marker asset name to an on-disk jar path while preventing path
+     * traversal or nested path tricks from escaping {@code jarsDir}.
+     */
     private Path resolveAssetPath(Path jarsDir, String assetName) {
         if (!isValidAssetName(assetName)) {
             return null;
@@ -115,6 +157,9 @@ public class UpdateRuntimeCleanupService {
         return assetPath.startsWith(normalizedJarsDir) ? assetPath : null;
     }
 
+    /**
+     * Accept only plain file names written by the update artifact store.
+     */
     private boolean isValidAssetName(String assetName) {
         if (assetName == null || assetName.isBlank()) {
             return false;
@@ -132,6 +177,10 @@ public class UpdateRuntimeCleanupService {
         return fileName != null ? fileName.toString() : null;
     }
 
+    /**
+     * Read a marker file best-effort. Invalid or unreadable markers are treated as
+     * absent so startup cleanup stays resilient.
+     */
     private String readMarker(Path markerPath) {
         try {
             if (!workspaceFilePort.exists(markerPath)) {

--- a/src/main/java/me/golemcore/bot/launcher/RuntimeLauncher.java
+++ b/src/main/java/me/golemcore/bot/launcher/RuntimeLauncher.java
@@ -15,6 +15,13 @@ import me.golemcore.bot.domain.service.RuntimeVersionSupport;
 /**
  * Supervises the actual bot runtime so self-update can restart into a staged
  * jar instead of relaunching the immutable container classpath.
+ *
+ * <p>
+ * The launcher decides between the bundled image runtime and a persisted
+ * self-updated jar before Spring starts. This is the critical decision point
+ * that allows a newly pulled container image to take over from an older
+ * persisted runtime when appropriate.
+ * </p>
  */
 public final class RuntimeLauncher {
 
@@ -137,6 +144,15 @@ public final class RuntimeLauncher {
         return new LaunchCommand(List.copyOf(command), "bundled runtime from image classpath");
     }
 
+    /**
+     * Resolve the persisted current runtime jar, if any.
+     *
+     * <p>
+     * The marker is validated defensively before any comparison happens so a
+     * damaged or tampered persisted state cannot redirect startup outside the
+     * updates directory.
+     * </p>
+     */
     Path resolveCurrentJar(String[] args) {
         Path updatesDir = resolveUpdatesDir(args);
         Path markerPath = updatesDir.resolve(CURRENT_MARKER_NAME);
@@ -196,6 +212,15 @@ public final class RuntimeLauncher {
                 .normalize();
     }
 
+    /**
+     * Decide whether the bundled runtime should override the persisted current jar.
+     *
+     * <p>
+     * Variant A is intentionally preserved here: equal versions keep using the
+     * persisted jar, so only a strictly newer bundled image suppresses the current
+     * marker.
+     * </p>
+     */
     private boolean isBundledRuntimeNewer(String assetName) {
         String bundledVersion = runtimeVersionSupport.normalizeVersion(runtimeVersionReader.currentVersion());
         String currentJarVersion = runtimeVersionSupport.extractVersionFromAssetName(assetName);
@@ -354,6 +379,16 @@ public final class RuntimeLauncher {
         }
     }
 
+    /**
+     * Reads the version baked into the bundled image runtime.
+     *
+     * <p>
+     * The context class loader is preferred to satisfy PMD and to work in
+     * environments where the launcher class loader is not the one that sees the
+     * build-info resource. A system-classloader fallback keeps the lookup stable
+     * when no context loader is set.
+     * </p>
+     */
     private static final class ClasspathRuntimeVersionReader implements RuntimeVersionReader {
 
         @Override

--- a/src/main/java/me/golemcore/bot/launcher/RuntimeLauncher.java
+++ b/src/main/java/me/golemcore/bot/launcher/RuntimeLauncher.java
@@ -34,7 +34,7 @@ public final class RuntimeLauncher {
     static final String STORAGE_PATH_PROPERTY = "bot.storage.local.base-path";
     static final String UPDATE_PATH_ENV = "UPDATE_PATH";
     static final String UPDATE_PATH_PROPERTY = "bot.update.updates-path";
-    private static final String BUILD_INFO_RESOURCE = "META-INF/build-info.properties";
+    static final String BUILD_INFO_RESOURCE = "META-INF/build-info.properties";
 
     private final String javaCommand;
     private final ProcessStarter processStarter;
@@ -389,7 +389,7 @@ public final class RuntimeLauncher {
      * when no context loader is set.
      * </p>
      */
-    private static final class ClasspathRuntimeVersionReader implements RuntimeVersionReader {
+    static final class ClasspathRuntimeVersionReader implements RuntimeVersionReader {
 
         @Override
         public String currentVersion() {

--- a/src/main/java/me/golemcore/bot/launcher/RuntimeLauncher.java
+++ b/src/main/java/me/golemcore/bot/launcher/RuntimeLauncher.java
@@ -1,6 +1,7 @@
 package me.golemcore.bot.launcher;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -8,6 +9,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+import java.util.Properties;
+import me.golemcore.bot.domain.service.RuntimeVersionSupport;
 
 /**
  * Supervises the actual bot runtime so self-update can restart into a staged
@@ -24,15 +27,18 @@ public final class RuntimeLauncher {
     static final String STORAGE_PATH_PROPERTY = "bot.storage.local.base-path";
     static final String UPDATE_PATH_ENV = "UPDATE_PATH";
     static final String UPDATE_PATH_PROPERTY = "bot.update.updates-path";
+    private static final String BUILD_INFO_RESOURCE = "META-INF/build-info.properties";
 
     private final String javaCommand;
     private final ProcessStarter processStarter;
     private final EnvironmentReader environmentReader;
     private final LauncherOutput output;
+    private final RuntimeVersionReader runtimeVersionReader;
+    private final RuntimeVersionSupport runtimeVersionSupport;
 
     public RuntimeLauncher() {
         this(resolveJavaCommand(), new DefaultProcessStarter(), new SystemEnvironmentReader(),
-                new ConsoleLauncherOutput());
+                new ConsoleLauncherOutput(), new ClasspathRuntimeVersionReader(), new RuntimeVersionSupport());
     }
 
     RuntimeLauncher(
@@ -40,10 +46,32 @@ public final class RuntimeLauncher {
             ProcessStarter processStarter,
             EnvironmentReader environmentReader,
             LauncherOutput output) {
+        this(javaCommand, processStarter, environmentReader, output, new ClasspathRuntimeVersionReader(),
+                new RuntimeVersionSupport());
+    }
+
+    RuntimeLauncher(
+            String javaCommand,
+            ProcessStarter processStarter,
+            EnvironmentReader environmentReader,
+            LauncherOutput output,
+            RuntimeVersionReader runtimeVersionReader) {
+        this(javaCommand, processStarter, environmentReader, output, runtimeVersionReader, new RuntimeVersionSupport());
+    }
+
+    RuntimeLauncher(
+            String javaCommand,
+            ProcessStarter processStarter,
+            EnvironmentReader environmentReader,
+            LauncherOutput output,
+            RuntimeVersionReader runtimeVersionReader,
+            RuntimeVersionSupport runtimeVersionSupport) {
         this.javaCommand = javaCommand;
         this.processStarter = processStarter;
         this.environmentReader = environmentReader;
         this.output = output;
+        this.runtimeVersionReader = runtimeVersionReader;
+        this.runtimeVersionSupport = runtimeVersionSupport;
     }
 
     public static void main(String[] args) {
@@ -136,6 +164,9 @@ public final class RuntimeLauncher {
                 output.error("Current marker points to a missing jar: " + jarPath);
                 return null;
             }
+            if (isBundledRuntimeNewer(assetName)) {
+                return null;
+            }
             return jarPath;
         } catch (IOException e) {
             output.error("Failed to read current marker: " + safeMessage(e));
@@ -163,6 +194,25 @@ public final class RuntimeLauncher {
         return Path.of(System.getProperty("user.home"), ".golemcore", "workspace", "updates")
                 .toAbsolutePath()
                 .normalize();
+    }
+
+    private boolean isBundledRuntimeNewer(String assetName) {
+        String bundledVersion = runtimeVersionSupport.normalizeVersion(runtimeVersionReader.currentVersion());
+        String currentJarVersion = runtimeVersionSupport.extractVersionFromAssetName(assetName);
+        if (bundledVersion == null || currentJarVersion == null) {
+            return false;
+        }
+        if (!runtimeVersionSupport.isSemanticVersion(bundledVersion)
+                || !runtimeVersionSupport.isSemanticVersion(currentJarVersion)) {
+            return false;
+        }
+
+        boolean bundledIsNewer = runtimeVersionSupport.compareVersions(bundledVersion, currentJarVersion) > 0;
+        if (bundledIsNewer) {
+            output.info("Ignoring current marker because bundled runtime " + bundledVersion
+                    + " is newer than " + currentJarVersion);
+        }
+        return bundledIsNewer;
     }
 
     private static Path normalizePath(String value) {
@@ -246,6 +296,10 @@ public final class RuntimeLauncher {
         void error(String message);
     }
 
+    interface RuntimeVersionReader {
+        String currentVersion();
+    }
+
     private static final class DefaultProcessStarter implements ProcessStarter {
 
         @Override
@@ -296,6 +350,25 @@ public final class RuntimeLauncher {
         @Override
         public void error(String message) {
             System.err.println("[launcher] " + message);
+        }
+    }
+
+    private static final class ClasspathRuntimeVersionReader implements RuntimeVersionReader {
+
+        @Override
+        public String currentVersion() {
+            try (InputStream inputStream = RuntimeLauncher.class.getClassLoader()
+                    .getResourceAsStream(BUILD_INFO_RESOURCE)) {
+                if (inputStream == null) {
+                    return "dev";
+                }
+                Properties properties = new Properties();
+                properties.load(inputStream);
+                String version = properties.getProperty("build.version");
+                return version == null || version.isBlank() ? "dev" : version;
+            } catch (IOException ignored) {
+                return "dev";
+            }
         }
     }
 }

--- a/src/main/java/me/golemcore/bot/launcher/RuntimeLauncher.java
+++ b/src/main/java/me/golemcore/bot/launcher/RuntimeLauncher.java
@@ -207,6 +207,7 @@ public final class RuntimeLauncher {
             return false;
         }
 
+        // Variant A: equal versions keep using the persisted current jar.
         boolean bundledIsNewer = runtimeVersionSupport.compareVersions(bundledVersion, currentJarVersion) > 0;
         if (bundledIsNewer) {
             output.info("Ignoring current marker because bundled runtime " + bundledVersion
@@ -357,8 +358,7 @@ public final class RuntimeLauncher {
 
         @Override
         public String currentVersion() {
-            try (InputStream inputStream = RuntimeLauncher.class.getClassLoader()
-                    .getResourceAsStream(BUILD_INFO_RESOURCE)) {
+            try (InputStream inputStream = readBuildInfo()) {
                 if (inputStream == null) {
                     return "dev";
                 }
@@ -369,6 +369,17 @@ public final class RuntimeLauncher {
             } catch (IOException ignored) {
                 return "dev";
             }
+        }
+
+        private InputStream readBuildInfo() {
+            ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+            if (contextClassLoader != null) {
+                InputStream contextStream = contextClassLoader.getResourceAsStream(BUILD_INFO_RESOURCE);
+                if (contextStream != null) {
+                    return contextStream;
+                }
+            }
+            return ClassLoader.getSystemResourceAsStream(BUILD_INFO_RESOURCE);
         }
     }
 }

--- a/src/test/java/me/golemcore/bot/adapter/inbound/runtime/UpdateRuntimeCleanupLifecycleTest.java
+++ b/src/test/java/me/golemcore/bot/adapter/inbound/runtime/UpdateRuntimeCleanupLifecycleTest.java
@@ -1,0 +1,26 @@
+package me.golemcore.bot.adapter.inbound.runtime;
+
+import me.golemcore.bot.domain.service.UpdateRuntimeCleanupService;
+import me.golemcore.bot.port.outbound.UpdateVersionPort;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class UpdateRuntimeCleanupLifecycleTest {
+
+    @Test
+    void shouldForwardRunningVersionToCleanupService() {
+        UpdateRuntimeCleanupService cleanupService = mock(UpdateRuntimeCleanupService.class);
+        UpdateVersionPort updateVersionPort = mock(UpdateVersionPort.class);
+        when(updateVersionPort.currentVersion()).thenReturn("0.4.2");
+
+        UpdateRuntimeCleanupLifecycle lifecycle = new UpdateRuntimeCleanupLifecycle(cleanupService, updateVersionPort);
+
+        lifecycle.onApplicationReady();
+
+        verify(updateVersionPort).currentVersion();
+        verify(cleanupService).cleanupAfterSuccessfulStartup("0.4.2");
+    }
+}

--- a/src/test/java/me/golemcore/bot/domain/service/RuntimeVersionSupportTest.java
+++ b/src/test/java/me/golemcore/bot/domain/service/RuntimeVersionSupportTest.java
@@ -1,0 +1,71 @@
+package me.golemcore.bot.domain.service;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RuntimeVersionSupportTest {
+
+    private final RuntimeVersionSupport runtimeVersionSupport = new RuntimeVersionSupport();
+
+    @Test
+    void shouldNormalizePrefixedJarAndExecVersions() {
+        assertEquals("1.2.3", runtimeVersionSupport.normalizeVersion("v1.2.3.jar"));
+        assertEquals("2.3.4", runtimeVersionSupport.normalizeVersion("V2.3.4-exec"));
+        assertEquals("1.2.3-rc.1", runtimeVersionSupport.normalizeVersion("v1.2.3-rc.1.jar"));
+    }
+
+    @Test
+    void shouldExtractSemanticVersionFromAssetNames() {
+        assertEquals("1.2.3", runtimeVersionSupport.extractVersionFromAssetName("bot-1.2.3.jar"));
+        assertEquals("1.2.3-rc.1", runtimeVersionSupport.extractVersionFromAssetName("release-v1.2.3-rc.1.jar"));
+        assertEquals("2.3.4-beta-2", runtimeVersionSupport.extractVersionFromAssetName("release-V2.3.4-beta-2.jar"));
+        assertEquals("1.2.3", runtimeVersionSupport.extractVersionFromAssetName("bot-1.2.3-exec.jar"));
+    }
+
+    @Test
+    void shouldReturnNullWhenAssetNameDoesNotContainSemanticVersion() {
+        assertNull(runtimeVersionSupport.extractVersionFromAssetName("bot-latest.jar"));
+        assertNull(runtimeVersionSupport.extractVersionFromAssetName("bot-1.2.jar"));
+        assertNull(runtimeVersionSupport.extractVersionFromAssetName(""));
+        assertNull(runtimeVersionSupport.extractVersionFromAssetName(null));
+    }
+
+    @Test
+    void shouldRecognizeSemanticVersionsAndIgnoreInvalidOnes() {
+        assertTrue(runtimeVersionSupport.isSemanticVersion("1.2.3"));
+        assertTrue(runtimeVersionSupport.isSemanticVersion("1.2.3-rc.1"));
+        assertTrue(runtimeVersionSupport.isSemanticVersion("v1.2.3+build.1"));
+        assertFalse(runtimeVersionSupport.isSemanticVersion("dev"));
+        assertFalse(runtimeVersionSupport.isSemanticVersion("1.2"));
+        assertFalse(runtimeVersionSupport.isSemanticVersion("release-10"));
+    }
+
+    @Test
+    void shouldCompareSemanticVersionsAcrossMainSegmentsAndPrerelease() {
+        assertTrue(runtimeVersionSupport.compareVersions("1.2.4", "1.2.3") > 0);
+        assertTrue(runtimeVersionSupport.compareVersions("1.3.0", "1.2.9") > 0);
+        assertTrue(runtimeVersionSupport.compareVersions("2.0.0", "1.9.9") > 0);
+        assertTrue(runtimeVersionSupport.compareVersions("1.2.3", "1.2.3-rc.1") > 0);
+        assertTrue(runtimeVersionSupport.compareVersions("1.2.3-rc.2", "1.2.3-rc.1") > 0);
+        assertTrue(runtimeVersionSupport.compareVersions("1.2.3-alpha", "1.2.3-1") > 0);
+        assertTrue(runtimeVersionSupport.compareVersions("1.2.3-rc.1.1", "1.2.3-rc.1") > 0);
+        assertEquals(0, runtimeVersionSupport.compareVersions("v1.2.3+build.1", "1.2.3"));
+    }
+
+    @Test
+    void shouldFallbackToNormalizedLexicographicComparisonForNonSemanticVersions() {
+        assertTrue(runtimeVersionSupport.compareVersions("release-2", "release-10") > 0);
+        assertTrue(runtimeVersionSupport.compareVersions("branch-z", "branch-a") > 0);
+    }
+
+    @Test
+    void shouldReportWhenRemoteVersionIsNewer() {
+        assertTrue(runtimeVersionSupport.isRemoteVersionNewer("1.2.4", "1.2.3"));
+        assertFalse(runtimeVersionSupport.isRemoteVersionNewer("1.2.3", "1.2.3"));
+        assertFalse(runtimeVersionSupport.isRemoteVersionNewer("1.2.3-rc.1", "1.2.3"));
+    }
+}

--- a/src/test/java/me/golemcore/bot/domain/service/UpdateRuntimeCleanupServiceTest.java
+++ b/src/test/java/me/golemcore/bot/domain/service/UpdateRuntimeCleanupServiceTest.java
@@ -38,6 +38,70 @@ class UpdateRuntimeCleanupServiceTest {
     }
 
     @Test
+    void shouldDeleteStaleCurrentMarkerAndJarWhenRunningImageIsNewer(@TempDir Path tempDir) throws Exception {
+        BotProperties botProperties = new BotProperties();
+        botProperties.getUpdate().setEnabled(true);
+        botProperties.getUpdate().setUpdatesPath(tempDir.toString());
+
+        Path jarsDir = tempDir.resolve("jars");
+        Files.createDirectories(jarsDir);
+        Files.writeString(jarsDir.resolve("bot-0.4.1.jar"), "old-current", StandardCharsets.UTF_8);
+        Files.writeString(jarsDir.resolve("bot-0.4.3.jar"), "staged", StandardCharsets.UTF_8);
+        Files.writeString(tempDir.resolve("current.txt"), "bot-0.4.1.jar\n", StandardCharsets.UTF_8);
+        Files.writeString(tempDir.resolve("staged.txt"), "bot-0.4.3.jar\n", StandardCharsets.UTF_8);
+
+        UpdateRuntimeCleanupService service = new UpdateRuntimeCleanupService(
+                me.golemcore.bot.support.TestPorts.settings(botProperties),
+                new LocalTestWorkspaceFilePort());
+        service.cleanupAfterSuccessfulStartup("0.4.2");
+
+        assertFalse(Files.exists(tempDir.resolve("current.txt")));
+        assertFalse(Files.exists(jarsDir.resolve("bot-0.4.1.jar")));
+        assertTrue(Files.exists(tempDir.resolve("staged.txt")));
+        assertTrue(Files.exists(jarsDir.resolve("bot-0.4.3.jar")));
+    }
+
+    @Test
+    void shouldDeleteStaleStagedMarkerWhenRunningImageIsNewer(@TempDir Path tempDir) throws Exception {
+        BotProperties botProperties = new BotProperties();
+        botProperties.getUpdate().setEnabled(true);
+        botProperties.getUpdate().setUpdatesPath(tempDir.toString());
+
+        Path jarsDir = tempDir.resolve("jars");
+        Files.createDirectories(jarsDir);
+        Files.writeString(jarsDir.resolve("bot-0.4.1.jar"), "stale-staged", StandardCharsets.UTF_8);
+        Files.writeString(tempDir.resolve("staged.txt"), "bot-0.4.1.jar\n", StandardCharsets.UTF_8);
+
+        UpdateRuntimeCleanupService service = new UpdateRuntimeCleanupService(
+                me.golemcore.bot.support.TestPorts.settings(botProperties),
+                new LocalTestWorkspaceFilePort());
+        service.cleanupAfterSuccessfulStartup("0.4.2");
+
+        assertFalse(Files.exists(tempDir.resolve("staged.txt")));
+        assertFalse(Files.exists(jarsDir.resolve("bot-0.4.1.jar")));
+    }
+
+    @Test
+    void shouldKeepCurrentMarkerWhenVersionsAreEqual(@TempDir Path tempDir) throws Exception {
+        BotProperties botProperties = new BotProperties();
+        botProperties.getUpdate().setEnabled(true);
+        botProperties.getUpdate().setUpdatesPath(tempDir.toString());
+
+        Path jarsDir = tempDir.resolve("jars");
+        Files.createDirectories(jarsDir);
+        Files.writeString(jarsDir.resolve("bot-0.4.2.jar"), "current", StandardCharsets.UTF_8);
+        Files.writeString(tempDir.resolve("current.txt"), "bot-0.4.2.jar\n", StandardCharsets.UTF_8);
+
+        UpdateRuntimeCleanupService service = new UpdateRuntimeCleanupService(
+                me.golemcore.bot.support.TestPorts.settings(botProperties),
+                new LocalTestWorkspaceFilePort());
+        service.cleanupAfterSuccessfulStartup("0.4.2");
+
+        assertTrue(Files.exists(tempDir.resolve("current.txt")));
+        assertTrue(Files.exists(jarsDir.resolve("bot-0.4.2.jar")));
+    }
+
+    @Test
     void shouldDeleteRedundantStagedMarkerWhenItMatchesCurrent(@TempDir Path tempDir) throws Exception {
         BotProperties botProperties = new BotProperties();
         botProperties.getUpdate().setEnabled(true);

--- a/src/test/java/me/golemcore/bot/domain/service/UpdateRuntimeCleanupServiceTest.java
+++ b/src/test/java/me/golemcore/bot/domain/service/UpdateRuntimeCleanupServiceTest.java
@@ -38,6 +38,46 @@ class UpdateRuntimeCleanupServiceTest {
     }
 
     @Test
+    void shouldIgnoreCurrentMarkerOutsideJarsDirWhenCleaningUp(@TempDir Path tempDir) throws Exception {
+        BotProperties botProperties = new BotProperties();
+        botProperties.getUpdate().setEnabled(true);
+        botProperties.getUpdate().setUpdatesPath(tempDir.toString());
+
+        Path jarsDir = tempDir.resolve("jars");
+        Files.createDirectories(jarsDir);
+        Files.writeString(tempDir.resolve("bot-0.4.1.jar"), "outside", StandardCharsets.UTF_8);
+        Files.writeString(tempDir.resolve("current.txt"), "../bot-0.4.1.jar\n", StandardCharsets.UTF_8);
+
+        UpdateRuntimeCleanupService service = new UpdateRuntimeCleanupService(
+                me.golemcore.bot.support.TestPorts.settings(botProperties),
+                new LocalTestWorkspaceFilePort());
+        service.cleanupAfterSuccessfulStartup("0.4.3");
+
+        assertFalse(Files.exists(tempDir.resolve("current.txt")));
+        assertTrue(Files.exists(tempDir.resolve("bot-0.4.1.jar")));
+    }
+
+    @Test
+    void shouldIgnoreStagedMarkerOutsideJarsDirWhenCleaningUp(@TempDir Path tempDir) throws Exception {
+        BotProperties botProperties = new BotProperties();
+        botProperties.getUpdate().setEnabled(true);
+        botProperties.getUpdate().setUpdatesPath(tempDir.toString());
+
+        Path jarsDir = tempDir.resolve("jars");
+        Files.createDirectories(jarsDir);
+        Files.writeString(tempDir.resolve("bot-0.4.1.jar"), "outside", StandardCharsets.UTF_8);
+        Files.writeString(tempDir.resolve("staged.txt"), "../bot-0.4.1.jar\n", StandardCharsets.UTF_8);
+
+        UpdateRuntimeCleanupService service = new UpdateRuntimeCleanupService(
+                me.golemcore.bot.support.TestPorts.settings(botProperties),
+                new LocalTestWorkspaceFilePort());
+        service.cleanupAfterSuccessfulStartup("0.4.3");
+
+        assertFalse(Files.exists(tempDir.resolve("staged.txt")));
+        assertTrue(Files.exists(tempDir.resolve("bot-0.4.1.jar")));
+    }
+
+    @Test
     void shouldDeleteStaleCurrentMarkerAndJarWhenRunningImageIsNewer(@TempDir Path tempDir) throws Exception {
         BotProperties botProperties = new BotProperties();
         botProperties.getUpdate().setEnabled(true);

--- a/src/test/java/me/golemcore/bot/domain/service/UpdateServiceTest.java
+++ b/src/test/java/me/golemcore/bot/domain/service/UpdateServiceTest.java
@@ -869,16 +869,29 @@ class UpdateServiceTest {
 
     @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
     private static Method getDeclaredMethod(String methodName, Class<?>... parameterTypes) {
-        try {
-            Class<?> owner = "compareVersions".equals(methodName)
-                    ? UpdateVersionSupport.class
-                    : UpdateService.class;
-            Method method = owner.getDeclaredMethod(methodName, parameterTypes);
-            method.setAccessible(true);
-            return method;
-        } catch (NoSuchMethodException exception) {
-            throw new IllegalStateException("Method not found: " + methodName, exception);
+        Class<?> owner = "compareVersions".equals(methodName)
+                ? UpdateVersionSupport.class
+                : UpdateService.class;
+        Method method = findDeclaredMethod(owner, methodName, parameterTypes);
+        if (method == null) {
+            throw new IllegalStateException("Method not found: " + methodName);
         }
+        method.setAccessible(true);
+        return method;
+    }
+
+    private static Method findDeclaredMethod(Class<?> owner, String methodName, Class<?>... parameterTypes) {
+        Class<?> current = owner;
+        while (current != null) {
+            try {
+                // compareVersions now lives in shared RuntimeVersionSupport, so the
+                // compatibility wrapper test must walk inherited declarations too.
+                return current.getDeclaredMethod(methodName, parameterTypes);
+            } catch (NoSuchMethodException ignored) {
+                current = current.getSuperclass();
+            }
+        }
+        return null;
     }
 
     private static Object invokeReflective(Method method, Object target, Object... arguments) {

--- a/src/test/java/me/golemcore/bot/launcher/RuntimeLauncherTest.java
+++ b/src/test/java/me/golemcore/bot/launcher/RuntimeLauncherTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -92,6 +93,152 @@ class RuntimeLauncherTest {
                 "-jar",
                 jarPath.toAbsolutePath().normalize().toString(),
                 "--spring.profiles.active=prod"), processStarter.commands().getFirst());
+    }
+
+    @Test
+    void shouldLaunchBundledRuntimeWhenCurrentMarkerIsBlank(@TempDir Path tempDir) throws Exception {
+        Files.writeString(tempDir.resolve("current.txt"), "   \n", StandardCharsets.UTF_8);
+
+        RecordingProcessStarter processStarter = new RecordingProcessStarter(List.of(0));
+        RuntimeLauncher launcher = createLauncher(tempDir, processStarter);
+
+        int exitCode = launcher.run(new String[0]);
+
+        assertEquals(0, exitCode);
+        assertEquals(List.of(
+                "java",
+                "-cp",
+                "@/app/jib-classpath-file",
+                "me.golemcore.bot.BotApplication"), processStarter.commands().getFirst());
+    }
+
+    @Test
+    void shouldFallbackToBundledRuntimeWhenCurrentMarkerUsesBackslashes(@TempDir Path tempDir) throws Exception {
+        Files.writeString(tempDir.resolve("current.txt"), "subdir\\bot-0.4.2.jar\n", StandardCharsets.UTF_8);
+
+        RecordingProcessStarter processStarter = new RecordingProcessStarter(List.of(0));
+        CapturingLauncherOutput output = new CapturingLauncherOutput();
+        RuntimeLauncher launcher = createLauncher(Map.of("UPDATE_PATH", tempDir.toString()), processStarter, output);
+
+        int exitCode = launcher.run(new String[0]);
+
+        assertEquals(0, exitCode);
+        assertTrue(
+                output.errorMessages().contains("Ignoring invalid current marker asset name: subdir\\bot-0.4.2.jar"));
+    }
+
+    @Test
+    void shouldKeepCurrentJarWhenBundledVersionIsNotSemantic(@TempDir Path tempDir) throws Exception {
+        Path jarsDir = tempDir.resolve("jars");
+        Files.createDirectories(jarsDir);
+        Path jarPath = jarsDir.resolve("bot-0.4.2.jar");
+        Files.writeString(jarPath, "payload", StandardCharsets.UTF_8);
+        Files.writeString(tempDir.resolve("current.txt"), "bot-0.4.2.jar\n", StandardCharsets.UTF_8);
+
+        RecordingProcessStarter processStarter = new RecordingProcessStarter(List.of(0));
+        RuntimeLauncher launcher = createLauncher(tempDir, processStarter, "dev");
+
+        int exitCode = launcher.run(new String[0]);
+
+        assertEquals(0, exitCode);
+        assertEquals(List.of(
+                "java",
+                "-jar",
+                jarPath.toAbsolutePath().normalize().toString()), processStarter.commands().getFirst());
+    }
+
+    @Test
+    void shouldKeepCurrentJarWhenCurrentMarkerVersionIsNotSemantic(@TempDir Path tempDir) throws Exception {
+        Path jarsDir = tempDir.resolve("jars");
+        Files.createDirectories(jarsDir);
+        Path jarPath = jarsDir.resolve("bot-latest.jar");
+        Files.writeString(jarPath, "payload", StandardCharsets.UTF_8);
+        Files.writeString(tempDir.resolve("current.txt"), "bot-latest.jar\n", StandardCharsets.UTF_8);
+
+        RecordingProcessStarter processStarter = new RecordingProcessStarter(List.of(0));
+        RuntimeLauncher launcher = createLauncher(tempDir, processStarter, "0.4.2");
+
+        int exitCode = launcher.run(new String[0]);
+
+        assertEquals(0, exitCode);
+        assertEquals(List.of(
+                "java",
+                "-jar",
+                jarPath.toAbsolutePath().normalize().toString()), processStarter.commands().getFirst());
+    }
+
+    @Test
+    void shouldPreferSystemPropertyUpdatePathWhenArgumentIsMissing(@TempDir Path tempDir) {
+        String previousValue = System.getProperty(RuntimeLauncher.UPDATE_PATH_PROPERTY);
+        Path systemUpdatesDir = tempDir.resolve("system-updates");
+        System.setProperty(RuntimeLauncher.UPDATE_PATH_PROPERTY, systemUpdatesDir.toString());
+        try {
+            RuntimeLauncher launcher = createLauncher(
+                    Map.of("UPDATE_PATH", tempDir.resolve("env-updates").toString()),
+                    new RecordingProcessStarter(List.of(0)),
+                    new NoOpLauncherOutput());
+
+            Path updatesDir = launcher.resolveUpdatesDir(new String[0]);
+
+            assertEquals(systemUpdatesDir.toAbsolutePath().normalize(), updatesDir);
+        } finally {
+            restoreSystemProperty(RuntimeLauncher.UPDATE_PATH_PROPERTY, previousValue);
+        }
+    }
+
+    @Test
+    void shouldPreferSystemPropertyStoragePathWhenUpdatePathIsMissing(@TempDir Path tempDir) {
+        String previousValue = System.getProperty(RuntimeLauncher.STORAGE_PATH_PROPERTY);
+        Path storagePath = tempDir.resolve("system-workspace");
+        System.setProperty(RuntimeLauncher.STORAGE_PATH_PROPERTY, storagePath.toString());
+        try {
+            RuntimeLauncher launcher = createLauncher(
+                    Map.of(),
+                    new RecordingProcessStarter(List.of(0)),
+                    new NoOpLauncherOutput());
+
+            Path updatesDir = launcher.resolveUpdatesDir(new String[0]);
+
+            assertEquals(storagePath.resolve("updates").toAbsolutePath().normalize(), updatesDir);
+        } finally {
+            restoreSystemProperty(RuntimeLauncher.STORAGE_PATH_PROPERTY, previousValue);
+        }
+    }
+
+    @Test
+    void shouldExpandTildeInUpdatePathArgument(@TempDir Path tempDir) {
+        String previousHome = System.getProperty("user.home");
+        System.setProperty("user.home", tempDir.toString());
+        try {
+            RuntimeLauncher launcher = createLauncher(
+                    Map.of(),
+                    new RecordingProcessStarter(List.of(0)),
+                    new NoOpLauncherOutput());
+
+            Path updatesDir = launcher.resolveUpdatesDir(new String[] { "--bot.update.updates-path=~/custom-updates" });
+
+            assertEquals(tempDir.resolve("custom-updates").toAbsolutePath().normalize(), updatesDir);
+        } finally {
+            restoreSystemProperty("user.home", previousHome);
+        }
+    }
+
+    @Test
+    void shouldExpandUserHomePlaceholderInStoragePathEnvironment(@TempDir Path tempDir) {
+        String previousHome = System.getProperty("user.home");
+        System.setProperty("user.home", tempDir.toString());
+        try {
+            RuntimeLauncher launcher = createLauncher(
+                    Map.of("STORAGE_PATH", "${user.home}/workspace-root"),
+                    new RecordingProcessStarter(List.of(0)),
+                    new NoOpLauncherOutput());
+
+            Path updatesDir = launcher.resolveUpdatesDir(new String[0]);
+
+            assertEquals(tempDir.resolve("workspace-root").resolve("updates").toAbsolutePath().normalize(), updatesDir);
+        } finally {
+            restoreSystemProperty("user.home", previousHome);
+        }
     }
 
     @Test
@@ -221,6 +368,63 @@ class RuntimeLauncherTest {
         }
     }
 
+    @Test
+    void shouldReadRuntimeVersionFromContextClassLoaderWhenResourceExists() {
+        RuntimeLauncher.RuntimeVersionReader reader = reflectiveClasspathRuntimeVersionReader();
+        ClassLoader previousClassLoader = Thread.currentThread().getContextClassLoader();
+        Thread.currentThread().setContextClassLoader(new SingleResourceClassLoader("build.version=1.2.3\n"));
+        try {
+            assertEquals("1.2.3", reader.currentVersion());
+        } finally {
+            Thread.currentThread().setContextClassLoader(previousClassLoader);
+        }
+    }
+
+    @Test
+    void shouldReturnBundledBuildVersionWhenContextClassLoaderDoesNotProvideBuildInfo() {
+        RuntimeLauncher.RuntimeVersionReader reader = reflectiveClasspathRuntimeVersionReader();
+        ClassLoader previousClassLoader = Thread.currentThread().getContextClassLoader();
+        Thread.currentThread().setContextClassLoader(new EmptyResourceClassLoader());
+        try {
+            assertEquals("0.0.0-fix_update_image_runtime_precedence", reader.currentVersion());
+        } finally {
+            Thread.currentThread().setContextClassLoader(previousClassLoader);
+        }
+    }
+
+    @Test
+    void shouldReturnDevWhenBuildInfoContainsBlankVersion() {
+        RuntimeLauncher.RuntimeVersionReader reader = reflectiveClasspathRuntimeVersionReader();
+        ClassLoader previousClassLoader = Thread.currentThread().getContextClassLoader();
+        Thread.currentThread().setContextClassLoader(new SingleResourceClassLoader("build.version=   \n"));
+        try {
+            assertEquals("dev", reader.currentVersion());
+        } finally {
+            Thread.currentThread().setContextClassLoader(previousClassLoader);
+        }
+    }
+
+    private static RuntimeLauncher.RuntimeVersionReader reflectiveClasspathRuntimeVersionReader() {
+        try {
+            Class<?> type = Class.forName("me.golemcore.bot.launcher.RuntimeLauncher$ClasspathRuntimeVersionReader");
+            java.lang.reflect.Constructor<?> constructor = type.getDeclaredConstructor();
+            constructor.setAccessible(true);
+            return (RuntimeLauncher.RuntimeVersionReader) constructor.newInstance();
+        } catch (ReflectiveOperationException exception) {
+            throw new IllegalStateException("Failed to construct ClasspathRuntimeVersionReader", exception);
+        }
+    }
+
+    private static String buildInfoResourceName() {
+        try {
+            java.lang.reflect.Field field = RuntimeLauncher.class.getDeclaredField("BUILD_INFO_RESOURCE");
+            field.setAccessible(true);
+            return (String) field.get(null);
+        } catch (ReflectiveOperationException exception) {
+            throw new IllegalStateException("Failed to read build info resource name", exception);
+        }
+    }
+
     private RuntimeLauncher createLauncher(Path updatesDir, RecordingProcessStarter processStarter) {
         return createLauncher(updatesDir, processStarter, "0.4.2");
     }
@@ -252,6 +456,14 @@ class RuntimeLauncherTest {
                 new MapEnvironmentReader(environment),
                 output,
                 new FixedRuntimeVersionReader(runtimeVersion));
+    }
+
+    private static void restoreSystemProperty(String key, String value) {
+        if (value == null) {
+            System.clearProperty(key);
+            return;
+        }
+        System.setProperty(key, value);
     }
 
     private static class RecordingProcessStarter implements RuntimeLauncher.ProcessStarter {
@@ -422,6 +634,36 @@ class RuntimeLauncherTest {
 
         private List<String> errorMessages() {
             return capturedErrorMessages;
+        }
+    }
+
+    private static final class SingleResourceClassLoader extends ClassLoader {
+
+        private final byte[] content;
+
+        private SingleResourceClassLoader(String content) {
+            super(null);
+            this.content = content.getBytes(StandardCharsets.UTF_8);
+        }
+
+        @Override
+        public InputStream getResourceAsStream(String name) {
+            if (buildInfoResourceName().equals(name)) {
+                return new java.io.ByteArrayInputStream(content);
+            }
+            return null;
+        }
+    }
+
+    private static final class EmptyResourceClassLoader extends ClassLoader {
+
+        private EmptyResourceClassLoader() {
+            super(null);
+        }
+
+        @Override
+        public InputStream getResourceAsStream(String name) {
+            return null;
         }
     }
 }

--- a/src/test/java/me/golemcore/bot/launcher/RuntimeLauncherTest.java
+++ b/src/test/java/me/golemcore/bot/launcher/RuntimeLauncherTest.java
@@ -32,7 +32,28 @@ class RuntimeLauncherTest {
     }
 
     @Test
-    void shouldLaunchUpdatedJarWhenCurrentMarkerPointsToExistingJar(@TempDir Path tempDir) throws Exception {
+    void shouldLaunchBundledRuntimeWhenImageVersionIsNewerThanCurrentMarker(@TempDir Path tempDir) throws Exception {
+        Path jarsDir = tempDir.resolve("jars");
+        Files.createDirectories(jarsDir);
+        Path jarPath = jarsDir.resolve("bot-0.4.1.jar");
+        Files.writeString(jarPath, "payload", StandardCharsets.UTF_8);
+        Files.writeString(tempDir.resolve("current.txt"), "bot-0.4.1.jar\n", StandardCharsets.UTF_8);
+
+        RecordingProcessStarter processStarter = new RecordingProcessStarter(List.of(0));
+        RuntimeLauncher launcher = createLauncher(tempDir, processStarter, "0.4.2");
+
+        int exitCode = launcher.run(new String[0]);
+
+        assertEquals(0, exitCode);
+        assertEquals(List.of(
+                "java",
+                "-cp",
+                "@/app/jib-classpath-file",
+                "me.golemcore.bot.BotApplication"), processStarter.commands().getFirst());
+    }
+
+    @Test
+    void shouldLaunchUpdatedJarWhenVersionsAreEqual(@TempDir Path tempDir) throws Exception {
         Path jarsDir = tempDir.resolve("jars");
         Files.createDirectories(jarsDir);
         Path jarPath = jarsDir.resolve("bot-0.4.2.jar");
@@ -40,7 +61,28 @@ class RuntimeLauncherTest {
         Files.writeString(tempDir.resolve("current.txt"), "bot-0.4.2.jar\n", StandardCharsets.UTF_8);
 
         RecordingProcessStarter processStarter = new RecordingProcessStarter(List.of(0));
-        RuntimeLauncher launcher = createLauncher(tempDir, processStarter);
+        RuntimeLauncher launcher = createLauncher(tempDir, processStarter, "0.4.2");
+
+        int exitCode = launcher.run(new String[] { "--spring.profiles.active=prod" });
+
+        assertEquals(0, exitCode);
+        assertEquals(List.of(
+                "java",
+                "-jar",
+                jarPath.toAbsolutePath().normalize().toString(),
+                "--spring.profiles.active=prod"), processStarter.commands().getFirst());
+    }
+
+    @Test
+    void shouldLaunchUpdatedJarWhenCurrentMarkerVersionIsNewerThanImageVersion(@TempDir Path tempDir) throws Exception {
+        Path jarsDir = tempDir.resolve("jars");
+        Files.createDirectories(jarsDir);
+        Path jarPath = jarsDir.resolve("bot-0.4.3.jar");
+        Files.writeString(jarPath, "payload", StandardCharsets.UTF_8);
+        Files.writeString(tempDir.resolve("current.txt"), "bot-0.4.3.jar\n", StandardCharsets.UTF_8);
+
+        RecordingProcessStarter processStarter = new RecordingProcessStarter(List.of(0));
+        RuntimeLauncher launcher = createLauncher(tempDir, processStarter, "0.4.2");
 
         int exitCode = launcher.run(new String[] { "--spring.profiles.active=prod" });
 
@@ -180,18 +222,36 @@ class RuntimeLauncherTest {
     }
 
     private RuntimeLauncher createLauncher(Path updatesDir, RecordingProcessStarter processStarter) {
-        return createLauncher(Map.of("UPDATE_PATH", updatesDir.toString()), processStarter, new NoOpLauncherOutput());
+        return createLauncher(updatesDir, processStarter, "0.4.2");
+    }
+
+    private RuntimeLauncher createLauncher(Path updatesDir, RecordingProcessStarter processStarter,
+            String runtimeVersion) {
+        return createLauncher(
+                Map.of("UPDATE_PATH", updatesDir.toString()),
+                processStarter,
+                new NoOpLauncherOutput(),
+                runtimeVersion);
     }
 
     private RuntimeLauncher createLauncher(
             Map<String, String> environment,
             RuntimeLauncher.ProcessStarter processStarter,
             RuntimeLauncher.LauncherOutput output) {
+        return createLauncher(environment, processStarter, output, "0.4.2");
+    }
+
+    private RuntimeLauncher createLauncher(
+            Map<String, String> environment,
+            RuntimeLauncher.ProcessStarter processStarter,
+            RuntimeLauncher.LauncherOutput output,
+            String runtimeVersion) {
         return new RuntimeLauncher(
                 "java",
                 processStarter,
                 new MapEnvironmentReader(environment),
-                output);
+                output,
+                new FixedRuntimeVersionReader(runtimeVersion));
     }
 
     private static class RecordingProcessStarter implements RuntimeLauncher.ProcessStarter {
@@ -316,6 +376,20 @@ class RuntimeLauncherTest {
         @Override
         public String get(String name) {
             return values.get(name);
+        }
+    }
+
+    private static final class FixedRuntimeVersionReader implements RuntimeLauncher.RuntimeVersionReader {
+
+        private final String version;
+
+        private FixedRuntimeVersionReader(String version) {
+            this.version = version;
+        }
+
+        @Override
+        public String currentVersion() {
+            return version;
         }
     }
 

--- a/src/test/java/me/golemcore/bot/launcher/RuntimeLauncherTest.java
+++ b/src/test/java/me/golemcore/bot/launcher/RuntimeLauncherTest.java
@@ -11,6 +11,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -370,7 +371,7 @@ class RuntimeLauncherTest {
 
     @Test
     void shouldReadRuntimeVersionFromContextClassLoaderWhenResourceExists() {
-        RuntimeLauncher.RuntimeVersionReader reader = reflectiveClasspathRuntimeVersionReader();
+        RuntimeLauncher.RuntimeVersionReader reader = new RuntimeLauncher.ClasspathRuntimeVersionReader();
         ClassLoader previousClassLoader = Thread.currentThread().getContextClassLoader();
         Thread.currentThread().setContextClassLoader(new SingleResourceClassLoader("build.version=1.2.3\n"));
         try {
@@ -382,11 +383,11 @@ class RuntimeLauncherTest {
 
     @Test
     void shouldReturnBundledBuildVersionWhenContextClassLoaderDoesNotProvideBuildInfo() {
-        RuntimeLauncher.RuntimeVersionReader reader = reflectiveClasspathRuntimeVersionReader();
+        RuntimeLauncher.RuntimeVersionReader reader = new RuntimeLauncher.ClasspathRuntimeVersionReader();
         ClassLoader previousClassLoader = Thread.currentThread().getContextClassLoader();
         Thread.currentThread().setContextClassLoader(new EmptyResourceClassLoader());
         try {
-            assertEquals("0.0.0-fix_update_image_runtime_precedence", reader.currentVersion());
+            assertEquals(expectedSystemBuildVersion(), reader.currentVersion());
         } finally {
             Thread.currentThread().setContextClassLoader(previousClassLoader);
         }
@@ -394,7 +395,7 @@ class RuntimeLauncherTest {
 
     @Test
     void shouldReturnDevWhenBuildInfoContainsBlankVersion() {
-        RuntimeLauncher.RuntimeVersionReader reader = reflectiveClasspathRuntimeVersionReader();
+        RuntimeLauncher.RuntimeVersionReader reader = new RuntimeLauncher.ClasspathRuntimeVersionReader();
         ClassLoader previousClassLoader = Thread.currentThread().getContextClassLoader();
         Thread.currentThread().setContextClassLoader(new SingleResourceClassLoader("build.version=   \n"));
         try {
@@ -404,25 +405,22 @@ class RuntimeLauncherTest {
         }
     }
 
-    private static RuntimeLauncher.RuntimeVersionReader reflectiveClasspathRuntimeVersionReader() {
-        try {
-            Class<?> type = Class.forName("me.golemcore.bot.launcher.RuntimeLauncher$ClasspathRuntimeVersionReader");
-            java.lang.reflect.Constructor<?> constructor = type.getDeclaredConstructor();
-            constructor.setAccessible(true);
-            return (RuntimeLauncher.RuntimeVersionReader) constructor.newInstance();
-        } catch (ReflectiveOperationException exception) {
-            throw new IllegalStateException("Failed to construct ClasspathRuntimeVersionReader", exception);
+    private static String expectedSystemBuildVersion() {
+        try (InputStream inputStream = ClassLoader.getSystemResourceAsStream(RuntimeLauncher.BUILD_INFO_RESOURCE)) {
+            if (inputStream == null) {
+                return "dev";
+            }
+            Properties properties = new Properties();
+            properties.load(inputStream);
+            String version = properties.getProperty("build.version");
+            return version == null || version.isBlank() ? "dev" : version;
+        } catch (IOException exception) {
+            throw new IllegalStateException("Failed to read expected system build version", exception);
         }
     }
 
     private static String buildInfoResourceName() {
-        try {
-            java.lang.reflect.Field field = RuntimeLauncher.class.getDeclaredField("BUILD_INFO_RESOURCE");
-            field.setAccessible(true);
-            return (String) field.get(null);
-        } catch (ReflectiveOperationException exception) {
-            throw new IllegalStateException("Failed to read build info resource name", exception);
-        }
+        return RuntimeLauncher.BUILD_INFO_RESOURCE;
     }
 
     private RuntimeLauncher createLauncher(Path updatesDir, RecordingProcessStarter processStarter) {


### PR DESCRIPTION
## Summary
- make the launcher prefer the bundled image runtime when it is newer than the persisted current jar
- keep variant A behavior so equal versions still continue to use the persisted jar
- clean up stale persisted current/staged markers after startup and reuse shared runtime version comparison logic
