### PR TITLE
fix(dashboard): add staged update force install

### DIFF
--- a/dashboard/src/api/system.ts
+++ b/dashboard/src/api/system.ts
@@ -130,6 +130,11 @@ export async function updateSystemNow(): Promise<SystemUpdateActionResponse> {
   return data;
 }
 
+export async function forceInstallStagedUpdate(): Promise<SystemUpdateActionResponse> {
+  const { data } = await client.post<SystemUpdateActionResponse>('/system/update/force-install-staged');
+  return data;
+}
+
 export async function updateSystemUpdateConfig(
   payload: SystemUpdateConfigResponse,
 ): Promise<SystemUpdateConfigResponse> {

--- a/dashboard/src/hooks/useSystem.ts
+++ b/dashboard/src/hooks/useSystem.ts
@@ -6,6 +6,7 @@ import {
   type SystemUpdateConfigResponse,
   type SystemUpdateStatusResponse,
   checkSystemUpdate,
+  forceInstallStagedUpdate,
   getSystemChannels,
   getSystemDiagnostics,
   getSystemHealth,
@@ -63,6 +64,17 @@ export function useUpdateSystemNow(): UseMutationResult<SystemUpdateActionRespon
   const qc = useQueryClient();
   return useMutation({
     mutationFn: updateSystemNow,
+    onSuccess: () => {
+      invalidateUpdateQueries(qc);
+      void qc.invalidateQueries({ queryKey: ['system', 'health'] });
+    },
+  });
+}
+
+export function useForceInstallStagedUpdate(): UseMutationResult<SystemUpdateActionResponse, unknown, void> {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: forceInstallStagedUpdate,
     onSuccess: () => {
       invalidateUpdateQueries(qc);
       void qc.invalidateQueries({ queryKey: ['system', 'health'] });

--- a/dashboard/src/pages/settings/UpdateOverviewCard.tsx
+++ b/dashboard/src/pages/settings/UpdateOverviewCard.tsx
@@ -1,0 +1,216 @@
+import type { ReactElement } from 'react';
+import { Alert, Button, Card } from '../../components/ui/tailwind-components';
+
+import type { SystemUpdateStatusResponse } from '../../api/system';
+import ConfirmModal from '../../components/common/ConfirmModal';
+import SettingsCardTitle from '../../components/common/SettingsCardTitle';
+import {
+  getPrimaryUpdateVersion,
+  getUpdateActionLabel,
+  getUpdateStateDescription,
+  getUpdateWorkflowPresentation,
+  hasPendingUpdate,
+} from '../../utils/systemUpdateUi';
+import { UpdateWorkflowPanel } from './UpdateWorkflowPanel';
+
+interface AutoReloadStateSnapshot {
+  hasSeenDowntime: boolean;
+  lastProbeError: string | null;
+}
+
+interface UpdateOverviewCardProps {
+  status: SystemUpdateStatusResponse;
+  canCheck: boolean;
+  canUpdate: boolean;
+  canForceInstall: boolean;
+  isBusy: boolean;
+  isCheckPending: boolean;
+  isUpdatePending: boolean;
+  isForceInstallPending: boolean;
+  isAutoReloadArmed: boolean;
+  autoReloadState: AutoReloadStateSnapshot;
+  isForceInstallConfirmOpen: boolean;
+  forceInstallMessage: string;
+  onCheck: () => void;
+  onUpdateNow: () => void;
+  onOpenForceInstallConfirm: () => void;
+  onConfirmForceInstall: () => void;
+  onCancelForceInstall: () => void;
+}
+
+interface UpdateWorkflowActionsProps {
+  status: SystemUpdateStatusResponse;
+  canCheck: boolean;
+  canUpdate: boolean;
+  canForceInstall: boolean;
+  isBusy: boolean;
+  isCheckPending: boolean;
+  isUpdatePending: boolean;
+  isForceInstallPending: boolean;
+  onCheck: () => void;
+  onUpdateNow: () => void;
+  onOpenForceInstallConfirm: () => void;
+}
+
+interface UpdateStatusMessagesProps {
+  status: SystemUpdateStatusResponse;
+  canForceInstall: boolean;
+}
+
+function getIdleHint(status: SystemUpdateStatusResponse): string | null {
+  if (!status.enabled) {
+    return 'Updates are disabled by backend configuration.';
+  }
+  if (status.state === 'IDLE' && !hasPendingUpdate(status)) {
+    return 'No update is queued. Run a check to look for a newer compatible release.';
+  }
+  if (status.state === 'FAILED' && hasPendingUpdate(status)) {
+    return 'A target version is still available. Review the error and retry when ready.';
+  }
+  return null;
+}
+
+function buildUpdatesFootnote(status: SystemUpdateStatusResponse): string {
+  const pendingVersion = getPrimaryUpdateVersion(status);
+  if (pendingVersion == null) {
+    return 'Applying an update restarts the backend and refreshes this page automatically.';
+  }
+  return `Target version: ${pendingVersion}. Applying the update restarts the backend and refreshes this page automatically.`;
+}
+
+function UpdateWorkflowActions({
+  status,
+  canCheck,
+  canUpdate,
+  canForceInstall,
+  isBusy,
+  isCheckPending,
+  isUpdatePending,
+  isForceInstallPending,
+  onCheck,
+  onUpdateNow,
+  onOpenForceInstallConfirm,
+}: UpdateWorkflowActionsProps): ReactElement {
+  return (
+    <div className="updates-actions">
+      <Button type="button" size="sm" variant="secondary" onClick={onCheck} disabled={!canCheck}>
+        {isCheckPending ? 'Checking...' : 'Check for updates'}
+      </Button>
+      <Button type="button" size="sm" variant="primary" onClick={onUpdateNow} disabled={!canUpdate}>
+        {isUpdatePending || isBusy ? 'Updating...' : getUpdateActionLabel(status)}
+      </Button>
+      {canForceInstall && (
+        <Button type="button" size="sm" variant="warning" onClick={onOpenForceInstallConfirm} disabled={isForceInstallPending}>
+          {isForceInstallPending ? 'Force installing...' : 'Force install now'}
+        </Button>
+      )}
+    </div>
+  );
+}
+
+function UpdateStatusMessages({ status, canForceInstall }: UpdateStatusMessagesProps): ReactElement {
+  const idleHint = getIdleHint(status);
+  const workflow = getUpdateWorkflowPresentation(status);
+
+  return (
+    <>
+      <div className="small text-body-secondary updates-footnote">
+        {buildUpdatesFootnote(status)}
+      </div>
+
+      {canForceInstall && (
+        <Alert variant="warning" className="mb-3 small">
+          The update package is already staged locally. If runtime activity looks stuck, you can force the install and restart now.
+        </Alert>
+      )}
+
+      {idleHint != null && (
+        <Alert variant="secondary" className="mb-3 small">
+          {idleHint}
+        </Alert>
+      )}
+
+      {status.lastError != null && status.lastError.trim().length > 0 && (
+        <Alert variant="danger" className="mb-0 small">
+          {status.lastError}
+        </Alert>
+      )}
+
+      {status.lastError == null && idleHint == null && status.state === 'FAILED' && (
+        <Alert variant="danger" className="mb-0 small">
+          {getUpdateStateDescription(status.state)}
+        </Alert>
+      )}
+
+      {status.lastError == null && idleHint == null && status.state === 'IDLE' && !hasPendingUpdate(status) && (
+        <Alert variant="secondary" className="mb-0 small">
+          {workflow.description}
+        </Alert>
+      )}
+    </>
+  );
+}
+
+export function UpdateOverviewCard({
+  status,
+  canCheck,
+  canUpdate,
+  canForceInstall,
+  isBusy,
+  isCheckPending,
+  isUpdatePending,
+  isForceInstallPending,
+  isAutoReloadArmed,
+  autoReloadState,
+  isForceInstallConfirmOpen,
+  forceInstallMessage,
+  onCheck,
+  onUpdateNow,
+  onOpenForceInstallConfirm,
+  onConfirmForceInstall,
+  onCancelForceInstall,
+}: UpdateOverviewCardProps): ReactElement {
+  return (
+    <>
+      <Card className="settings-card updates-card">
+        <Card.Body>
+          <SettingsCardTitle title="Updates" tip="Track every update stage and restart automatically when the new runtime is ready" />
+
+          <UpdateWorkflowPanel
+            status={status}
+            isAutoReloadActive={isAutoReloadArmed}
+            hasSeenDowntime={autoReloadState.hasSeenDowntime}
+            lastProbeError={autoReloadState.lastProbeError}
+          />
+
+          <UpdateWorkflowActions
+            status={status}
+            canCheck={canCheck}
+            canUpdate={canUpdate}
+            canForceInstall={canForceInstall}
+            isBusy={isBusy}
+            isCheckPending={isCheckPending}
+            isUpdatePending={isUpdatePending}
+            isForceInstallPending={isForceInstallPending}
+            onCheck={onCheck}
+            onUpdateNow={onUpdateNow}
+            onOpenForceInstallConfirm={onOpenForceInstallConfirm}
+          />
+
+          <UpdateStatusMessages status={status} canForceInstall={canForceInstall} />
+        </Card.Body>
+      </Card>
+
+      <ConfirmModal
+        show={isForceInstallConfirmOpen}
+        title="Force install staged update?"
+        message={forceInstallMessage}
+        confirmLabel="Force install"
+        confirmVariant="warning"
+        isProcessing={isForceInstallPending}
+        onConfirm={onConfirmForceInstall}
+        onCancel={onCancelForceInstall}
+      />
+    </>
+  );
+}

--- a/dashboard/src/pages/settings/UpdateSettingsActions.tsx
+++ b/dashboard/src/pages/settings/UpdateSettingsActions.tsx
@@ -2,7 +2,7 @@ import type { ReactElement } from 'react';
 import { Alert, Button } from '../../components/ui/tailwind-components';
 
 import type { SystemUpdateStatusResponse } from '../../api/system';
-import { formatUpdateTimestamp } from '../../utils/systemUpdateUi';
+import { formatUpdateTimestamp, getUpdateBlockedReasonLabel } from '../../utils/systemUpdateUi';
 import { canSaveUpdateSettings } from './updateSettingsValidation';
 import type { UpdateSettingsFormState } from './updateSettingsUtils';
 
@@ -26,12 +26,14 @@ export function UpdateSettingsSummary({
   localTimezone,
   saveSummary,
 }: UpdateSettingsSummaryProps): ReactElement {
+  const blockedReason = getUpdateBlockedReasonLabel(status.blockedReason);
+
   return (
     <Alert variant="secondary" className="mb-3 small">
       <div>Your timezone: {localTimezone}</div>
       <div>Saved on server as {saveSummary}</div>
       {status.state === 'WAITING_FOR_WINDOW' && status.nextEligibleAt != null && <div>Next eligible window: {formatUpdateTimestamp(status.nextEligibleAt)}</div>}
-      {status.state === 'WAITING_FOR_IDLE' && status.blockedReason != null && <div>Current blocker: {status.blockedReason}</div>}
+      {status.state === 'WAITING_FOR_IDLE' && blockedReason != null && <div>Current blocker: {blockedReason}</div>}
     </Alert>
   );
 }

--- a/dashboard/src/pages/settings/UpdatesTab.test.tsx
+++ b/dashboard/src/pages/settings/UpdatesTab.test.tsx
@@ -1,0 +1,194 @@
+/* @vitest-environment jsdom */
+
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { SystemUpdateConfigResponse, SystemUpdateStatusResponse } from '../../api/system';
+import { UpdatesTab } from './UpdatesTab';
+
+declare global {
+  var IS_REACT_ACT_ENVIRONMENT: boolean | undefined;
+}
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const checkMutateAsync = vi.hoisted(() => vi.fn<() => Promise<{ message: string }>>(() => Promise.resolve({ message: 'Checked' })));
+const updateMutateAsync = vi.hoisted(() => vi.fn<() => Promise<{ message: string }>>(() => Promise.resolve({ message: 'Updated' })));
+const forceInstallMutateAsync = vi.hoisted(() => vi.fn<() => Promise<{ message: string }>>(() => Promise.resolve({ message: 'Force installed' })));
+const updateConfigMutateAsync = vi.hoisted(() => vi.fn(() => Promise.resolve()));
+const refetchStatus = vi.hoisted(() => vi.fn(() => Promise.resolve()));
+const refetchConfig = vi.hoisted(() => vi.fn(() => Promise.resolve()));
+const toastSuccess = vi.hoisted(() => vi.fn<(message: string) => void>());
+const toastError = vi.hoisted(() => vi.fn<(message: string) => void>());
+const statusState = vi.hoisted(() => ({
+  data: {} as SystemUpdateStatusResponse,
+  isLoading: false,
+  isError: false,
+  refetch: refetchStatus,
+}));
+const configState = vi.hoisted(() => ({
+  data: {} as SystemUpdateConfigResponse,
+  isLoading: false,
+  isError: false,
+  refetch: refetchConfig,
+}));
+
+vi.mock('react-hot-toast', () => ({
+  default: {
+    success: toastSuccess,
+    error: toastError,
+  },
+}));
+
+vi.mock('../../hooks/useUpdateAutoReload', () => ({
+  useUpdateAutoReload: () => ({ hasSeenDowntime: false, lastProbeError: null }),
+}));
+
+vi.mock('../../hooks/useSystem', () => ({
+  useSystemUpdateStatus: () => statusState,
+  useSystemUpdateConfig: () => configState,
+  useCheckSystemUpdate: () => ({ isPending: false, mutateAsync: checkMutateAsync }),
+  useUpdateSystemNow: () => ({ isPending: false, mutateAsync: updateMutateAsync }),
+  useForceInstallStagedUpdate: () => ({ isPending: false, mutateAsync: forceInstallMutateAsync }),
+  useUpdateSystemConfig: () => ({ isPending: false, mutateAsync: updateConfigMutateAsync }),
+}));
+
+interface RenderResult {
+  container: HTMLDivElement;
+  unmount: () => void;
+}
+
+function buildStatus(overrides: Partial<SystemUpdateStatusResponse> = {}): SystemUpdateStatusResponse {
+  return {
+    state: 'WAITING_FOR_IDLE',
+    enabled: true,
+    autoEnabled: true,
+    maintenanceWindowEnabled: false,
+    current: { version: '0.4.0', source: 'image' },
+    target: { version: '0.4.2' },
+    staged: { version: '0.4.2' },
+    available: null,
+    busy: true,
+    blockedReason: 'SESSION_WORK_RUNNING',
+    lastCheckAt: '2026-02-20T12:00:00Z',
+    lastError: null,
+    progressPercent: 80,
+    stageTitle: 'Waiting for running work 0.4.2',
+    stageDescription: 'The release is staged and will be applied once active session or auto-mode work finishes.',
+    ...overrides,
+  };
+}
+
+function buildConfig(): SystemUpdateConfigResponse {
+  return {
+    autoEnabled: true,
+    checkIntervalMinutes: 60,
+    maintenanceWindowEnabled: false,
+    maintenanceWindowStartUtc: '00:00',
+    maintenanceWindowEndUtc: '00:00',
+  };
+}
+
+function renderUpdatesTab(): RenderResult {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root: Root = createRoot(container);
+
+  act(() => {
+    root.render(<UpdatesTab />);
+  });
+
+  return {
+    container,
+    unmount: () => {
+      act(() => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+}
+
+function getButtonByText(label: string): HTMLButtonElement {
+  const buttons = Array.from(document.querySelectorAll('button'));
+  const match = buttons.find((button) => button.textContent?.trim() === label);
+  if (!(match instanceof HTMLButtonElement)) {
+    throw new Error(`Button "${label}" not found`);
+  }
+  return match;
+}
+
+function click(element: HTMLElement): void {
+  act(() => {
+    element.click();
+  });
+}
+
+async function flushPromises(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+describe('UpdatesTab', () => {
+  beforeEach(() => {
+    checkMutateAsync.mockClear();
+    updateMutateAsync.mockClear();
+    forceInstallMutateAsync.mockClear();
+    updateConfigMutateAsync.mockClear();
+    refetchStatus.mockClear();
+    refetchConfig.mockClear();
+    toastSuccess.mockClear();
+    toastError.mockClear();
+    statusState.data = buildStatus();
+    configState.data = buildConfig();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    document.body.style.overflow = '';
+  });
+
+  it('shows force install affordance and human-readable blocker when staged update is blocked by activity', () => {
+    const view = renderUpdatesTab();
+    const pageText = document.body.textContent ?? '';
+
+    expect(pageText).toContain('Force install now');
+    expect(pageText).toContain('An active or queued session is still running');
+    expect(pageText).toContain('The update package is already staged locally');
+
+    view.unmount();
+  });
+
+  it('confirms before force installing and calls the dedicated mutation', async () => {
+    const view = renderUpdatesTab();
+
+    click(getButtonByText('Force install now'));
+
+    expect(document.body.textContent ?? '').toContain('Force install staged update?');
+    expect(document.body.textContent ?? '').toContain('may interrupt the current work');
+
+    click(getButtonByText('Force install'));
+    await flushPromises();
+
+    expect(forceInstallMutateAsync).toHaveBeenCalledTimes(1);
+    expect(toastSuccess).toHaveBeenCalledWith('Force installed');
+
+    view.unmount();
+  });
+
+  it('hides force install action when no staged update is available', () => {
+    statusState.data = buildStatus({
+      staged: null,
+      target: null,
+      available: null,
+    });
+
+    const view = renderUpdatesTab();
+
+    expect(document.body.textContent ?? '').not.toContain('Force install now');
+
+    view.unmount();
+  });
+});

--- a/dashboard/src/pages/settings/UpdatesTab.tsx
+++ b/dashboard/src/pages/settings/UpdatesTab.tsx
@@ -1,5 +1,5 @@
-import { useCallback, type ReactElement } from 'react';
-import { Alert, Button, Card, Spinner } from '../../components/ui/tailwind-components';
+import { useCallback, useState, type ReactElement } from 'react';
+import { Button, Card, Spinner } from '../../components/ui/tailwind-components';
 import toast from 'react-hot-toast';
 import type {
   SystemUpdateActionResponse,
@@ -10,20 +10,15 @@ import SettingsCardTitle from '../../components/common/SettingsCardTitle';
 import { useUpdateAutoReload } from '../../hooks/useUpdateAutoReload';
 import {
   useCheckSystemUpdate,
+  useForceInstallStagedUpdate,
   useSystemUpdateConfig,
   useSystemUpdateStatus,
   useUpdateSystemConfig,
   useUpdateSystemNow,
 } from '../../hooks/useSystem';
 import { extractErrorMessage } from '../../utils/extractErrorMessage';
-import {
-  getPrimaryUpdateVersion,
-  getUpdateActionLabel,
-  getUpdateStateDescription,
-  getUpdateWorkflowPresentation,
-  hasPendingUpdate,
-} from '../../utils/systemUpdateUi';
-import { UpdateWorkflowPanel } from './UpdateWorkflowPanel';
+import { getPrimaryUpdateVersion, getUpdateBlockedReasonLabel } from '../../utils/systemUpdateUi';
+import { UpdateOverviewCard } from './UpdateOverviewCard';
 import { UpdateSettingsCard } from './UpdateSettingsCard';
 import {
   resolveExpectedUpdateVersion,
@@ -32,7 +27,6 @@ import {
   useUpdateConfigForm,
 } from './UpdatesTabHooks';
 import type { UpdateSettingsFormState } from './updateSettingsUtils';
-
 
 interface UpdatesErrorCardProps {
   onRetry: () => void;
@@ -44,31 +38,31 @@ interface UpdatesBodyProps {
   configForm: UpdateSettingsFormState | null;
   canCheck: boolean;
   canUpdate: boolean;
+  canForceInstall: boolean;
   isBusy: boolean;
   isCheckPending: boolean;
   isUpdatePending: boolean;
+  isForceInstallPending: boolean;
   isConfigLoading: boolean;
   isConfigSaving: boolean;
   isAutoReloadArmed: boolean;
   autoReloadState: ReturnType<typeof useUpdateAutoReload>;
+  isForceInstallConfirmOpen: boolean;
+  forceInstallMessage: string;
   onCheck: () => void;
   onUpdateNow: () => void;
+  onOpenForceInstallConfirm: () => void;
+  onConfirmForceInstall: () => void;
+  onCancelForceInstall: () => void;
   onConfigRetry: () => void;
   onConfigChange: (updater: (current: UpdateSettingsFormState) => UpdateSettingsFormState) => void;
   onConfigSave: () => void;
 }
 
-function getIdleHint(status: SystemUpdateStatusResponse): string | null {
-  if (!status.enabled) {
-    return 'Updates are disabled by backend configuration.';
-  }
-  if (status.state === 'IDLE' && !hasPendingUpdate(status)) {
-    return 'No update is queued. Run a check to look for a newer compatible release.';
-  }
-  if (status.state === 'FAILED' && hasPendingUpdate(status)) {
-    return 'A target version is still available. Review the error and retry when ready.';
-  }
-  return null;
+function buildForceInstallMessage(status: SystemUpdateStatusResponse): string {
+  const version = getPrimaryUpdateVersion(status) ?? 'the staged update';
+  const blockedReason = getUpdateBlockedReasonLabel(status.blockedReason) ?? 'Runtime activity is still reported as busy.';
+  return `The update package for ${version} is already staged locally, but the normal install action is blocked because ${blockedReason}. Force install will restart the backend immediately and may interrupt the current work.`;
 }
 
 function UpdatesLoadingCard(): ReactElement {
@@ -87,9 +81,9 @@ function UpdatesErrorCard({ onRetry }: UpdatesErrorCardProps): ReactElement {
     <Card className="settings-card updates-card">
       <Card.Body>
         <SettingsCardTitle title="Updates" />
-        <Alert variant="warning" className="mb-3">
+        <div className="alert alert-warning mb-3">
           Unable to load update status from backend.
-        </Alert>
+        </div>
         <Button type="button" size="sm" variant="secondary" onClick={onRetry}>
           Retry
         </Button>
@@ -104,76 +98,47 @@ function UpdatesBody({
   configForm,
   canCheck,
   canUpdate,
+  canForceInstall,
   isBusy,
   isCheckPending,
   isUpdatePending,
+  isForceInstallPending,
   isConfigLoading,
   isConfigSaving,
   isAutoReloadArmed,
   autoReloadState,
+  isForceInstallConfirmOpen,
+  forceInstallMessage,
   onCheck,
   onUpdateNow,
+  onOpenForceInstallConfirm,
+  onConfirmForceInstall,
+  onCancelForceInstall,
   onConfigRetry,
   onConfigChange,
   onConfigSave,
 }: UpdatesBodyProps): ReactElement {
-  const pendingVersion = getPrimaryUpdateVersion(status);
-  const idleHint = getIdleHint(status);
-  const workflow = getUpdateWorkflowPresentation(status);
-
   return (
     <>
-      <Card className="settings-card updates-card">
-        <Card.Body>
-          <SettingsCardTitle title="Updates" tip="Track every update stage and restart automatically when the new runtime is ready" />
-
-          <UpdateWorkflowPanel
-            status={status}
-            isAutoReloadActive={isAutoReloadArmed}
-            hasSeenDowntime={autoReloadState.hasSeenDowntime}
-            lastProbeError={autoReloadState.lastProbeError}
-          />
-
-          <div className="updates-actions">
-            <Button type="button" size="sm" variant="secondary" onClick={onCheck} disabled={!canCheck}>
-              {isCheckPending ? 'Checking...' : 'Check for updates'}
-            </Button>
-            <Button type="button" size="sm" variant="primary" onClick={onUpdateNow} disabled={!canUpdate}>
-              {isUpdatePending || isBusy ? 'Updating...' : getUpdateActionLabel(status)}
-            </Button>
-          </div>
-
-          <div className="small text-body-secondary updates-footnote">
-            {pendingVersion == null
-              ? 'Applying an update restarts the backend and refreshes this page automatically.'
-              : `Target version: ${pendingVersion}. Applying the update restarts the backend and refreshes this page automatically.`}
-          </div>
-
-          {idleHint != null && (
-            <Alert variant="secondary" className="mb-3 small">
-              {idleHint}
-            </Alert>
-          )}
-
-          {status.lastError != null && status.lastError.trim().length > 0 && (
-            <Alert variant="danger" className="mb-0 small">
-              {status.lastError}
-            </Alert>
-          )}
-
-          {status.lastError == null && idleHint == null && status.state === 'FAILED' && (
-            <Alert variant="danger" className="mb-0 small">
-              {getUpdateStateDescription(status.state)}
-            </Alert>
-          )}
-
-          {status.lastError == null && idleHint == null && status.state === 'IDLE' && !hasPendingUpdate(status) && (
-            <Alert variant="secondary" className="mb-0 small">
-              {workflow.description}
-            </Alert>
-          )}
-        </Card.Body>
-      </Card>
+      <UpdateOverviewCard
+        status={status}
+        canCheck={canCheck}
+        canUpdate={canUpdate}
+        canForceInstall={canForceInstall}
+        isBusy={isBusy}
+        isCheckPending={isCheckPending}
+        isUpdatePending={isUpdatePending}
+        isForceInstallPending={isForceInstallPending}
+        isAutoReloadArmed={isAutoReloadArmed}
+        autoReloadState={autoReloadState}
+        isForceInstallConfirmOpen={isForceInstallConfirmOpen}
+        forceInstallMessage={forceInstallMessage}
+        onCheck={onCheck}
+        onUpdateNow={onUpdateNow}
+        onOpenForceInstallConfirm={onOpenForceInstallConfirm}
+        onConfirmForceInstall={onConfirmForceInstall}
+        onCancelForceInstall={onCancelForceInstall}
+      />
 
       <UpdateSettingsCard
         status={status}
@@ -208,7 +173,9 @@ export function UpdatesTab(): ReactElement {
   const configQuery = useSystemUpdateConfig();
   const checkMutation = useCheckSystemUpdate();
   const updateNowMutation = useUpdateSystemNow();
+  const forceInstallMutation = useForceInstallStagedUpdate();
   const updateConfigMutation = useUpdateSystemConfig();
+  const [isForceInstallConfirmOpen, setIsForceInstallConfirmOpen] = useState<boolean>(false);
   const status = statusQuery.data ?? null;
   const config = configQuery.data ?? null;
   const [configForm, setConfigForm, currentPayload] = useUpdateConfigForm(config);
@@ -216,6 +183,7 @@ export function UpdatesTab(): ReactElement {
   const [isAutoReloadArmed, setIsAutoReloadArmed] = useUpdateAutoReloadLifecycle({
     status,
     isUpdatePending: updateNowMutation.isPending,
+    isForceInstallPending: forceInstallMutation.isPending,
     refetchStatus,
   });
 
@@ -225,10 +193,11 @@ export function UpdatesTab(): ReactElement {
     isEnabled: isAutoReloadArmed,
   });
 
-  const { isBusy, canCheck, canUpdate } = useUpdateActionAvailability(
+  const { isBusy, canCheck, canUpdate, canForceInstall } = useUpdateActionAvailability(
     status,
     checkMutation.isPending,
     updateNowMutation.isPending,
+    forceInstallMutation.isPending,
   );
 
   const handleConfigRetry = useCallback((): void => {
@@ -239,6 +208,16 @@ export function UpdatesTab(): ReactElement {
     setConfigForm((current) => (current == null ? current : updater(current)));
   }, [setConfigForm]);
 
+  const handleOpenForceInstallConfirm = useCallback((): void => {
+    setIsForceInstallConfirmOpen(true);
+  }, []);
+
+  const handleCancelForceInstall = useCallback((): void => {
+    if (forceInstallMutation.isPending) {
+      return;
+    }
+    setIsForceInstallConfirmOpen(false);
+  }, [forceInstallMutation.isPending]);
 
   if (statusQuery.isLoading) {
     return <UpdatesLoadingCard />;
@@ -246,8 +225,6 @@ export function UpdatesTab(): ReactElement {
   if (statusQuery.isError || status == null) {
     return <UpdatesErrorCard onRetry={() => { void statusQuery.refetch(); }} />;
   }
-
-
 
   const handleCheck = (): void => {
     void runUpdateAction(async () => {
@@ -264,6 +241,18 @@ export function UpdatesTab(): ReactElement {
       await statusQuery.refetch();
       return result;
     }, 'Update failed', () => {
+      setIsAutoReloadArmed(false);
+    });
+  };
+
+  const handleConfirmForceInstall = (): void => {
+    setIsAutoReloadArmed(true);
+    void runUpdateAction(async () => {
+      const result = await forceInstallMutation.mutateAsync();
+      setIsForceInstallConfirmOpen(false);
+      await statusQuery.refetch();
+      return result;
+    }, 'Force install failed', () => {
       setIsAutoReloadArmed(false);
     });
   };
@@ -292,15 +281,22 @@ export function UpdatesTab(): ReactElement {
       configForm={configForm}
       canCheck={canCheck}
       canUpdate={canUpdate}
+      canForceInstall={canForceInstall}
       isBusy={isBusy}
       isCheckPending={checkMutation.isPending}
       isUpdatePending={updateNowMutation.isPending}
+      isForceInstallPending={forceInstallMutation.isPending}
       isConfigLoading={configQuery.isLoading}
       isConfigSaving={updateConfigMutation.isPending}
       isAutoReloadArmed={isAutoReloadArmed}
       autoReloadState={autoReloadState}
+      isForceInstallConfirmOpen={isForceInstallConfirmOpen}
+      forceInstallMessage={buildForceInstallMessage(status)}
       onCheck={handleCheck}
       onUpdateNow={handleUpdateNow}
+      onOpenForceInstallConfirm={handleOpenForceInstallConfirm}
+      onConfirmForceInstall={handleConfirmForceInstall}
+      onCancelForceInstall={handleCancelForceInstall}
       onConfigRetry={handleConfigRetry}
       onConfigChange={handleConfigChange}
       onConfigSave={handleConfigSave}

--- a/dashboard/src/pages/settings/UpdatesTabHooks.ts
+++ b/dashboard/src/pages/settings/UpdatesTabHooks.ts
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 
 import type { SystemUpdateConfigResponse, SystemUpdateStatusResponse } from '../../api/system';
-import { UPDATE_BUSY_STATES, getPrimaryUpdateVersion, hasPendingUpdate } from '../../utils/systemUpdateUi';
+import { UPDATE_BUSY_STATES, canForceInstallStagedUpdate, getPrimaryUpdateVersion, hasPendingUpdate } from '../../utils/systemUpdateUi';
 import { configToForm, isValidTimeInput, localTimeToUtc, normalizeIntervalValue, type UpdateSettingsFormState } from './updateSettingsUtils';
 
 const LIVE_STATUS_POLL_MS = 1500;
@@ -9,6 +9,7 @@ const LIVE_STATUS_POLL_MS = 1500;
 interface AutoReloadLifecycleArgs {
   status: SystemUpdateStatusResponse | null;
   isUpdatePending: boolean;
+  isForceInstallPending: boolean;
   refetchStatus: () => void;
 }
 
@@ -52,6 +53,7 @@ export function useUpdateConfigForm(config: SystemUpdateConfigResponse | null): 
 export function useUpdateAutoReloadLifecycle({
   status,
   isUpdatePending,
+  isForceInstallPending,
   refetchStatus,
 }: AutoReloadLifecycleArgs): [boolean, React.Dispatch<React.SetStateAction<boolean>>] {
   const [isAutoReloadArmed, setIsAutoReloadArmed] = useState<boolean>(false);
@@ -60,7 +62,7 @@ export function useUpdateAutoReloadLifecycle({
     if (status == null) {
       return undefined;
     }
-    const shouldLivePoll = isAutoReloadArmed || isUpdatePending || UPDATE_BUSY_STATES.has(status.state);
+    const shouldLivePoll = isAutoReloadArmed || isUpdatePending || isForceInstallPending || UPDATE_BUSY_STATES.has(status.state);
     if (!shouldLivePoll) {
       return undefined;
     }
@@ -68,7 +70,7 @@ export function useUpdateAutoReloadLifecycle({
     return () => {
       window.clearInterval(intervalId);
     };
-  }, [isAutoReloadArmed, isUpdatePending, refetchStatus, status]);
+  }, [isAutoReloadArmed, isForceInstallPending, isUpdatePending, refetchStatus, status]);
 
   useEffect(() => {
     if (!isAutoReloadArmed || status == null) {
@@ -86,21 +88,22 @@ export function resolveExpectedUpdateVersion(status: SystemUpdateStatusResponse 
   return status == null ? null : getPrimaryUpdateVersion(status);
 }
 
-
 export function useUpdateActionAvailability(
   status: SystemUpdateStatusResponse | null,
   isCheckPending: boolean,
   isUpdatePending: boolean,
-): { isBusy: boolean; canCheck: boolean; canUpdate: boolean } {
+  isForceInstallPending: boolean,
+): { isBusy: boolean; canCheck: boolean; canUpdate: boolean; canForceInstall: boolean } {
   return useMemo(() => {
     if (status == null) {
-      return { isBusy: false, canCheck: false, canUpdate: false };
+      return { isBusy: false, canCheck: false, canUpdate: false, canForceInstall: false };
     }
-    const isWorkflowBusy = isCheckPending || isUpdatePending || UPDATE_BUSY_STATES.has(status.state);
+    const isWorkflowBusy = isCheckPending || isUpdatePending || isForceInstallPending || UPDATE_BUSY_STATES.has(status.state);
     return {
       isBusy: isWorkflowBusy || Boolean(status.busy),
       canCheck: status.enabled && !isWorkflowBusy,
       canUpdate: status.enabled && !isWorkflowBusy && !status.busy && hasPendingUpdate(status),
+      canForceInstall: !isWorkflowBusy && canForceInstallStagedUpdate(status),
     };
-  }, [isCheckPending, isUpdatePending, status]);
+  }, [isCheckPending, isForceInstallPending, isUpdatePending, status]);
 }

--- a/dashboard/src/utils/systemUpdateUi.test.ts
+++ b/dashboard/src/utils/systemUpdateUi.test.ts
@@ -3,11 +3,13 @@ import type { SystemUpdateStatusResponse } from '../api/system';
 import {
   AUTO_UPDATE_CHECK_INTERVAL_MS,
   type BackgroundUpdateCheckStatus,
+  canForceInstallStagedUpdate,
   formatUpdateTimestamp,
   formatVersionLabel,
   getSidebarUpdateBadge,
   getTopbarUpdateNotice,
   getUpdateActionLabel,
+  getUpdateBlockedReasonLabel,
   getUpdateSourceLabel,
   getUpdateStateDescription,
   getUpdateStateLabel,
@@ -106,6 +108,28 @@ describe('systemUpdateUi', () => {
     expect(getUpdateActionLabel(buildStatus({ state: 'VERIFYING', target: { version: '0.4.2' } }))).toBe('Restarting...');
     expect(getUpdateSourceLabel('jar')).toBe('Local package');
     expect(getUpdateSourceLabel('image')).toBe('Container image');
+  });
+
+  it('shouldProvideFriendlyBlockedReasonLabelsAndForceInstallAvailability', () => {
+    expect(getUpdateBlockedReasonLabel('SESSION_WORK_RUNNING')).toBe('An active or queued session is still running');
+    expect(getUpdateBlockedReasonLabel('AUTO_JOB_RUNNING')).toBe('An auto-mode job is still running');
+    expect(getUpdateBlockedReasonLabel('custom-blocker')).toBe('custom-blocker');
+    expect(getUpdateBlockedReasonLabel(null)).toBeNull();
+
+    expect(canForceInstallStagedUpdate(buildStatus({
+      state: 'WAITING_FOR_IDLE',
+      busy: true,
+      staged: { version: '0.4.2' },
+      target: { version: '0.4.2' },
+      blockedReason: 'SESSION_WORK_RUNNING',
+    }))).toBe(true);
+
+    expect(canForceInstallStagedUpdate(buildStatus({
+      state: 'WAITING_FOR_WINDOW',
+      busy: false,
+      staged: { version: '0.4.2' },
+      target: { version: '0.4.2' },
+    }))).toBe(false);
   });
 
   it('shouldDeriveFailedWorkflowStepsAndFallbackProgress', () => {

--- a/dashboard/src/utils/systemUpdateUi.ts
+++ b/dashboard/src/utils/systemUpdateUi.ts
@@ -32,6 +32,11 @@ const UPDATE_STATE_DESCRIPTIONS: Record<string, string> = {
   FAILED: 'The last update attempt failed.',
 };
 
+const UPDATE_BLOCKED_REASON_LABELS: Record<string, string> = {
+  SESSION_WORK_RUNNING: 'An active or queued session is still running',
+  AUTO_JOB_RUNNING: 'An auto-mode job is still running',
+};
+
 const WORKFLOW_STEPS = ['check', 'download', 'stage', 'restart', 'verify'] as const;
 
 const WORKFLOW_STEP_LABELS: Record<(typeof WORKFLOW_STEPS)[number], string> = {
@@ -140,6 +145,18 @@ export function getPrimaryUpdateVersion(status: SystemUpdateStatusResponse): str
 
 export function hasPendingUpdate(status: SystemUpdateStatusResponse): boolean {
   return getPrimaryUpdateVersion(status) != null;
+}
+
+export function getUpdateBlockedReasonLabel(blockedReason: string | null | undefined): string | null {
+  if (blockedReason == null || blockedReason.trim().length === 0) {
+    return null;
+  }
+
+  return UPDATE_BLOCKED_REASON_LABELS[blockedReason] ?? blockedReason;
+}
+
+export function canForceInstallStagedUpdate(status: SystemUpdateStatusResponse): boolean {
+  return status.enabled && Boolean(status.busy) && status.staged != null && !UPDATE_BUSY_STATES.has(status.state);
 }
 
 export function getUpdateActionLabel(status: SystemUpdateStatusResponse): string {

--- a/src/main/java/me/golemcore/bot/adapter/inbound/web/controller/UpdateController.java
+++ b/src/main/java/me/golemcore/bot/adapter/inbound/web/controller/UpdateController.java
@@ -46,6 +46,12 @@ public class UpdateController {
                 .subscribeOn(Schedulers.boundedElastic());
     }
 
+    @PostMapping("/force-install-staged")
+    public Mono<ResponseEntity<UpdateActionResult>> forceInstallStagedUpdate() {
+        return Mono.fromCallable(() -> ResponseEntity.ok(updateService.forceInstallStagedUpdate()))
+                .subscribeOn(Schedulers.boundedElastic());
+    }
+
     @PutMapping("/config")
     public Mono<ResponseEntity<RuntimeConfig.UpdateConfig>> updateConfig(
             @RequestBody RuntimeConfig.UpdateConfig config) {

--- a/src/main/java/me/golemcore/bot/application/update/UpdateService.java
+++ b/src/main/java/me/golemcore/bot/application/update/UpdateService.java
@@ -213,6 +213,23 @@ public class UpdateService {
                 .build();
     }
 
+    public UpdateActionResult forceInstallStagedUpdate() {
+        synchronized (lock) {
+            ensureEnabled();
+            ensureNoBusyOperation();
+            lastCheckError = "";
+
+            UpdateVersionInfo staged = resolveStagedInfo();
+            if (staged == null) {
+                throw new IllegalStateException("No staged update to force install");
+            }
+
+            activeTarget = Optional.of(copyVersionInfo(staged));
+        }
+
+        return applyStagedUpdate();
+    }
+
     private UpdateActionResult applyStagedUpdate() {
         synchronized (lock) {
             ensureEnabled();

--- a/src/test/java/me/golemcore/bot/adapter/inbound/web/controller/UpdateControllerTest.java
+++ b/src/test/java/me/golemcore/bot/adapter/inbound/web/controller/UpdateControllerTest.java
@@ -92,6 +92,26 @@ class UpdateControllerTest {
     }
 
     @Test
+    void shouldCallForceInstallStagedEndpoint() {
+        UpdateActionResult updateResult = UpdateActionResult.builder()
+                .success(true)
+                .message("Update 0.4.2 is being applied. JVM restart scheduled.")
+                .version("0.4.2")
+                .build();
+        when(updateService.forceInstallStagedUpdate()).thenReturn(updateResult);
+
+        StepVerifier.create(controller.forceInstallStagedUpdate())
+                .assertNext(response -> {
+                    assertEquals(HttpStatus.OK, response.getStatusCode());
+                    assertNotNull(response.getBody());
+                    assertEquals("0.4.2", response.getBody().getVersion());
+                })
+                .verifyComplete();
+
+        verify(updateService).forceInstallStagedUpdate();
+    }
+
+    @Test
     void shouldReturnUpdateConfig() {
         RuntimeConfig.UpdateConfig config = RuntimeConfig.UpdateConfig.builder()
                 .autoEnabled(true)

--- a/src/test/java/me/golemcore/bot/adapter/inbound/web/controller/UpdateControllerWebTest.java
+++ b/src/test/java/me/golemcore/bot/adapter/inbound/web/controller/UpdateControllerWebTest.java
@@ -37,4 +37,18 @@ class UpdateControllerWebTest {
                 .jsonPath("$.status").isEqualTo(409)
                 .jsonPath("$.message").isEqualTo("No available update. Run check first.");
     }
+
+    @Test
+    void shouldMapIllegalStateToConflictForForceInstallStagedUpdate() {
+        when(updateService.forceInstallStagedUpdate())
+                .thenThrow(new IllegalStateException("No staged update to force install"));
+
+        webTestClient.post()
+                .uri("/api/system/update/force-install-staged")
+                .exchange()
+                .expectStatus().isEqualTo(409)
+                .expectBody()
+                .jsonPath("$.status").isEqualTo(409)
+                .jsonPath("$.message").isEqualTo("No staged update to force install");
+    }
 }

--- a/src/test/java/me/golemcore/bot/domain/service/UpdateServiceTest.java
+++ b/src/test/java/me/golemcore/bot/domain/service/UpdateServiceTest.java
@@ -466,6 +466,37 @@ class UpdateServiceTest {
     }
 
     @Test
+    void shouldForceApplyStagedUpdateWhenRuntimeWorkIsActive(@TempDir Path tempDir) {
+        enableUpdates(tempDir);
+        when(updateActivityGate.getStatus()).thenReturn(
+                UpdateActivityGate.Result.busy(UpdateBlockedReason.SESSION_WORK_RUNNING));
+        when(updateArtifactStorePort.findStagedArtifact())
+                .thenReturn(Optional.of(new UpdateArtifactStorePort.StoredArtifact("bot-0.4.2.jar", BASE_TIME)));
+
+        TestableUpdateService service = createTestableService(new StubReleaseSource());
+
+        UpdateActionResult result = service.forceInstallStagedUpdate();
+
+        assertEquals("Update 0.4.2 is being applied. JVM restart scheduled.", result.getMessage());
+        assertEquals("0.4.2", result.getVersion());
+        assertTrue(service.isRestartRequested());
+        assertEquals(UpdateState.APPLYING, service.getStatus().getState());
+    }
+
+    @Test
+    void shouldRejectForceInstallWhenNoStagedUpdateExists(@TempDir Path tempDir) {
+        enableUpdates(tempDir);
+        when(updateActivityGate.getStatus()).thenReturn(
+                UpdateActivityGate.Result.busy(UpdateBlockedReason.SESSION_WORK_RUNNING));
+
+        UpdateService service = createService(new StubReleaseSource());
+
+        IllegalStateException error = assertThrows(IllegalStateException.class, service::forceInstallStagedUpdate);
+
+        assertEquals("No staged update to force install", error.getMessage());
+    }
+
+    @Test
     void shouldNotInitializeAutoUpdateSchedulerWhenFeatureIsDisabled() {
         botProperties.getUpdate().setEnabled(false);
         UpdateService service = createService(new StubReleaseSource());


### PR DESCRIPTION
## Summary
- add a dedicated staged-update force install endpoint so operators can restart into an already downloaded jar even when runtime activity looks stuck
- surface a guarded "Force install now" action in Settings → Updates with confirmation copy and human-readable blocker messages
- cover the new backend and dashboard flow with targeted JUnit, Vitest, and Playwright/local verification
