### PR TITLE
fix(ci): repair javadoc generation for release builds

### DIFF
--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -1,0 +1,43 @@
+name: Javadoc
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+env:
+  PLUGIN_API_REPO_REF: 67cd0d10a997f494dcaf4686438e5c6bcfc8ac65
+
+jobs:
+  javadoc:
+    name: Javadoc Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Checkout plugin APIs
+        uses: actions/checkout@v6
+        with:
+          repository: alexk-dev/golemcore-plugins
+          ref: ${{ env.PLUGIN_API_REPO_REF }}
+          path: golemcore-plugins
+
+      - name: Install plugin API artifacts
+        run: mvn -B -ntp -Djgitver.skip=true -f golemcore-plugins/pom.xml -pl extension-api,runtime-api -am install -DskipTests
+
+      - name: Build javadoc jar (central-publish profile)
+        run: ./mvnw -B -ntp -DskipTests -DskipGitHooks=true -P central-publish package

--- a/pom.xml
+++ b/pom.xml
@@ -674,10 +674,38 @@
                         </executions>
                     </plugin>
                     <plugin>
+                        <groupId>org.projectlombok</groupId>
+                        <artifactId>lombok-maven-plugin</artifactId>
+                        <version>1.18.20.0</version>
+                        <dependencies>
+                            <dependency>
+                                <groupId>org.projectlombok</groupId>
+                                <artifactId>lombok</artifactId>
+                                <version>${lombok.version}</version>
+                            </dependency>
+                        </dependencies>
+                        <executions>
+                            <execution>
+                                <id>delombok-for-javadoc</id>
+                                <phase>generate-sources</phase>
+                                <goals>
+                                    <goal>delombok</goal>
+                                </goals>
+                                <configuration>
+                                    <sourceDirectory>${project.basedir}/src/main/java</sourceDirectory>
+                                    <outputDirectory>${project.build.directory}/delombok</outputDirectory>
+                                    <addOutputDirectory>false</addOutputDirectory>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <configuration>
                             <doclint>none</doclint>
+                            <sourcepath>${project.build.directory}/delombok${path.separator}${project.build.directory}/generated-sources/protobuf/java</sourcepath>
+                            <failOnError>true</failOnError>
                         </configuration>
                         <executions>
                             <execution>


### PR DESCRIPTION
## Summary

- Root cause: `maven-javadoc-plugin:jar` in the `central-publish` profile fails because `javadoc` does not execute Lombok's annotation processor, so Lombok-generated inner types such as `DashboardFileContent.DashboardFileContentBuilder` (referenced in `DashboardFileService`) cannot be resolved. The last three `Release` runs (#294, #297, #299) failed at exactly this step and never produced a tag.
- Fix: add `lombok-maven-plugin` (pinned to the project `${lombok.version}`) to the `central-publish` profile, delombok `src/main/java` into `target/delombok` in `generate-sources`, and point `maven-javadoc-plugin` at the delombok output + the protobuf-generated sources so the javadoc jar can always be built.
- Guardrail: new `javadoc.yml` workflow runs the same `mvn -P central-publish package` path on every PR and push to `main`, so a javadoc regression is now caught before it can reach a release tag.

Verified locally: `./mvnw -B -ntp -DskipTests -DskipGitHooks=true -P central-publish package` succeeds and emits `target/bot-*-javadoc.jar`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)