### PR TITLE
feat(dashboard): guide users to relevant docs

### DIFF
--- a/dashboard/src/components/common/DocsLinkAnchor.tsx
+++ b/dashboard/src/components/common/DocsLinkAnchor.tsx
@@ -1,0 +1,36 @@
+import type { AnchorHTMLAttributes, ReactElement, ReactNode } from 'react';
+import { FiExternalLink } from 'react-icons/fi';
+
+import type { DocLink } from '../../lib/docsLinks';
+import { cn } from '../../lib/utils';
+
+const BUTTON_CLASS_NAME = 'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-xl border border-border/90 bg-card/80 px-3 py-2 text-xs font-semibold text-foreground shadow-soft transition-all duration-200 hover:border-primary/40 hover:bg-card';
+const TEXT_CLASS_NAME = 'inline-flex items-center gap-1 text-sm font-semibold text-primary underline-offset-4 hover:underline';
+
+export interface DocsLinkAnchorProps extends Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'href'> {
+  doc: DocLink;
+  children?: ReactNode;
+  appearance?: 'button' | 'text';
+}
+
+export function DocsLinkAnchor({
+  doc,
+  children,
+  appearance = 'button',
+  className,
+  ...props
+}: DocsLinkAnchorProps): ReactElement {
+  return (
+    <a
+      {...props}
+      href={doc.url}
+      target="_blank"
+      rel="noreferrer"
+      title={`Open ${doc.title} on docs.golemcore.me`}
+      className={cn(appearance === 'button' ? BUTTON_CLASS_NAME : TEXT_CLASS_NAME, className)}
+    >
+      <span>{children ?? doc.shortLabel}</span>
+      <FiExternalLink size={appearance === 'button' ? 14 : 12} aria-hidden="true" />
+    </a>
+  );
+}

--- a/dashboard/src/components/common/HelpTip.tsx
+++ b/dashboard/src/components/common/HelpTip.tsx
@@ -1,11 +1,17 @@
 import type { ReactElement } from 'react';
-import { FiHelpCircle } from 'react-icons/fi';
+import { FiExternalLink, FiHelpCircle } from 'react-icons/fi';
 
-interface HelpTipProps {
+export interface HelpTipProps {
   text: string;
+  href?: string;
+  linkLabel?: string;
 }
 
-export default function HelpTip({ text }: HelpTipProps): ReactElement {
+export default function HelpTip({ text, href, linkLabel }: HelpTipProps): ReactElement {
+  const tooltipClassName = href != null
+    ? 'absolute bottom-[calc(100%+0.5rem)] left-1/2 z-30 hidden w-64 -translate-x-1/2 rounded-2xl border border-border/80 bg-card/95 px-3 py-2 text-xs leading-5 text-card-foreground shadow-2xl backdrop-blur-sm group-hover:block group-focus-within:block'
+    : 'pointer-events-none absolute bottom-[calc(100%+0.5rem)] left-1/2 z-30 hidden w-56 -translate-x-1/2 rounded-2xl border border-border/80 bg-card/95 px-3 py-2 text-xs leading-5 text-card-foreground shadow-2xl backdrop-blur-sm group-hover:block group-focus-within:block';
+
   return (
     <span className="group relative inline-flex">
       <button
@@ -15,11 +21,19 @@ export default function HelpTip({ text }: HelpTipProps): ReactElement {
       >
         <FiHelpCircle aria-hidden="true" focusable="false" />
       </button>
-      <span
-        role="tooltip"
-        className="pointer-events-none absolute bottom-[calc(100%+0.5rem)] left-1/2 z-30 hidden w-56 -translate-x-1/2 rounded-2xl border border-border/80 bg-card/95 px-3 py-2 text-xs leading-5 text-card-foreground shadow-2xl backdrop-blur-sm group-hover:block group-focus-within:block"
-      >
-        {text}
+      <span role="tooltip" className={tooltipClassName}>
+        <span>{text}</span>
+        {href != null && (
+          <a
+            href={href}
+            target="_blank"
+            rel="noreferrer"
+            className="mt-2 inline-flex items-center gap-1 text-[11px] font-semibold text-primary underline-offset-4 hover:underline"
+          >
+            <span>{linkLabel ?? 'Open docs'}</span>
+            <FiExternalLink size={11} aria-hidden="true" />
+          </a>
+        )}
       </span>
     </span>
   );

--- a/dashboard/src/components/common/PageDocsLinks.tsx
+++ b/dashboard/src/components/common/PageDocsLinks.tsx
@@ -1,0 +1,34 @@
+import type { ReactElement } from 'react';
+
+import type { DocLink } from '../../lib/docsLinks';
+import { cn } from '../../lib/utils';
+import { DocsLinkAnchor } from './DocsLinkAnchor';
+
+export interface PageDocsLinksProps {
+  title?: string;
+  docs: DocLink[];
+  className?: string;
+}
+
+export function PageDocsLinks({
+  title = 'Relevant docs',
+  docs,
+  className,
+}: PageDocsLinksProps): ReactElement | null {
+  if (docs.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={cn('space-y-2', className)}>
+      <div className="text-[0.72rem] font-semibold uppercase tracking-[0.24em] text-primary/80">
+        {title}
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {docs.map((doc) => (
+          <DocsLinkAnchor key={doc.id} doc={doc} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/components/ide/IdeHeader.tsx
+++ b/dashboard/src/components/ide/IdeHeader.tsx
@@ -1,5 +1,7 @@
 import type { ReactElement } from 'react';
 import { FiCommand, FiFolder, FiMinus, FiPlus, FiSave } from 'react-icons/fi';
+import { PageDocsLinks } from '../common/PageDocsLinks';
+import { type DocLink, getDocLinks } from '../../lib/docsLinks';
 import { Badge } from '../ui/badge';
 import { Button } from '../ui/button';
 
@@ -17,6 +19,14 @@ export interface IdeHeaderProps {
   onDecreaseSidebarWidth: () => void;
 }
 
+function resolveIdeDocs(activeFileLabel: string | null): DocLink[] {
+  const normalizedLabel = activeFileLabel?.toLowerCase() ?? '';
+  if (normalizedLabel.endsWith('skill.md') || normalizedLabel.includes('/skills/')) {
+    return getDocLinks(['skills', 'mcp', 'dashboard']);
+  }
+  return getDocLinks(['dashboard', 'skills']);
+}
+
 export function IdeHeader({
   activeFileLabel,
   isMobileLayout,
@@ -30,6 +40,8 @@ export function IdeHeader({
   onIncreaseSidebarWidth,
   onDecreaseSidebarWidth,
 }: IdeHeaderProps): ReactElement {
+  const ideDocs = resolveIdeDocs(activeFileLabel);
+
   return (
     <div className="section-header flex flex-wrap items-start justify-between gap-3">
       <div className="min-w-0 flex-1">
@@ -37,6 +49,7 @@ export function IdeHeader({
         <p className="text-sm text-muted-foreground">
           Open a file, make a quick change, and save it back to the workspace.
         </p>
+        <PageDocsLinks title="Workspace docs" docs={ideDocs} className="mt-3" />
         {isMobileLayout && (
           <div className="mt-2 flex items-center gap-2 text-xs text-muted-foreground">
             <span className="font-semibold uppercase tracking-[0.16em]">Current file</span>

--- a/dashboard/src/components/layout/Topbar.tsx
+++ b/dashboard/src/components/layout/Topbar.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useAuthStore } from '../../store/authStore';
 import { useChatRuntimeStore } from '../../store/chatRuntimeStore';
 import { useChatSessionStore } from '../../store/chatSessionStore';
@@ -7,8 +7,9 @@ import { useSidebarStore } from '../../store/sidebarStore';
 import { useBackgroundSystemUpdateCheck } from '../../hooks/useBackgroundSystemUpdateCheck';
 import { useSystemUpdateStatus } from '../../hooks/useSystem';
 import { logout } from '../../api/auth';
+import { getPrimaryDocForPath } from '../../lib/docsLinks';
 import { type TopbarUpdateNotice, getTopbarUpdateNotice } from '../../utils/systemUpdateUi';
-import { FiArrowUpCircle, FiLogOut, FiMenu, FiMoon, FiSun } from 'react-icons/fi';
+import { FiArrowUpCircle, FiBookOpen, FiLogOut, FiMenu, FiMoon, FiSun } from 'react-icons/fi';
 
 interface ChatStatusState {
   trackedSessionId: string | null;
@@ -69,6 +70,7 @@ function TopbarUpdateShortcut({ notice, onClick }: { notice: TopbarUpdateNotice;
 }
 
 export default function Topbar() {
+  const location = useLocation();
   const nav = useNavigate();
   const doLogout = useAuthStore((s) => s.logout);
   const activeSessionId = useChatSessionStore((s) => s.activeSessionId);
@@ -83,6 +85,7 @@ export default function Topbar() {
   const { data: updateStatus } = useSystemUpdateStatus();
   const chatStatus = resolveChatStatus(activeSessionId, activeSession, runningSessionId, connectionState);
   const updateNotice = getTopbarUpdateNotice(updateStatus);
+  const primaryDoc = getPrimaryDocForPath(location.pathname);
 
   useBackgroundSystemUpdateCheck(updateStatus);
 
@@ -135,6 +138,20 @@ export default function Topbar() {
         )}
       </div>
       <div className="d-flex align-items-center gap-2">
+        {primaryDoc != null && (
+          <a
+            href={primaryDoc.url}
+            target="_blank"
+            rel="noreferrer"
+            className="topbar-action-btn text-decoration-none d-flex align-items-center px-3"
+            title={`Open ${primaryDoc.title} on docs.golemcore.me`}
+            aria-label={`Open ${primaryDoc.title} on docs.golemcore.me`}
+          >
+            <FiBookOpen size={16} className="me-0 me-lg-2" />
+            <span className="fw-medium small d-none d-lg-inline">{primaryDoc.shortLabel}</span>
+            <span className="fw-medium small d-lg-none">Docs</span>
+          </a>
+        )}
         {updateNotice != null && (
           <TopbarUpdateShortcut notice={updateNotice} onClick={handleOpenUpdates} />
         )}

--- a/dashboard/src/components/webhooks/ValidationIssuesAlert.tsx
+++ b/dashboard/src/components/webhooks/ValidationIssuesAlert.tsx
@@ -1,10 +1,15 @@
 import type { ReactElement } from 'react';
 import { Alert } from '../ui/tailwind-components';
+
 import type { WebhookValidationResult } from '../../api/webhooks';
+import { DocsLinkAnchor } from '../common/DocsLinkAnchor';
+import { getDocLink } from '../../lib/docsLinks';
 
 interface ValidationIssuesAlertProps {
   validation: WebhookValidationResult;
 }
+
+const WEBHOOKS_DOC = getDocLink('webhooks');
 
 export function ValidationIssuesAlert({ validation }: ValidationIssuesAlertProps): ReactElement | null {
   if (validation.valid) {
@@ -19,6 +24,11 @@ export function ValidationIssuesAlert({ validation }: ValidationIssuesAlertProps
           <li key={issue}>{issue}</li>
         ))}
       </ul>
+      <div className="mt-3">
+        <DocsLinkAnchor doc={WEBHOOKS_DOC} appearance="text">
+          Review the webhook guide
+        </DocsLinkAnchor>
+      </div>
     </Alert>
   );
 }

--- a/dashboard/src/components/webhooks/WebhooksPageHeader.tsx
+++ b/dashboard/src/components/webhooks/WebhooksPageHeader.tsx
@@ -2,6 +2,9 @@ import type { ReactElement } from 'react';
 import { Badge } from '../ui/tailwind-components';
 import { FiGlobe } from 'react-icons/fi';
 
+import { PageDocsLinks } from '../common/PageDocsLinks';
+import { getDocLinks } from '../../lib/docsLinks';
+
 export interface WebhookSummary {
   total: number;
   agent: number;
@@ -12,6 +15,8 @@ interface WebhooksPageHeaderProps {
   enabled: boolean;
   summary: WebhookSummary;
 }
+
+const WEBHOOK_DOCS = getDocLinks(['webhooks', 'dashboard']);
 
 export function WebhooksPageHeader({ enabled, summary }: WebhooksPageHeaderProps): ReactElement {
   return (
@@ -24,8 +29,9 @@ export function WebhooksPageHeader({ enabled, summary }: WebhooksPageHeaderProps
         <p className="text-body-secondary mb-0">
           Configure inbound HTTP hooks, authentication, templates, and delivery routes.
         </p>
+        <PageDocsLinks title="Relevant docs" docs={WEBHOOK_DOCS} className="mt-3" />
       </div>
-      <div className="d-flex flex-wrap gap-2">
+      <div className="d-flex flex-wrap gap-2 align-content-start">
         <Badge bg={enabled ? 'success' : 'secondary'}>
           {enabled ? 'Enabled' : 'Disabled'}
         </Badge>

--- a/dashboard/src/lib/docsLinks.ts
+++ b/dashboard/src/lib/docsLinks.ts
@@ -1,0 +1,259 @@
+import type { ReactElement } from 'react';
+
+const DOCS_BASE_URL = 'https://docs.golemcore.me';
+
+export type DocId =
+  | 'overview'
+  | 'quickstart'
+  | 'dashboard'
+  | 'model-routing'
+  | 'memory'
+  | 'memory-tuning'
+  | 'skills'
+  | 'plugins'
+  | 'mcp'
+  | 'auto-mode'
+  | 'delayed-actions'
+  | 'webhooks'
+  | 'configuration'
+  | 'deployment'
+  | 'architecture'
+  | 'troubleshooting';
+
+export interface DocDefinition {
+  title: string;
+  shortLabel: string;
+  path: string;
+}
+
+export interface DocLink extends DocDefinition {
+  id: DocId;
+  url: string;
+}
+
+interface PathDocsRule {
+  docs: readonly DocId[];
+  matches: (pathname: string) => boolean;
+}
+
+const DOC_DEFINITIONS: Record<DocId, DocDefinition> = {
+  overview: {
+    title: 'Overview',
+    shortLabel: 'Overview',
+    path: '/docs',
+  },
+  quickstart: {
+    title: 'Quickstart',
+    shortLabel: 'Quickstart',
+    path: '/docs/user-guide/quickstart',
+  },
+  dashboard: {
+    title: 'Dashboard',
+    shortLabel: 'Dashboard',
+    path: '/docs/user-guide/dashboard',
+  },
+  'model-routing': {
+    title: 'Model Routing',
+    shortLabel: 'Model Routing',
+    path: '/docs/user-guide/model-routing',
+  },
+  memory: {
+    title: 'Memory',
+    shortLabel: 'Memory',
+    path: '/docs/user-guide/memory',
+  },
+  'memory-tuning': {
+    title: 'Memory Tuning',
+    shortLabel: 'Memory Tuning',
+    path: '/docs/user-guide/memory-tuning',
+  },
+  skills: {
+    title: 'Skills',
+    shortLabel: 'Skills',
+    path: '/docs/user-guide/skills',
+  },
+  plugins: {
+    title: 'Plugins',
+    shortLabel: 'Plugins',
+    path: '/docs/user-guide/plugins',
+  },
+  mcp: {
+    title: 'MCP Servers',
+    shortLabel: 'MCP',
+    path: '/docs/user-guide/mcp',
+  },
+  'auto-mode': {
+    title: 'Auto Mode',
+    shortLabel: 'Auto Mode',
+    path: '/docs/user-guide/auto-mode',
+  },
+  'delayed-actions': {
+    title: 'Delayed Actions',
+    shortLabel: 'Delayed Actions',
+    path: '/docs/user-guide/delayed-actions',
+  },
+  webhooks: {
+    title: 'Webhooks',
+    shortLabel: 'Webhooks',
+    path: '/docs/user-guide/webhooks',
+  },
+  configuration: {
+    title: 'Configuration',
+    shortLabel: 'Configuration',
+    path: '/docs/user-guide/configuration',
+  },
+  deployment: {
+    title: 'Deployment',
+    shortLabel: 'Deployment',
+    path: '/docs/user-guide/deployment',
+  },
+  architecture: {
+    title: 'Architecture',
+    shortLabel: 'Architecture',
+    path: '/docs/developer-guide/architecture',
+  },
+  troubleshooting: {
+    title: 'Troubleshooting',
+    shortLabel: 'Troubleshooting',
+    path: '/docs/reference/troubleshooting',
+  },
+};
+
+const DEFAULT_SETTINGS_DOCS: readonly DocId[] = ['configuration', 'dashboard'];
+const SETTINGS_SECTION_DOCS: Record<string, readonly DocId[]> = {
+  general: ['dashboard', 'configuration'],
+  'llm-providers': ['quickstart', 'configuration'],
+  'model-catalog': ['quickstart', 'configuration'],
+  models: ['model-routing', 'configuration'],
+  'plugins-marketplace': ['plugins', 'configuration'],
+  'tool-filesystem': ['dashboard', 'configuration'],
+  'tool-shell': ['dashboard', 'configuration'],
+  'tool-automation': ['dashboard', 'configuration'],
+  'tool-goals': ['dashboard', 'configuration'],
+  'tool-voice': ['dashboard', 'configuration'],
+  memory: ['memory', 'memory-tuning'],
+  skills: ['skills', 'mcp'],
+  turn: ['dashboard', 'configuration'],
+  usage: ['dashboard', 'configuration'],
+  telemetry: ['dashboard', 'configuration'],
+  tracing: ['dashboard', 'configuration'],
+  mcp: ['mcp', 'skills'],
+  hive: ['architecture', 'configuration'],
+  'self-evolving': ['architecture', 'dashboard'],
+  plan: ['auto-mode', 'delayed-actions'],
+  auto: ['auto-mode', 'delayed-actions'],
+  updates: ['deployment', 'configuration'],
+  'advanced-rate-limit': ['configuration', 'troubleshooting'],
+  'advanced-security': ['configuration', 'troubleshooting'],
+  'advanced-compaction': ['configuration', 'troubleshooting'],
+};
+const PATH_DOC_RULES: PathDocsRule[] = [
+  {
+    docs: ['dashboard', 'quickstart'],
+    matches: (pathname) => pathname === '/' || pathname.startsWith('/chat'),
+  },
+  {
+    docs: ['quickstart', 'dashboard', 'configuration'],
+    matches: (pathname) => pathname === '/setup',
+  },
+  {
+    docs: ['skills', 'mcp'],
+    matches: (pathname) => pathname.startsWith('/skills'),
+  },
+  {
+    docs: ['webhooks', 'dashboard'],
+    matches: (pathname) => pathname.startsWith('/webhooks'),
+  },
+  {
+    docs: ['dashboard', 'skills'],
+    matches: (pathname) => pathname.startsWith('/ide'),
+  },
+  {
+    docs: ['auto-mode', 'delayed-actions'],
+    matches: (pathname) => pathname.startsWith('/scheduler') || pathname.startsWith('/goals'),
+  },
+  {
+    docs: ['dashboard', 'troubleshooting'],
+    matches: (pathname) => pathname.startsWith('/logs')
+      || pathname.startsWith('/sessions')
+      || pathname.startsWith('/analytics')
+      || pathname.startsWith('/diagnostics'),
+  },
+  {
+    docs: ['dashboard', 'configuration'],
+    matches: (pathname) => pathname.startsWith('/prompts'),
+  },
+  {
+    docs: ['architecture', 'dashboard'],
+    matches: (pathname) => pathname.startsWith('/self-evolving'),
+  },
+];
+
+function normalizePath(pathname: string): string {
+  if (pathname.length > 1 && pathname.endsWith('/')) {
+    return pathname.slice(0, -1);
+  }
+  return pathname;
+}
+
+function dedupeDocIds(docIds: readonly DocId[]): DocId[] {
+  const seen = new Set<DocId>();
+  return docIds.filter((docId) => {
+    if (seen.has(docId)) {
+      return false;
+    }
+    seen.add(docId);
+    return true;
+  });
+}
+
+function cloneDocIds(docIds: readonly DocId[]): DocId[] {
+  return [...docIds];
+}
+
+export function getDocLink(docId: DocId): DocLink {
+  const definition = DOC_DEFINITIONS[docId];
+  return {
+    id: docId,
+    title: definition.title,
+    shortLabel: definition.shortLabel,
+    path: definition.path,
+    url: `${DOCS_BASE_URL}${definition.path}`,
+  };
+}
+
+export function getDocLinks(docIds: readonly DocId[]): DocLink[] {
+  return dedupeDocIds(docIds).map((docId) => getDocLink(docId));
+}
+
+export function getDocsForSettingsSection(section: string | null | undefined): DocId[] {
+  if (section == null) {
+    return cloneDocIds(DEFAULT_SETTINGS_DOCS);
+  }
+
+  return cloneDocIds(SETTINGS_SECTION_DOCS[section] ?? DEFAULT_SETTINGS_DOCS);
+}
+
+export function getDocsForPath(pathname: string): DocId[] {
+  const normalizedPath = normalizePath(pathname);
+  if (normalizedPath.startsWith('/settings')) {
+    return getDocsForSettingsSection(normalizedPath.split('/')[2] ?? null);
+  }
+
+  const matchedRule = PATH_DOC_RULES.find((rule) => rule.matches(normalizedPath));
+  if (matchedRule != null) {
+    return cloneDocIds(matchedRule.docs);
+  }
+
+  return ['overview'];
+}
+
+export function getPrimaryDocForPath(pathname: string): DocLink | null {
+  const docs = getDocLinks(getDocsForPath(pathname));
+  return docs[0] ?? null;
+}
+
+export interface DocsRouteMatch {
+  doc: DocLink;
+  renderLabel: () => ReactElement | string;
+}

--- a/dashboard/src/pages/SettingsPage.tsx
+++ b/dashboard/src/pages/SettingsPage.tsx
@@ -1,6 +1,8 @@
 import { useDeferredValue, useEffect, useState, type ReactElement } from 'react';
 import { Card, Button, Spinner, Placeholder } from '../components/ui/tailwind-components';
 import { useNavigate, useParams } from 'react-router-dom';
+import { PageDocsLinks } from '../components/common/PageDocsLinks';
+import { getDocLinks, getDocsForSettingsSection } from '../lib/docsLinks';
 import {
   useSettings, useRuntimeConfig, useUpdateRuntimeConfig,
 } from '../hooks/useSettings';
@@ -42,7 +44,8 @@ import { SettingsCatalogView, type CatalogBlockView } from './settings/SettingsC
 import { buildCatalogBlocks, buildMarketplaceBadge, resolveSectionMeta } from './settings/SettingsPageState';
 import { useTelemetry } from '../lib/telemetry/TelemetryContext';
 
-// ==================== Main ====================
+const SETTINGS_CATALOG_DOCS = getDocLinks(['configuration', 'dashboard', 'quickstart']);
+const PLUGIN_SETTINGS_DOCS = getDocLinks(['plugins', 'configuration']);
 
 export default function SettingsPage(): ReactElement {
   const navigate = useNavigate();
@@ -74,6 +77,11 @@ export default function SettingsPage(): ReactElement {
 
   const sectionMeta = resolveSectionMeta(staticSection, pluginSection);
   const selectedSectionKey = staticSection ?? pluginSection?.routeKey ?? 'catalog';
+  const sectionDocs = staticSection != null
+    ? getDocLinks(getDocsForSettingsSection(staticSection))
+    : pluginSection != null
+      ? PLUGIN_SETTINGS_DOCS
+      : SETTINGS_CATALOG_DOCS;
 
   const catalogBlocks: CatalogBlockView[] = buildCatalogBlocks(pluginCatalog, marketplaceBadge);
   const filteredCatalogBlocks = filterCatalogBlocks(catalogBlocks, deferredCatalogSearch);
@@ -94,6 +102,7 @@ export default function SettingsPage(): ReactElement {
         <div className="page-header">
           <h4>Settings</h4>
           <p className="text-body-secondary mb-0">Configure your GolemCore instance</p>
+          <PageDocsLinks title="Key guides" docs={SETTINGS_CATALOG_DOCS} className="mt-3" />
         </div>
         <Card className="settings-card">
           <Card.Body>
@@ -112,6 +121,7 @@ export default function SettingsPage(): ReactElement {
   if (staticSection == null && pluginSection == null) {
     return (
       <SettingsCatalogView
+        docs={SETTINGS_CATALOG_DOCS}
         catalogSearch={catalogSearch}
         filteredCatalogBlocks={filteredCatalogBlocks}
         onSearchChange={(value) => {
@@ -129,8 +139,9 @@ export default function SettingsPage(): ReactElement {
       <div className="page-header">
         <h4>{sectionMeta?.title ?? 'Settings'}</h4>
         <p className="text-body-secondary mb-0">{sectionMeta?.description ?? 'Configure your GolemCore instance'}</p>
+        <PageDocsLinks title="Relevant docs" docs={sectionDocs} className="mt-3" />
       </div>
-      <div className="mb-3">
+      <div className="mb-3 d-flex flex-wrap gap-2">
         <Button type="button" variant="secondary" size="sm" onClick={() => navigate('/settings')}>
           Back to catalog
         </Button>

--- a/dashboard/src/pages/SetupPage.tsx
+++ b/dashboard/src/pages/SetupPage.tsx
@@ -1,6 +1,8 @@
 import type { ReactElement } from 'react';
 import { Alert, Badge, Button, Card, Spinner } from '../components/ui/tailwind-components';
 import { useNavigate } from 'react-router-dom';
+import { PageDocsLinks } from '../components/common/PageDocsLinks';
+import { getDocLinks } from '../lib/docsLinks';
 import { useRuntimeConfig } from '../hooks/useSettings';
 import { extractErrorMessage } from '../utils/extractErrorMessage';
 import {
@@ -17,6 +19,8 @@ interface SetupStepCardProps {
   actionLabel: string;
   onAction: () => void;
 }
+
+const SETUP_DOCS = getDocLinks(['quickstart', 'dashboard', 'configuration']);
 
 function SetupStepCard({
   step,
@@ -57,6 +61,18 @@ function SetupLoadingState(): ReactElement {
   );
 }
 
+function SetupHeader(): ReactElement {
+  return (
+    <div className="page-header">
+      <h4>Startup Setup Wizard</h4>
+      <p className="text-body-secondary mb-0">
+        Finish recommended startup configuration for reliable model routing and responses.
+      </p>
+      <PageDocsLinks title="Start here" docs={SETUP_DOCS} className="mt-3" />
+    </div>
+  );
+}
+
 function getErrorMessage(error: unknown, fallback: string): string {
   const message = extractErrorMessage(error);
   return message === 'Unknown error' ? fallback : message;
@@ -68,14 +84,22 @@ export default function SetupPage(): ReactElement {
   const runtimeConfig = runtimeConfigQuery.data;
 
   if (runtimeConfigQuery.isLoading) {
-    return <SetupLoadingState />;
+    return (
+      <div>
+        <SetupHeader />
+        <SetupLoadingState />
+      </div>
+    );
   }
 
   if (runtimeConfig == null) {
     return (
-      <Alert variant="danger" className="mb-0">
-        {getErrorMessage(runtimeConfigQuery.error, 'Failed to load runtime configuration.')}
-      </Alert>
+      <div>
+        <SetupHeader />
+        <Alert variant="danger" className="mb-0">
+          {getErrorMessage(runtimeConfigQuery.error, 'Failed to load runtime configuration.')}
+        </Alert>
+      </div>
     );
   }
 
@@ -86,12 +110,7 @@ export default function SetupPage(): ReactElement {
 
   return (
     <div>
-      <div className="page-header">
-        <h4>Startup Setup Wizard</h4>
-        <p className="text-body-secondary mb-0">
-          Finish recommended startup configuration for reliable model routing and responses.
-        </p>
-      </div>
+      <SetupHeader />
 
       {runtimeConfigQuery.error != null && (
         <Alert variant="warning">

--- a/dashboard/src/pages/SkillsPage.tsx
+++ b/dashboard/src/pages/SkillsPage.tsx
@@ -4,10 +4,12 @@ import { useSearchParams } from 'react-router-dom';
 import toast from 'react-hot-toast';
 import type { SkillInfo, SkillUpdateRequest } from '../api/skills';
 import ConfirmModal from '../components/common/ConfirmModal';
+import { PageDocsLinks } from '../components/common/PageDocsLinks';
 import { Button } from '../components/ui/button';
 import { Input } from '../components/ui/field';
 import { Modal } from '../components/ui/overlay';
 import { Card, CardContent } from '../components/ui/card';
+import { getDocLinks } from '../lib/docsLinks';
 import { cn } from '../lib/utils';
 import {
   useCreateSkill,
@@ -28,6 +30,7 @@ model_tier: balanced
 `;
 const SKILL_NAME_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
 const SKILLS_TAB_QUERY_PARAM = 'tab';
+const SKILLS_DOCS = getDocLinks(['skills', 'mcp', 'dashboard']);
 
 type SkillsTabKey = 'local' | 'marketplace';
 
@@ -204,6 +207,7 @@ export default function SkillsPage(): ReactElement {
             <p className="mt-1 max-w-3xl text-sm leading-6 text-muted-foreground">
               Manage local skills and install maintained artifacts from one workspace.
             </p>
+            <PageDocsLinks title="Relevant docs" docs={SKILLS_DOCS} className="mt-3" />
           </div>
         </div>
 

--- a/dashboard/src/pages/settings/ModelsTab.tsx
+++ b/dashboard/src/pages/settings/ModelsTab.tsx
@@ -3,6 +3,7 @@ import toast from 'react-hot-toast';
 import { useNavigate } from 'react-router-dom';
 import HelpTip from '../../components/common/HelpTip';
 import SettingsCardTitle from '../../components/common/SettingsCardTitle';
+import { DocsLinkAnchor } from '../../components/common/DocsLinkAnchor';
 import type { HiveStatusResponse } from '../../api/hive';
 import type { AvailableModel } from '../../api/models';
 import { modelReferenceFromSpec, modelReferenceToSpec } from '../../api/settings';
@@ -10,6 +11,7 @@ import type { LlmConfig, ModelRouterConfig } from '../../api/settingsTypes';
 import { useUpdateModelRouter } from '../../hooks/useSettings';
 import { useAvailableModels } from '../../hooks/useModels';
 import { useBeforeUnloadGuard } from '../../hooks/useBeforeUnloadGuard';
+import { getDocLink } from '../../lib/docsLinks';
 import { toEditorModelIdForProvider } from '../../lib/providerModelIds';
 import { cloneModelRouterConfig, getTierBinding, updateTierBinding } from '../../lib/modelRouter';
 import {
@@ -45,13 +47,77 @@ interface TierCardConfig {
   allowEmptyModel: boolean;
 }
 
+interface GlobalSettingsCardProps {
+  dynamicTierEnabled: boolean;
+  onDynamicTierEnabledChange: (enabled: boolean) => void;
+}
+
+interface NoProvidersNoticeProps {
+  isVisible: boolean;
+}
+
 const EMPTY_AVAILABLE_MODELS: Record<string, AvailableModel[]> = {};
+const MODEL_ROUTING_DOC = getDocLink('model-routing');
+const PROVIDER_SETUP_DOC = getDocLink('configuration');
 const TIER_CARDS: TierCardConfig[] = EXPLICIT_MODEL_TIER_ORDER.map((tier) => ({
   key: tier,
   label: MODEL_TIER_META[tier].label,
   color: MODEL_TIER_META[tier].settingsCardColor,
   allowEmptyModel: allowsEmptyModelSelection(tier),
 }));
+
+function GlobalSettingsCard({
+  dynamicTierEnabled,
+  onDynamicTierEnabledChange,
+}: GlobalSettingsCardProps): ReactElement {
+  return (
+    <Card className="settings-card mb-3">
+      <Card.Body>
+        <SettingsCardTitle title="Global Settings" />
+        <Row className="g-3">
+          <Col md={6} className="d-flex align-items-end">
+            <Form.Check
+              type="switch"
+              label={<>
+                Dynamic tier upgrade{' '}
+                <HelpTip
+                  text="Automatically upgrade to coding tier when code-related activity is detected mid-conversation"
+                  href={MODEL_ROUTING_DOC.url}
+                  linkLabel="Read Model Routing docs"
+                />
+              </>}
+              checked={dynamicTierEnabled}
+              onChange={(event) => onDynamicTierEnabledChange(event.target.checked)}
+            />
+          </Col>
+        </Row>
+      </Card.Body>
+    </Card>
+  );
+}
+
+function NoProvidersNotice({ isVisible }: NoProvidersNoticeProps): ReactElement | null {
+  if (!isVisible) {
+    return null;
+  }
+
+  return (
+    <Col xs={12}>
+      <Card className="settings-card">
+        <Card.Body className="py-2">
+          <small className="text-body-secondary d-block">
+            No LLM providers with API keys configured. Add a provider with an API key in the LLM Providers tab to select models here.
+          </small>
+          <div className="mt-2">
+            <DocsLinkAnchor doc={PROVIDER_SETUP_DOC} appearance="text">
+              Open provider setup guide
+            </DocsLinkAnchor>
+          </div>
+        </Card.Body>
+      </Card>
+    </Col>
+  );
+}
 
 export default function ModelsTab({ config, llmConfig, hiveStatus }: ModelsTabProps): ReactElement {
   const navigate = useNavigate();
@@ -129,34 +195,13 @@ export default function ModelsTab({ config, llmConfig, hiveStatus }: ModelsTabPr
       ) : null}
 
       <fieldset disabled={managedPolicy != null} className="border-0 m-0 p-0">
-        <Card className="settings-card mb-3">
-          <Card.Body>
-            <SettingsCardTitle title="Global Settings" />
-            <Row className="g-3">
-              <Col md={6} className="d-flex align-items-end">
-                <Form.Check
-                  type="switch"
-                  label={<>Dynamic tier upgrade <HelpTip text="Automatically upgrade to coding tier when code-related activity is detected mid-conversation" /></>}
-                  checked={form.dynamicTierEnabled ?? true}
-                  onChange={(e) => setForm({ ...form, dynamicTierEnabled: e.target.checked })}
-                />
-              </Col>
-            </Row>
-          </Card.Body>
-        </Card>
+        <GlobalSettingsCard
+          dynamicTierEnabled={form.dynamicTierEnabled ?? true}
+          onDynamicTierEnabledChange={(dynamicTierEnabled) => setForm({ ...form, dynamicTierEnabled })}
+        />
 
         <Row className="g-3 mb-3">
-          {providerNames.length === 0 && (
-            <Col xs={12}>
-              <Card className="settings-card">
-                <Card.Body className="py-2">
-                  <small className="text-body-secondary">
-                    No LLM providers with API keys configured. Add a provider with an API key in the LLM Providers tab to select models here.
-                  </small>
-                </Card.Body>
-              </Card>
-            </Col>
-          )}
+          <NoProvidersNotice isVisible={providerNames.length === 0} />
 
           <Col sm={6} lg={3}>
             <TierModelCard

--- a/dashboard/src/pages/settings/SettingsCatalogView.tsx
+++ b/dashboard/src/pages/settings/SettingsCatalogView.tsx
@@ -2,7 +2,11 @@ import type { ReactElement } from 'react';
 import { Badge, Button, Card, Col, Form, InputGroup, Row } from '../../components/ui/tailwind-components';
 import { FiSearch, FiX } from 'react-icons/fi';
 
+import { DocsLinkAnchor } from '../../components/common/DocsLinkAnchor';
+import { PageDocsLinks } from '../../components/common/PageDocsLinks';
+import type { DocLink } from '../../lib/docsLinks';
 import type { SettingsSectionMeta } from './settingsCatalog';
+import { SettingsIntentCards } from './SettingsIntentCards';
 
 export interface CatalogCardItem {
   key: string;
@@ -23,6 +27,7 @@ export interface CatalogBlockView {
 }
 
 interface SettingsCatalogViewProps {
+  docs: DocLink[];
   catalogSearch: string;
   filteredCatalogBlocks: CatalogBlockView[];
   onSearchChange: (value: string) => void;
@@ -31,6 +36,7 @@ interface SettingsCatalogViewProps {
 }
 
 export function SettingsCatalogView({
+  docs,
   catalogSearch,
   filteredCatalogBlocks,
   onSearchChange,
@@ -39,10 +45,29 @@ export function SettingsCatalogView({
 }: SettingsCatalogViewProps): ReactElement {
   return (
     <div>
-      <div className="page-header"><h4>Settings</h4><p className="text-body-secondary mb-0">Select a settings category</p></div>
-      <Card className="settings-card mb-4"><Card.Body><SettingsCatalogSearch catalogSearch={catalogSearch} onSearchChange={onSearchChange} onClearSearch={onClearSearch} /></Card.Body></Card>
+      <div className="page-header">
+        <h4>Settings</h4>
+        <p className="text-body-secondary mb-0">Select a settings category</p>
+        <PageDocsLinks title="Key guides" docs={docs} className="mt-3" />
+      </div>
+      <SettingsIntentCards onOpenSection={onOpenSection} />
+      <Card className="settings-card mb-4">
+        <Card.Body>
+          <SettingsCatalogSearch catalogSearch={catalogSearch} onSearchChange={onSearchChange} onClearSearch={onClearSearch} />
+        </Card.Body>
+      </Card>
       {filteredCatalogBlocks.length === 0 ? (
-        <Card className="settings-card"><Card.Body><h2 className="h6 mb-2">Nothing found</h2><p className="text-body-secondary small mb-0">No settings match `{catalogSearch}`. Try another name or clear the search.</p></Card.Body></Card>
+        <Card className="settings-card">
+          <Card.Body>
+            <h2 className="h6 mb-2">Nothing found</h2>
+            <p className="text-body-secondary small mb-3">
+              No settings match `{catalogSearch}`. Try another name or clear the search.
+            </p>
+            <DocsLinkAnchor doc={docs[0]} appearance="text">
+              Open the main settings guide
+            </DocsLinkAnchor>
+          </Card.Body>
+        </Card>
       ) : filteredCatalogBlocks.map((block) => <SettingsCatalogBlock key={block.key} block={block} onOpenSection={onOpenSection} />)}
     </div>
   );

--- a/dashboard/src/pages/settings/SettingsIntentCards.tsx
+++ b/dashboard/src/pages/settings/SettingsIntentCards.tsx
@@ -1,0 +1,108 @@
+import type { ReactElement } from 'react';
+import { Card, Button } from '../../components/ui/tailwind-components';
+
+import { DocsLinkAnchor } from '../../components/common/DocsLinkAnchor';
+import { getDocLinks, type DocId, type DocLink } from '../../lib/docsLinks';
+
+export interface SettingsIntentCard {
+  key: string;
+  title: string;
+  description: string;
+  routeKey: string;
+  docs: DocLink[];
+}
+
+export interface SettingsIntentCardsProps {
+  onOpenSection: (routeKey: string) => void;
+}
+
+function buildIntentCards(): SettingsIntentCard[] {
+  const cardDefinitions: Array<{
+    key: string;
+    title: string;
+    description: string;
+    routeKey: string;
+    docs: DocId[];
+  }> = [
+    {
+      key: 'connect-model',
+      title: 'Connect my first model',
+      description: 'Add a provider key and make the runtime ready for its first chat turn.',
+      routeKey: 'llm-providers',
+      docs: ['quickstart', 'configuration'],
+    },
+    {
+      key: 'route-models',
+      title: 'Configure routing and fallbacks',
+      description: 'Choose which concrete models power routing, coding, and deep analysis tiers.',
+      routeKey: 'models',
+      docs: ['model-routing', 'configuration'],
+    },
+    {
+      key: 'tune-memory',
+      title: 'Tune long-term memory',
+      description: 'Control recall depth, budgets, and presets before memory becomes noisy.',
+      routeKey: 'memory',
+      docs: ['memory', 'memory-tuning'],
+    },
+    {
+      key: 'install-skills',
+      title: 'Install skills and MCP tools',
+      description: 'Use the marketplace and skill runtime controls to add focused capabilities.',
+      routeKey: 'skills',
+      docs: ['skills', 'mcp'],
+    },
+    {
+      key: 'enable-auto-mode',
+      title: 'Enable autonomous runs',
+      description: 'Turn on goals, schedules, and delayed follow-ups for recurring workflows.',
+      routeKey: 'auto',
+      docs: ['auto-mode', 'delayed-actions'],
+    },
+  ];
+
+  return cardDefinitions.map((card) => ({
+    key: card.key,
+    title: card.title,
+    description: card.description,
+    routeKey: card.routeKey,
+    docs: getDocLinks(card.docs),
+  }));
+}
+
+const SETTINGS_INTENT_CARDS = buildIntentCards();
+
+export function SettingsIntentCards({ onOpenSection }: SettingsIntentCardsProps): ReactElement {
+  return (
+    <div className="mb-4">
+      <div className="mb-2">
+        <h2 className="h6 mb-1">What are you trying to do?</h2>
+        <p className="text-body-secondary small mb-0">
+          Jump straight to the right settings section and the matching documentation guide.
+        </p>
+      </div>
+      <div className="row g-3">
+        {SETTINGS_INTENT_CARDS.map((card) => (
+          <div key={card.key} className="col-sm-6 col-xl-4">
+            <Card className="settings-card h-100">
+              <Card.Body className="d-flex flex-column gap-3">
+                <div>
+                  <h3 className="h6 mb-2">{card.title}</h3>
+                  <p className="text-body-secondary small mb-0">{card.description}</p>
+                </div>
+                <div className="d-flex flex-wrap gap-2 mt-auto">
+                  <Button type="button" size="sm" variant="primary" onClick={() => onOpenSection(card.routeKey)}>
+                    Open section
+                  </Button>
+                  {card.docs.map((doc) => (
+                    <DocsLinkAnchor key={doc.id} doc={doc} />
+                  ))}
+                </div>
+              </Card.Body>
+            </Card>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/pages/skills/LocalSkillsPanel.tsx
+++ b/dashboard/src/pages/skills/LocalSkillsPanel.tsx
@@ -1,10 +1,12 @@
 import type { ReactElement } from 'react';
 import { FiArrowRight } from 'react-icons/fi';
 import type { SkillInfo, SkillUpdateRequest } from '../../api/skills';
+import { DocsLinkAnchor } from '../../components/common/DocsLinkAnchor';
 import { Badge } from '../../components/ui/badge';
 import { Button } from '../../components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../../components/ui/card';
 import { Input } from '../../components/ui/field';
+import { getDocLink } from '../../lib/docsLinks';
 import { cn } from '../../lib/utils';
 import { LocalSkillDetailPane } from './LocalSkillDetailPane';
 
@@ -25,14 +27,21 @@ interface LocalSkillsPanelProps {
   deletePending: boolean;
 }
 
+const SKILLS_DOC = getDocLink('skills');
+
 function EmptyState({ onOpenMarketplace }: { onOpenMarketplace: () => void }): ReactElement {
   return (
     <div className="rounded-2xl border border-dashed border-border/80 bg-muted/20 px-4 py-8 text-center">
       <p className="text-sm text-muted-foreground">No skills match this filter.</p>
-      <Button type="button" variant="link" className="mt-2" onClick={onOpenMarketplace}>
-        Open marketplace
-        <FiArrowRight size={14} />
-      </Button>
+      <div className="mt-2 flex flex-wrap items-center justify-center gap-3">
+        <Button type="button" variant="link" onClick={onOpenMarketplace}>
+          Open marketplace
+          <FiArrowRight size={14} />
+        </Button>
+        <DocsLinkAnchor doc={SKILLS_DOC} appearance="text">
+          How skills work
+        </DocsLinkAnchor>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add a centralized dashboard docs link registry for docs.golemcore.me route mapping
- add contextual docs entry points in the topbar and key dashboard pages
- surface targeted docs links in settings intent cards, help tips, and empty or validation states
