### PR TITLE
refactor(dashboard): redesign workspace chat toolbar header

### DIFF
--- a/dashboard/src/components/chat/ChatToolbar.test.tsx
+++ b/dashboard/src/components/chat/ChatToolbar.test.tsx
@@ -194,6 +194,55 @@ describe('ChatToolbar', () => {
     unmountHarness(harness);
   });
 
+  it('disables the memory selector while presets are loading', () => {
+    const harness = mountHarness(
+      <ChatToolbar
+        {...baseProps()}
+        embedded
+        tier="balanced"
+        tierForce={false}
+        memoryPreset=""
+        memoryPresetOptions={[]}
+        memoryPresetsLoading
+        onTierChange={vi.fn()}
+        onForceChange={vi.fn()}
+        onMemoryPresetChange={vi.fn()}
+      />,
+    );
+    const select = getRequiredSelect(
+      harness.container,
+      '[data-testid="chat-toolbar-memory-preset-select"]',
+    );
+    expect(select.disabled).toBe(true);
+    const placeholderOption = select.querySelector('option[value=""]');
+    expect(placeholderOption?.textContent).toBe('Loading memory');
+    unmountHarness(harness);
+  });
+
+  it('shows the inherited global memory label in the placeholder when no preset is selected', () => {
+    const harness = mountHarness(
+      <ChatToolbar
+        {...baseProps()}
+        embedded
+        tier="balanced"
+        tierForce={false}
+        memoryPreset=""
+        memoryPresetOptions={[{ id: 'coding_balanced', label: 'Coding balanced' }]}
+        inheritedMemoryPresetLabel="Coding balanced"
+        onTierChange={vi.fn()}
+        onForceChange={vi.fn()}
+        onMemoryPresetChange={vi.fn()}
+      />,
+    );
+    const select = getRequiredSelect(
+      harness.container,
+      '[data-testid="chat-toolbar-memory-preset-select"]',
+    );
+    const placeholderOption = select.querySelector('option[value=""]');
+    expect(placeholderOption?.textContent).toBe('Global memory (Coding balanced)');
+    unmountHarness(harness);
+  });
+
   it('fires onMemoryPresetChange when the embedded memory selector changes', () => {
     const onMemoryPresetChange = vi.fn();
     const harness = mountHarness(

--- a/dashboard/src/components/chat/ChatToolbar.tsx
+++ b/dashboard/src/components/chat/ChatToolbar.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from 'react';
-import { FiLayout, FiMessageSquare, FiPlus } from 'react-icons/fi';
+import { FiCpu, FiDatabase, FiLayout, FiMessageSquare, FiPlus } from 'react-icons/fi';
 import { getExplicitModelTierOptions } from '../../lib/modelTiers';
 
 export interface MemoryPresetOption {
@@ -29,42 +29,108 @@ export interface ChatToolbarProps {
  * Toolbar shown above the workspace chat, with chat/session actions and optional
  * embedded model controls.
  */
-export function ChatToolbar({
-  chatSessionId,
+export function ChatToolbar(props: ChatToolbarProps): ReactElement {
+  const sessionShort = props.chatSessionId.slice(0, 8);
+  if (props.embedded === true) {
+    return (
+      <EmbeddedToolbar
+        connected={props.connected}
+        sessionShort={sessionShort}
+        onNewChat={props.onNewChat}
+        tier={props.tier ?? 'balanced'}
+        tierForce={props.tierForce === true}
+        memoryPreset={props.memoryPreset ?? ''}
+        memoryPresetOptions={props.memoryPresetOptions ?? []}
+        memoryPresetsLoading={props.memoryPresetsLoading === true}
+        inheritedMemoryPresetLabel={props.inheritedMemoryPresetLabel ?? null}
+        onTierChange={props.onTierChange}
+        onForceChange={props.onForceChange}
+        onMemoryPresetChange={props.onMemoryPresetChange}
+      />
+    );
+  }
+  return (
+    <StandaloneToolbar
+      connected={props.connected}
+      sessionShort={sessionShort}
+      panelOpen={props.panelOpen}
+      onNewChat={props.onNewChat}
+      onToggleContext={props.onToggleContext}
+    />
+  );
+}
+
+interface TierControlsValues {
+  tier: string;
+  tierForce: boolean;
+  memoryPreset: string;
+  memoryPresetOptions: MemoryPresetOption[];
+  memoryPresetsLoading: boolean;
+  inheritedMemoryPresetLabel: string | null;
+  onTierChange?: (tier: string) => void;
+  onForceChange?: (force: boolean) => void;
+  onMemoryPresetChange?: (preset: string) => void;
+}
+
+interface EmbeddedToolbarProps extends TierControlsValues {
+  connected: boolean;
+  sessionShort: string;
+  onNewChat: () => void;
+}
+
+function EmbeddedToolbar(props: EmbeddedToolbarProps): ReactElement {
+  return (
+    <div className="chat-toolbar chat-toolbar--embedded">
+      <div className="chat-toolbar-inner">
+        <CompactStatus connected={props.connected} sessionShort={props.sessionShort} />
+        <div className="chat-toolbar-actions">
+          <EmbeddedTierControls
+            tier={props.tier}
+            tierForce={props.tierForce}
+            memoryPreset={props.memoryPreset}
+            memoryPresetOptions={props.memoryPresetOptions}
+            memoryPresetsLoading={props.memoryPresetsLoading}
+            inheritedMemoryPresetLabel={props.inheritedMemoryPresetLabel}
+            onTierChange={props.onTierChange}
+            onForceChange={props.onForceChange}
+            onMemoryPresetChange={props.onMemoryPresetChange}
+          />
+          <button
+            type="button"
+            className="chat-toolbar-icon-btn"
+            onClick={props.onNewChat}
+            title="Start a new chat session"
+            aria-label="Start a new chat session"
+          >
+            <FiPlus size={14} aria-hidden="true" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface StandaloneToolbarProps {
+  connected: boolean;
+  sessionShort: string;
+  panelOpen: boolean;
+  onNewChat: () => void;
+  onToggleContext: () => void;
+}
+
+function StandaloneToolbar({
   connected,
+  sessionShort,
   panelOpen,
   onNewChat,
   onToggleContext,
-  embedded = false,
-  tier,
-  tierForce = false,
-  memoryPreset = '',
-  memoryPresetOptions = [],
-  memoryPresetsLoading = false,
-  inheritedMemoryPresetLabel = null,
-  onTierChange,
-  onForceChange,
-  onMemoryPresetChange,
-}: ChatToolbarProps): ReactElement {
+}: StandaloneToolbarProps): ReactElement {
   return (
     <div className="chat-toolbar">
       <div className="chat-toolbar-inner">
-        <div className="chat-toolbar-main">
-          <div className="chat-toolbar-title-group">
-            <div className="chat-toolbar-title">
-              <FiMessageSquare aria-hidden="true" />
-              <span>Workspace Chat</span>
-            </div>
-            <small className="chat-toolbar-subtitle">
-              Session: <span className="font-mono">{chatSessionId.slice(0, 8)}</span>
-            </small>
-          </div>
-          <div className="chat-toolbar-status" aria-live="polite">
-            <span className={`status-dot ${connected ? 'online' : 'offline'}`} aria-hidden="true" />
-            <small className="text-body-secondary">{connected ? 'Connected' : 'Reconnecting...'}</small>
-          </div>
-        </div>
+        <StandaloneHeader connected={connected} sessionShort={sessionShort} />
         <div className="chat-toolbar-actions">
+          <ContextToggleButton panelOpen={panelOpen} onToggleContext={onToggleContext} />
           <button
             type="button"
             className="btn btn-sm btn-secondary chat-toolbar-btn"
@@ -77,50 +143,77 @@ export function ChatToolbar({
             </span>
             <span>New chat</span>
           </button>
-          {embedded ? (
-            <EmbeddedTierControls
-              tier={tier ?? 'balanced'}
-              tierForce={tierForce}
-              memoryPreset={memoryPreset}
-              memoryPresetOptions={memoryPresetOptions}
-              memoryPresetsLoading={memoryPresetsLoading}
-              inheritedMemoryPresetLabel={inheritedMemoryPresetLabel}
-              onTierChange={onTierChange}
-              onForceChange={onForceChange}
-              onMemoryPresetChange={onMemoryPresetChange}
-            />
-          ) : (
-            <button
-              type="button"
-              className="btn btn-sm btn-secondary chat-toolbar-btn panel-toggle-btn"
-              onClick={onToggleContext}
-              title={panelOpen ? 'Hide context panel' : 'Show context panel'}
-              aria-label={panelOpen ? 'Hide context panel' : 'Show context panel'}
-              data-testid="chat-toolbar-context-toggle"
-            >
-              <span className="chat-toolbar-btn-icon" aria-hidden="true">
-                <FiLayout size={14} />
-              </span>
-              <span>{panelOpen ? 'Hide context' : 'Show context'}</span>
-            </button>
-          )}
         </div>
       </div>
     </div>
   );
 }
 
-interface EmbeddedTierControlsProps {
-  tier: string;
-  tierForce: boolean;
-  memoryPreset: string;
-  memoryPresetOptions: MemoryPresetOption[];
-  memoryPresetsLoading: boolean;
-  inheritedMemoryPresetLabel: string | null;
-  onTierChange?: (tier: string) => void;
-  onForceChange?: (force: boolean) => void;
-  onMemoryPresetChange?: (preset: string) => void;
+interface StatusProps {
+  connected: boolean;
+  sessionShort: string;
 }
+
+function CompactStatus({ connected, sessionShort }: StatusProps): ReactElement {
+  const label = connected ? `Connected — session ${sessionShort}` : 'Reconnecting...';
+  return (
+    <div
+      className="chat-toolbar-status chat-toolbar-status--compact"
+      aria-live="polite"
+      title={label}
+    >
+      <span className={`status-dot ${connected ? 'online' : 'offline'}`} aria-hidden="true" />
+      <span className="sr-only">{connected ? 'Connected' : 'Reconnecting'}</span>
+    </div>
+  );
+}
+
+function StandaloneHeader({ connected, sessionShort }: StatusProps): ReactElement {
+  return (
+    <div className="chat-toolbar-main">
+      <div className="chat-toolbar-title-group">
+        <div className="chat-toolbar-title">
+          <FiMessageSquare aria-hidden="true" />
+          <span>Workspace Chat</span>
+        </div>
+        <small className="chat-toolbar-subtitle">
+          Session: <span className="font-mono">{sessionShort}</span>
+        </small>
+      </div>
+      <div className="chat-toolbar-status" aria-live="polite">
+        <span className={`status-dot ${connected ? 'online' : 'offline'}`} aria-hidden="true" />
+        <small className="text-body-secondary">{connected ? 'Connected' : 'Reconnecting...'}</small>
+      </div>
+    </div>
+  );
+}
+
+interface ContextToggleButtonProps {
+  panelOpen: boolean;
+  onToggleContext: () => void;
+}
+
+function ContextToggleButton({ panelOpen, onToggleContext }: ContextToggleButtonProps): ReactElement {
+  const label = panelOpen ? 'Hide context' : 'Show context';
+  const title = panelOpen ? 'Hide context panel' : 'Show context panel';
+  return (
+    <button
+      type="button"
+      className="btn btn-sm btn-secondary chat-toolbar-btn panel-toggle-btn"
+      onClick={onToggleContext}
+      title={title}
+      aria-label={title}
+      data-testid="chat-toolbar-context-toggle"
+    >
+      <span className="chat-toolbar-btn-icon" aria-hidden="true">
+        <FiLayout size={14} />
+      </span>
+      <span>{label}</span>
+    </button>
+  );
+}
+
+type EmbeddedTierControlsProps = TierControlsValues;
 
 function EmbeddedTierControls({
   tier,
@@ -138,13 +231,17 @@ function EmbeddedTierControls({
   const inheritedLabel = inheritedMemoryPresetLabel != null && inheritedMemoryPresetLabel.length > 0
     ? `Global memory (${inheritedMemoryPresetLabel})`
     : 'Global memory';
+  const placeholder = memoryPresetsLoading ? 'Loading memory' : inheritedLabel;
 
   return (
     <div className="chat-toolbar-tier-controls">
-      <label className="chat-toolbar-tier-label">
-        <span className="visually-hidden">Model tier</span>
+      <label className="chat-toolbar-tier-field" title="Model tier">
+        <span className="chat-toolbar-tier-field-icon" aria-hidden="true">
+          <FiCpu size={12} />
+        </span>
+        <span className="sr-only">Model tier</span>
         <select
-          className="form-select form-select-sm chat-toolbar-tier-select"
+          className="chat-toolbar-tier-select"
           value={tier}
           onChange={(event) => onTierChange?.(event.target.value)}
           aria-label="Model tier"
@@ -157,17 +254,21 @@ function EmbeddedTierControls({
           ))}
         </select>
       </label>
-      <label className="chat-toolbar-tier-label">
-        <span className="visually-hidden">Memory preset</span>
+
+      <label className="chat-toolbar-tier-field" title="Memory preset">
+        <span className="chat-toolbar-tier-field-icon" aria-hidden="true">
+          <FiDatabase size={12} />
+        </span>
+        <span className="sr-only">Memory preset</span>
         <select
-          className="form-select form-select-sm chat-toolbar-memory-select"
+          className="chat-toolbar-memory-select"
           value={memoryPreset}
           onChange={(event) => onMemoryPresetChange?.(event.target.value)}
           aria-label="Memory preset"
           data-testid="chat-toolbar-memory-preset-select"
           disabled={memoryPresetsLoading}
         >
-          <option value="">{memoryPresetsLoading ? 'Loading memory' : inheritedLabel}</option>
+          <option value="">{placeholder}</option>
           {!hasSelectedMemoryPreset && (
             <option value={memoryPreset}>{memoryPreset}</option>
           )}
@@ -178,17 +279,21 @@ function EmbeddedTierControls({
           ))}
         </select>
       </label>
-      <label className="chat-toolbar-tier-force form-check form-switch m-0">
+
+      <label
+        className={`chat-toolbar-force-toggle${tierForce ? ' is-active' : ''}`}
+        title="Force the selected tier (disable auto-upgrade)"
+      >
         <input
           type="checkbox"
-          role="switch"
-          className="form-check-input"
+          className="chat-toolbar-force-input"
           checked={tierForce}
           onChange={(event) => onForceChange?.(event.target.checked)}
-          aria-label="Force tier"
           data-testid="chat-toolbar-tier-force"
         />
-        <span className="form-check-label visually-hidden">Force tier</span>
+        <span className="chat-toolbar-force-label">
+          Force<span className="sr-only"> tier</span>
+        </span>
       </label>
     </div>
   );

--- a/dashboard/src/styles/custom.scss
+++ b/dashboard/src/styles/custom.scss
@@ -1355,28 +1355,164 @@ textarea:focus-visible,
   display: inline-flex;
   align-items: center;
   flex-wrap: wrap;
-  gap: 0.5rem;
+  gap: 0.35rem;
 }
 
-.chat-toolbar-tier-label {
+%chat-toolbar-pill {
   display: inline-flex;
   align-items: center;
   margin: 0;
+  border-radius: 999px;
+  background-color: rgba(var(--gc-body-bg-rgb), 0.7);
+  border: 1px solid rgba(var(--gc-border-color-rgb), 0.55);
+  color: var(--gc-secondary-color);
+  transition: border-color 0.15s ease, background-color 0.15s ease, color 0.15s ease;
 }
 
-.chat-toolbar-tier-select {
-  min-width: 9rem;
-  font-size: 0.8125rem;
+.chat-toolbar-tier-field {
+  @extend %chat-toolbar-pill;
+  gap: 0.3rem;
+  padding: 0.15rem 0.2rem 0.15rem 0.55rem;
 }
 
+.chat-toolbar-tier-field:focus-within {
+  border-color: rgba(var(--gc-primary-rgb), 0.55);
+  background-color: rgba(var(--gc-body-bg-rgb), 0.92);
+}
+
+.chat-toolbar-tier-field-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: rgba(var(--gc-emphasis-color-rgb), 0.65);
+  flex: 0 0 auto;
+}
+
+.chat-toolbar-tier-select,
 .chat-toolbar-memory-select {
-  min-width: 10rem;
+  appearance: none;
+  -webkit-appearance: none;
+  background: transparent;
+  border: 0;
+  outline: none;
+  padding: 0.25rem 1.6rem 0.25rem 0.2rem;
   font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--gc-emphasis-color);
+  line-height: 1.2;
+  cursor: pointer;
+  background-image:
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 6' fill='none'><path d='M1 1l4 4 4-4' stroke='%235c6777' stroke-width='1.4' stroke-linecap='round' stroke-linejoin='round'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 0.55rem center;
+  background-size: 0.55rem 0.4rem;
+  max-width: 10rem;
+  text-overflow: ellipsis;
 }
 
-.chat-toolbar-tier-force {
-  padding-left: 2.25rem;
-  min-height: auto;
+[data-theme="dark"] .chat-toolbar-tier-select,
+[data-theme="dark"] .chat-toolbar-memory-select {
+  background-image:
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 6' fill='none'><path d='M1 1l4 4 4-4' stroke='%23c0c7d4' stroke-width='1.4' stroke-linecap='round' stroke-linejoin='round'/></svg>");
+}
+
+.chat-toolbar-tier-select:disabled,
+.chat-toolbar-memory-select:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.chat-toolbar-force-toggle {
+  @extend %chat-toolbar-pill;
+  gap: 0.35rem;
+  padding: 0.25rem 0.65rem;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  user-select: none;
+}
+
+.chat-toolbar-force-toggle:hover {
+  border-color: rgba(var(--gc-primary-rgb), 0.45);
+}
+
+.chat-toolbar-force-toggle:focus-within {
+  border-color: rgba(var(--gc-primary-rgb), 0.55);
+  box-shadow: 0 0 0 2px rgba(var(--gc-primary-rgb), 0.25);
+}
+
+.chat-toolbar-force-toggle.is-active {
+  background-color: rgba(var(--gc-primary-rgb), 0.14);
+  border-color: rgba(var(--gc-primary-rgb), 0.55);
+  color: var(--gc-primary-text-emphasis);
+}
+
+.chat-toolbar-force-input {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 0.85rem;
+  height: 0.85rem;
+  border-radius: 0.25rem;
+  border: 1.5px solid rgba(var(--gc-border-color-rgb), 0.8);
+  background-color: transparent;
+  margin: 0;
+  cursor: pointer;
+  transition: background-color 0.15s ease, border-color 0.15s ease;
+}
+
+.chat-toolbar-force-input:checked {
+  background-color: var(--gc-primary);
+  border-color: var(--gc-primary);
+  background-image:
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10' fill='none'><path d='M2 5.3l2.2 2.2L8 3.2' stroke='white' stroke-width='1.6' stroke-linecap='round' stroke-linejoin='round'/></svg>");
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: 0.7rem 0.7rem;
+}
+
+.chat-toolbar-force-input:focus-visible {
+  outline: none;
+}
+
+.chat-toolbar-force-label {
+  line-height: 1;
+}
+
+.chat-toolbar-icon-btn {
+  @extend %chat-toolbar-pill;
+  justify-content: center;
+  width: 1.9rem;
+  height: 1.9rem;
+  color: var(--gc-emphasis-color);
+  padding: 0;
+  cursor: pointer;
+}
+
+.chat-toolbar-icon-btn:hover {
+  border-color: rgba(var(--gc-primary-rgb), 0.45);
+  color: var(--gc-primary-text-emphasis);
+}
+
+.chat-toolbar-icon-btn:focus-visible {
+  outline: none;
+  border-color: rgba(var(--gc-primary-rgb), 0.55);
+  box-shadow: 0 0 0 2px rgba(var(--gc-primary-rgb), 0.25);
+}
+
+.chat-toolbar--embedded {
+  padding: 0.5rem 0.75rem;
+}
+
+.chat-toolbar--embedded .chat-toolbar-inner {
+  width: 100%;
+  max-width: none;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.chat-toolbar-status--compact {
+  padding: 0.3rem 0.5rem;
 }
 
 .chat-workspace-body {


### PR DESCRIPTION
## Summary

The embedded workspace chat toolbar was rendering its hidden labels as visible text ("Model tier", "Memory preset", "Force tier") and the tier/memory/force controls plus the "New chat" button overlapped in the narrow right-side panel.

Root cause: the original markup used Bootstrap's `visually-hidden` class, which was removed during the Tailwind migration and no longer maps to any styles.

