### PR TITLE
fix(workspace): add adaptive workspace shell

### DIFF
--- a/dashboard/src/components/layout/DashboardLayout.tsx
+++ b/dashboard/src/components/layout/DashboardLayout.tsx
@@ -3,12 +3,18 @@ import { ChatRuntimeController } from '../chat/ChatRuntimeController';
 import Sidebar from './Sidebar';
 import Topbar from './Topbar';
 
-export default function DashboardLayout({ children }: { children: React.ReactNode }) {
+interface DashboardLayoutProps {
+  children: React.ReactNode;
+}
+
+export default function DashboardLayout({ children }: DashboardLayoutProps) {
   const { pathname } = useLocation();
   const isChat = pathname === '/' || pathname.startsWith('/chat');
   const isIde = pathname.startsWith('/ide');
+  const isWorkspace = pathname.startsWith('/workspace');
+  const isShellRoute = isChat || isIde || isWorkspace;
 
-  const mainClassName = isChat || isIde
+  const mainClassName = isShellRoute
     ? 'dashboard-main-shell flex-grow-1 d-flex overflow-hidden'
     : 'dashboard-main flex-grow-1 overflow-auto';
 

--- a/dashboard/src/components/ui/overlay.tsx
+++ b/dashboard/src/components/ui/overlay.tsx
@@ -149,10 +149,12 @@ Modal.Body = OverlayBody;
 Modal.Footer = OverlayFooter;
 Modal.Title = OverlayTitle;
 
+export type OffcanvasPlacement = 'start' | 'end' | 'bottom';
+
 interface OffcanvasProps {
   show?: boolean;
   onHide?: () => void;
-  placement?: 'start' | 'end';
+  placement?: OffcanvasPlacement;
   className?: string;
   children?: React.ReactNode;
 }
@@ -161,6 +163,25 @@ interface OffcanvasComponent extends React.FC<OffcanvasProps> {
   Header: typeof OverlayHeader;
   Body: typeof OverlayBody;
   Title: typeof OverlayTitle;
+}
+
+function getOffcanvasClasses(placement: OffcanvasPlacement): { container: string; panel: string } {
+  if (placement === 'start') {
+    return {
+      container: 'justify-start items-stretch',
+      panel: 'h-full w-full max-w-[28rem] border-r border-border/80',
+    };
+  }
+  if (placement === 'bottom') {
+    return {
+      container: 'items-end justify-stretch',
+      panel: 'w-full max-h-[75vh] rounded-t-[1.5rem] border-t border-border/80',
+    };
+  }
+  return {
+    container: 'justify-end items-stretch',
+    panel: 'h-full w-full max-w-[28rem] border-l border-border/80',
+  };
 }
 
 const BaseOffcanvas: React.FC<OffcanvasProps> = ({
@@ -177,13 +198,12 @@ const BaseOffcanvas: React.FC<OffcanvasProps> = ({
     return null;
   }
 
-  const sideClassName = placement === 'start' ? 'justify-start' : 'justify-end';
-  const panelClassName = placement === 'start' ? 'translate-x-0' : 'translate-x-0';
+  const classes = getOffcanvasClasses(placement);
 
   return createPortal(
     <OverlayContext.Provider value={{ onHide }}>
       <div
-        className={cn('fixed inset-0 z-[1080] flex bg-slate-950/45 backdrop-blur-sm', sideClassName)}
+        className={cn('fixed inset-0 z-[1080] flex bg-slate-950/45 backdrop-blur-sm', classes.container)}
         onMouseDown={(event) => {
           if (event.target === event.currentTarget) {
             onHide?.();
@@ -192,8 +212,8 @@ const BaseOffcanvas: React.FC<OffcanvasProps> = ({
       >
         <div
           className={cn(
-            'h-full w-full max-w-[28rem] border-l border-border/80 bg-card/95 text-card-foreground shadow-[0_20px_80px_rgba(2,6,23,0.38)]',
-            panelClassName,
+            'bg-card/95 text-card-foreground shadow-[0_20px_80px_rgba(2,6,23,0.38)]',
+            classes.panel,
             className
           )}
           onMouseDown={(event) => event.stopPropagation()}

--- a/dashboard/src/main.tsx
+++ b/dashboard/src/main.tsx
@@ -6,6 +6,7 @@ import { Toaster } from 'react-hot-toast';
 import App from './App';
 import './styles/tailwind.css';
 import './styles/custom.scss';
+import './styles/workspace.scss';
 import './styles/responsive.scss';
 
 const queryClient = new QueryClient({

--- a/dashboard/src/pages/WorkspacePage.test.tsx
+++ b/dashboard/src/pages/WorkspacePage.test.tsx
@@ -92,11 +92,28 @@ function resetStore(): void {
   });
 }
 
+function installMatchMedia(matches: boolean): void {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
+
 describe('WorkspacePage', () => {
   beforeEach(() => {
     window.localStorage.clear();
     document.body.innerHTML = '';
     chatWindowPropsSpy.mockClear();
+    installMatchMedia(false);
     resetStore();
   });
 
@@ -151,14 +168,15 @@ describe('WorkspacePage', () => {
     useWorkspaceLayoutStore.getState().setChatVisible(false);
     const harness = mountHarness('/workspace?focus=chat');
     expect(useWorkspaceLayoutStore.getState().isChatVisible).toBe(true);
+    expect(useWorkspaceLayoutStore.getState().compactActivePane).toBe('chat');
     expect(harness.container.querySelector('[data-testid="workspace-chat-slot"]')).not.toBeNull();
     unmountHarness(harness);
   });
 
-  it('leaves chat hidden when mounted with ?focus=editor', () => {
-    useWorkspaceLayoutStore.getState().setChatVisible(false);
+  it('sets compact editor focus when mounted with ?focus=editor', () => {
+    useWorkspaceLayoutStore.getState().setCompactPane('chat');
     const harness = mountHarness('/workspace?focus=editor');
-    expect(useWorkspaceLayoutStore.getState().isChatVisible).toBe(false);
+    expect(useWorkspaceLayoutStore.getState().compactActivePane).toBe('editor');
     unmountHarness(harness);
   });
 
@@ -256,6 +274,53 @@ describe('WorkspacePage', () => {
       terminalToggle?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
     expect(useWorkspaceLayoutStore.getState().isTerminalVisible).toBe(true);
+
+    unmountHarness(harness);
+  });
+
+  it('renders a compact single-pane shell on narrow screens', () => {
+    installMatchMedia(true);
+    const harness = mountHarness();
+
+    expect(harness.container.querySelector('[data-testid="workspace-page-compact"]')).not.toBeNull();
+    expect(harness.container.querySelector('[data-testid="workspace-compact-main"]')).not.toBeNull();
+    expect(harness.container.querySelector('[data-testid="workspace-toggle-chat"]')).toBeNull();
+
+    unmountHarness(harness);
+  });
+
+  it('switches compact pane focus from editor to chat', () => {
+    installMatchMedia(true);
+    const harness = mountHarness();
+
+    const chatPaneButton = harness.container.querySelector<HTMLButtonElement>(
+      '[data-testid="workspace-compact-pane-chat"]',
+    );
+    expect(chatPaneButton).not.toBeNull();
+
+    act(() => {
+      chatPaneButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(useWorkspaceLayoutStore.getState().compactActivePane).toBe('chat');
+    expect(harness.container.querySelector('[data-testid="workspace-chat-slot"]')).not.toBeNull();
+
+    unmountHarness(harness);
+  });
+
+  it('uses compact terminal overlay toggling on narrow screens', () => {
+    installMatchMedia(true);
+    const harness = mountHarness();
+
+    expect(useWorkspaceLayoutStore.getState().isCompactTerminalVisible).toBe(false);
+
+    act(() => {
+      window.dispatchEvent(
+        new KeyboardEvent('keydown', { key: '`', ctrlKey: true, bubbles: true }),
+      );
+    });
+
+    expect(useWorkspaceLayoutStore.getState().isCompactTerminalVisible).toBe(true);
 
     unmountHarness(harness);
   });

--- a/dashboard/src/pages/WorkspacePage.tsx
+++ b/dashboard/src/pages/WorkspacePage.tsx
@@ -1,29 +1,27 @@
-import { useCallback, useEffect, type ReactElement } from 'react';
-import { useSearchParams } from 'react-router-dom';
-import { Group, Panel, Separator, type PanelSize } from 'react-resizable-panels';
-import { FiMessageSquare, FiTerminal } from 'react-icons/fi';
-import ChatWindow from '../components/chat/ChatWindow';
-import { ProposedEditsPanel } from '../components/ide/ProposedEditsPanel';
-import { TerminalPane } from '../components/terminal/TerminalPane';
-import { TerminalTabs } from '../components/terminal/TerminalTabs';
-import { useTerminalStore } from '../store/terminalStore';
-import { useWorkspaceLayoutStore } from '../store/workspaceLayoutStore';
-import IdePage from './IdePage';
+import { useCallback, type ReactElement } from 'react';
+import type { PanelSize } from 'react-resizable-panels';
+import { DesktopWorkspaceLayout, CompactWorkspaceLayout } from './workspace/WorkspaceLayouts';
+import { useWorkspacePageState } from './workspace/useWorkspacePageState';
 
 export default function WorkspacePage(): ReactElement {
-  const chatSize = useWorkspaceLayoutStore((state) => state.chatSize);
-  const terminalSize = useWorkspaceLayoutStore((state) => state.terminalSize);
-  const isChatVisible = useWorkspaceLayoutStore((state) => state.isChatVisible);
-  const isTerminalVisible = useWorkspaceLayoutStore((state) => state.isTerminalVisible);
-  const toggleChat = useWorkspaceLayoutStore((state) => state.toggleChat);
-  const toggleTerminal = useWorkspaceLayoutStore((state) => state.toggleTerminal);
-  const setChatVisible = useWorkspaceLayoutStore((state) => state.setChatVisible);
-  const setChatSize = useWorkspaceLayoutStore((state) => state.setChatSize);
-  const setTerminalSize = useWorkspaceLayoutStore((state) => state.setTerminalSize);
-
-  const tabs = useTerminalStore((state) => state.tabs);
-  const activeTabId = useTerminalStore((state) => state.activeTabId);
-  const openTab = useTerminalStore((state) => state.openTab);
+  const {
+    activeTabId,
+    chatSize,
+    compactActivePane,
+    isChatVisible,
+    isCompactLayout,
+    isCompactTerminalVisible,
+    isTerminalVisible,
+    setChatSize,
+    setCompactPane,
+    setCompactTerminalVisible,
+    setTerminalSize,
+    tabs,
+    terminalSize,
+    toggleChat,
+    toggleCompactTerminal,
+    toggleTerminal,
+  } = useWorkspacePageState();
 
   const handleChatResize = useCallback(
     (panelSize: PanelSize): void => {
@@ -39,121 +37,32 @@ export default function WorkspacePage(): ReactElement {
     [setTerminalSize],
   );
 
-  const [searchParams] = useSearchParams();
-  const focus = searchParams.get('focus');
-
-  // Sync stored chat visibility with ?focus= query param on mount / redirect landings.
-  useEffect(() => {
-    if (focus === 'chat') {
-      setChatVisible(true);
-    }
-  }, [focus, setChatVisible]);
-
-  // Global Ctrl+` shortcut toggles the integrated terminal panel.
-  useEffect(() => {
-    const handler = (event: KeyboardEvent): void => {
-      if (event.ctrlKey && event.key === '`') {
-        event.preventDefault();
-        toggleTerminal();
-      }
-    };
-    window.addEventListener('keydown', handler);
-    return (): void => {
-      window.removeEventListener('keydown', handler);
-    };
-  }, [toggleTerminal]);
-
-  // Auto-open a first terminal tab when the terminal panel becomes visible.
-  useEffect(() => {
-    if (isTerminalVisible && tabs.length === 0) {
-      openTab();
-    }
-  }, [isTerminalVisible, tabs.length, openTab]);
+  if (isCompactLayout) {
+    return (
+      <CompactWorkspaceLayout
+        activePane={compactActivePane}
+        isTerminalVisible={isCompactTerminalVisible}
+        tabs={tabs}
+        activeTabId={activeTabId}
+        onSelectPane={setCompactPane}
+        onToggleTerminal={toggleCompactTerminal}
+        onCloseTerminal={() => setCompactTerminalVisible(false)}
+      />
+    );
+  }
 
   return (
-    <div className="workspace-page">
-      <div className="workspace-toolbar" role="toolbar" aria-label="Workspace layout">
-        <button
-          type="button"
-          data-testid="workspace-toggle-chat"
-          className="workspace-toolbar-button"
-          aria-pressed={isChatVisible}
-          onClick={() => toggleChat()}
-          title="Toggle chat panel"
-        >
-          <FiMessageSquare size={14} />
-          <span>Chat</span>
-        </button>
-        <button
-          type="button"
-          data-testid="workspace-toggle-terminal"
-          className="workspace-toolbar-button"
-          aria-pressed={isTerminalVisible}
-          onClick={() => toggleTerminal()}
-          title="Toggle terminal panel"
-        >
-          <FiTerminal size={14} />
-          <span>Terminal</span>
-        </button>
-      </div>
-      <Group orientation="horizontal" className="workspace-main">
-        <Panel defaultSize={`${100 - (isChatVisible ? chatSize : 0)}%`} minSize="30%">
-          <Group orientation="vertical" className="workspace-center">
-            <Panel defaultSize={`${100 - (isTerminalVisible ? terminalSize : 0)}%`} minSize="30%">
-              <div className="workspace-editor-pane">
-                <ProposedEditsPanel />
-                <IdePage />
-              </div>
-            </Panel>
-            {isTerminalVisible ? (
-              <>
-                <Separator className="workspace-resize-handle workspace-resize-handle-horizontal" />
-                <Panel
-                  defaultSize={`${terminalSize}%`}
-                  minSize="10%"
-                  maxSize="80%"
-                  onResize={handleTerminalResize}
-                >
-                  <div className="workspace-terminal-pane">
-                    <TerminalTabs />
-                    <div className="workspace-terminal-body">
-                      {tabs.map((tab) => {
-                        const isActive = tab.id === activeTabId;
-                        return (
-                          <div
-                            key={tab.id}
-                            className="workspace-terminal-session"
-                            data-testid={`workspace-terminal-session-${tab.id}`}
-                            hidden={!isActive}
-                            aria-hidden={!isActive}
-                          >
-                            <TerminalPane tabId={tab.id} cwd={tab.cwd} active={isActive} />
-                          </div>
-                        );
-                      })}
-                    </div>
-                  </div>
-                </Panel>
-              </>
-            ) : null}
-          </Group>
-        </Panel>
-        {isChatVisible ? (
-          <>
-            <Separator className="workspace-resize-handle workspace-resize-handle-vertical" />
-            <Panel
-              defaultSize={`${chatSize}%`}
-              minSize="15%"
-              maxSize="60%"
-              onResize={handleChatResize}
-            >
-              <div className="workspace-chat-pane">
-                <ChatWindow embedded />
-              </div>
-            </Panel>
-          </>
-        ) : null}
-      </Group>
-    </div>
+    <DesktopWorkspaceLayout
+      chatSize={chatSize}
+      terminalSize={terminalSize}
+      isChatVisible={isChatVisible}
+      isTerminalVisible={isTerminalVisible}
+      tabs={tabs}
+      activeTabId={activeTabId}
+      onToggleChat={toggleChat}
+      onToggleTerminal={toggleTerminal}
+      onChatResize={handleChatResize}
+      onTerminalResize={handleTerminalResize}
+    />
   );
 }

--- a/dashboard/src/pages/workspace/WorkspaceLayouts.tsx
+++ b/dashboard/src/pages/workspace/WorkspaceLayouts.tsx
@@ -1,0 +1,249 @@
+import type { ReactElement } from 'react';
+import { Group, Panel, Separator, type PanelSize } from 'react-resizable-panels';
+import { FiCode, FiMessageSquare, FiMonitor, FiTerminal } from 'react-icons/fi';
+import { Offcanvas } from '../../components/ui/overlay';
+import ChatWindow from '../../components/chat/ChatWindow';
+import { ProposedEditsPanel } from '../../components/ide/ProposedEditsPanel';
+import { TerminalPane } from '../../components/terminal/TerminalPane';
+import { TerminalTabs } from '../../components/terminal/TerminalTabs';
+import type { TerminalTab } from '../../store/terminalStore';
+import type { WorkspaceCompactPane } from '../../store/workspaceLayoutStore';
+import IdePage from '../IdePage';
+
+export interface CompactWorkspaceLayoutProps {
+  activePane: WorkspaceCompactPane;
+  isTerminalVisible: boolean;
+  tabs: TerminalTab[];
+  activeTabId: string | null;
+  onSelectPane: (pane: WorkspaceCompactPane) => void;
+  onToggleTerminal: () => void;
+  onCloseTerminal: () => void;
+}
+
+export interface DesktopWorkspaceLayoutProps {
+  chatSize: number;
+  terminalSize: number;
+  isChatVisible: boolean;
+  isTerminalVisible: boolean;
+  tabs: TerminalTab[];
+  activeTabId: string | null;
+  onToggleChat: () => void;
+  onToggleTerminal: () => void;
+  onChatResize: (panelSize: PanelSize) => void;
+  onTerminalResize: (panelSize: PanelSize) => void;
+}
+
+interface CompactPaneToggleProps {
+  activePane: WorkspaceCompactPane;
+  pane: WorkspaceCompactPane;
+  icon: ReactElement;
+  label: string;
+  onClick: () => void;
+}
+
+interface WorkspaceTerminalContentProps {
+  tabs: TerminalTab[];
+  activeTabId: string | null;
+}
+
+function CompactPaneToggle({
+  activePane,
+  pane,
+  icon,
+  label,
+  onClick,
+}: CompactPaneToggleProps): ReactElement {
+  return (
+    <button
+      type="button"
+      className="workspace-toolbar-button"
+      aria-pressed={activePane === pane}
+      data-testid={`workspace-compact-pane-${pane}`}
+      onClick={onClick}
+      title={`Show ${label.toLowerCase()} pane`}
+    >
+      {icon}
+      <span>{label}</span>
+    </button>
+  );
+}
+
+function WorkspaceTerminalContent({ tabs, activeTabId }: WorkspaceTerminalContentProps): ReactElement {
+  return (
+    <div className="workspace-terminal-pane" data-testid="workspace-terminal-pane">
+      <TerminalTabs />
+      <div className="workspace-terminal-body">
+        {tabs.map((tab) => {
+          const isActive = tab.id === activeTabId;
+          return (
+            <div
+              key={tab.id}
+              className="workspace-terminal-session"
+              data-testid={`workspace-terminal-session-${tab.id}`}
+              hidden={!isActive}
+              aria-hidden={!isActive}
+            >
+              <TerminalPane tabId={tab.id} cwd={tab.cwd} active={isActive} />
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function WorkspaceEditorShell(): ReactElement {
+  return (
+    <div className="workspace-editor-pane" data-testid="workspace-editor-pane">
+      <ProposedEditsPanel />
+      <IdePage />
+    </div>
+  );
+}
+
+function WorkspaceChatShell(): ReactElement {
+  return (
+    <div className="workspace-chat-pane" data-testid="workspace-chat-pane">
+      <ChatWindow embedded />
+    </div>
+  );
+}
+
+export function CompactWorkspaceLayout({
+  activePane,
+  isTerminalVisible,
+  tabs,
+  activeTabId,
+  onSelectPane,
+  onToggleTerminal,
+  onCloseTerminal,
+}: CompactWorkspaceLayoutProps): ReactElement {
+  return (
+    <div className="workspace-page workspace-page--compact" data-testid="workspace-page-compact">
+      <div className="workspace-toolbar" role="toolbar" aria-label="Workspace layout">
+        <div className="workspace-toolbar-group" role="group" aria-label="Focused workspace pane">
+          <CompactPaneToggle
+            activePane={activePane}
+            pane="editor"
+            icon={<FiCode size={14} />}
+            label="Editor"
+            onClick={() => onSelectPane('editor')}
+          />
+          <CompactPaneToggle
+            activePane={activePane}
+            pane="chat"
+            icon={<FiMessageSquare size={14} />}
+            label="Chat"
+            onClick={() => onSelectPane('chat')}
+          />
+        </div>
+        <button
+          type="button"
+          data-testid="workspace-toggle-terminal"
+          className="workspace-toolbar-button"
+          aria-pressed={isTerminalVisible}
+          onClick={onToggleTerminal}
+          title="Toggle terminal panel"
+        >
+          <FiTerminal size={14} />
+          <span>Terminal</span>
+        </button>
+      </div>
+
+      <div className="workspace-compact-main" data-testid="workspace-compact-main">
+        {activePane === 'chat' ? <WorkspaceChatShell /> : <WorkspaceEditorShell />}
+      </div>
+
+      <Offcanvas
+        show={isTerminalVisible}
+        onHide={onCloseTerminal}
+        placement="bottom"
+        className="workspace-terminal-offcanvas"
+      >
+        <Offcanvas.Header closeButton>
+          <Offcanvas.Title>Terminal</Offcanvas.Title>
+        </Offcanvas.Header>
+        <Offcanvas.Body className="workspace-terminal-offcanvas-body p-0">
+          <WorkspaceTerminalContent tabs={tabs} activeTabId={activeTabId} />
+        </Offcanvas.Body>
+      </Offcanvas>
+    </div>
+  );
+}
+
+export function DesktopWorkspaceLayout({
+  chatSize,
+  terminalSize,
+  isChatVisible,
+  isTerminalVisible,
+  tabs,
+  activeTabId,
+  onToggleChat,
+  onToggleTerminal,
+  onChatResize,
+  onTerminalResize,
+}: DesktopWorkspaceLayoutProps): ReactElement {
+  return (
+    <div className="workspace-page" data-testid="workspace-page-desktop">
+      <div className="workspace-toolbar" role="toolbar" aria-label="Workspace layout">
+        <button
+          type="button"
+          data-testid="workspace-toggle-chat"
+          className="workspace-toolbar-button"
+          aria-pressed={isChatVisible}
+          onClick={onToggleChat}
+          title="Toggle chat panel"
+        >
+          <FiMonitor size={14} />
+          <span>Split Chat</span>
+        </button>
+        <button
+          type="button"
+          data-testid="workspace-toggle-terminal"
+          className="workspace-toolbar-button"
+          aria-pressed={isTerminalVisible}
+          onClick={onToggleTerminal}
+          title="Toggle terminal panel"
+        >
+          <FiTerminal size={14} />
+          <span>Terminal</span>
+        </button>
+      </div>
+      <Group orientation="horizontal" className="workspace-main">
+        <Panel defaultSize={`${100 - (isChatVisible ? chatSize : 0)}%`} minSize="30%">
+          <Group orientation="vertical" className="workspace-center">
+            <Panel defaultSize={`${100 - (isTerminalVisible ? terminalSize : 0)}%`} minSize="30%">
+              <WorkspaceEditorShell />
+            </Panel>
+            {isTerminalVisible ? (
+              <>
+                <Separator className="workspace-resize-handle workspace-resize-handle-horizontal" />
+                <Panel
+                  defaultSize={`${terminalSize}%`}
+                  minSize="10%"
+                  maxSize="80%"
+                  onResize={onTerminalResize}
+                >
+                  <WorkspaceTerminalContent tabs={tabs} activeTabId={activeTabId} />
+                </Panel>
+              </>
+            ) : null}
+          </Group>
+        </Panel>
+        {isChatVisible ? (
+          <>
+            <Separator className="workspace-resize-handle workspace-resize-handle-vertical" />
+            <Panel
+              defaultSize={`${chatSize}%`}
+              minSize="15%"
+              maxSize="60%"
+              onResize={onChatResize}
+            >
+              <WorkspaceChatShell />
+            </Panel>
+          </>
+        ) : null}
+      </Group>
+    </div>
+  );
+}

--- a/dashboard/src/pages/workspace/useWorkspacePageState.ts
+++ b/dashboard/src/pages/workspace/useWorkspacePageState.ts
@@ -1,0 +1,163 @@
+import { useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { useMediaQuery } from '../../hooks/useMediaQuery';
+import { useTerminalStore, type TerminalTab } from '../../store/terminalStore';
+import {
+  useWorkspaceLayoutStore,
+  type WorkspaceCompactPane,
+} from '../../store/workspaceLayoutStore';
+
+export interface WorkspaceFocusSyncOptions {
+  focus: string | null;
+  setChatVisible: (visible: boolean) => void;
+  setCompactPane: (pane: WorkspaceCompactPane) => void;
+  setCompactTerminalVisible: (visible: boolean) => void;
+}
+
+export interface WorkspaceTerminalShortcutOptions {
+  isCompactLayout: boolean;
+  toggleCompactTerminal: () => void;
+  toggleTerminal: () => void;
+}
+
+export interface WorkspaceTerminalBootstrapOptions {
+  isCompactLayout: boolean;
+  isCompactTerminalVisible: boolean;
+  isTerminalVisible: boolean;
+  tabs: TerminalTab[];
+  openTab: (cwd?: string) => string;
+}
+
+export interface WorkspacePageState {
+  chatSize: number;
+  terminalSize: number;
+  isChatVisible: boolean;
+  isTerminalVisible: boolean;
+  compactActivePane: WorkspaceCompactPane;
+  isCompactTerminalVisible: boolean;
+  tabs: TerminalTab[];
+  activeTabId: string | null;
+  isCompactLayout: boolean;
+  toggleChat: () => void;
+  toggleTerminal: () => void;
+  toggleCompactTerminal: () => void;
+  setCompactPane: (pane: WorkspaceCompactPane) => void;
+  setCompactTerminalVisible: (visible: boolean) => void;
+  setChatSize: (size: number) => void;
+  setTerminalSize: (size: number) => void;
+}
+
+export function useWorkspaceFocusSync({
+  focus,
+  setChatVisible,
+  setCompactPane,
+  setCompactTerminalVisible,
+}: WorkspaceFocusSyncOptions): void {
+  useEffect(() => {
+    // Sync query-param deep links with the compact workspace pane that should open first.
+    if (focus === 'chat') {
+      setChatVisible(true);
+      setCompactPane('chat');
+      return;
+    }
+    if (focus === 'editor') {
+      setCompactPane('editor');
+      return;
+    }
+    if (focus === 'terminal') {
+      setCompactTerminalVisible(true);
+    }
+  }, [focus, setChatVisible, setCompactPane, setCompactTerminalVisible]);
+}
+
+export function useWorkspaceTerminalShortcut({
+  isCompactLayout,
+  toggleCompactTerminal,
+  toggleTerminal,
+}: WorkspaceTerminalShortcutOptions): void {
+  useEffect(() => {
+    // Keep Ctrl+` mapped to the terminal surface that is actually visible for the current layout.
+    const handler = (event: KeyboardEvent): void => {
+      if (event.ctrlKey && event.key === '`') {
+        event.preventDefault();
+        if (isCompactLayout) {
+          toggleCompactTerminal();
+          return;
+        }
+        toggleTerminal();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return (): void => {
+      window.removeEventListener('keydown', handler);
+    };
+  }, [isCompactLayout, toggleCompactTerminal, toggleTerminal]);
+}
+
+export function useWorkspaceTerminalBootstrap({
+  isCompactLayout,
+  isCompactTerminalVisible,
+  isTerminalVisible,
+  tabs,
+  openTab,
+}: WorkspaceTerminalBootstrapOptions): void {
+  useEffect(() => {
+    // Ensure the terminal overlay/split always has an initial tab the first time it opens.
+    const shouldEnsureTerminalTab = isCompactLayout ? isCompactTerminalVisible : isTerminalVisible;
+    if (shouldEnsureTerminalTab && tabs.length === 0) {
+      openTab();
+    }
+  }, [isCompactLayout, isCompactTerminalVisible, isTerminalVisible, openTab, tabs.length]);
+}
+
+export function useWorkspacePageState(): WorkspacePageState {
+  const chatSize = useWorkspaceLayoutStore((state) => state.chatSize);
+  const terminalSize = useWorkspaceLayoutStore((state) => state.terminalSize);
+  const isChatVisible = useWorkspaceLayoutStore((state) => state.isChatVisible);
+  const isTerminalVisible = useWorkspaceLayoutStore((state) => state.isTerminalVisible);
+  const compactActivePane = useWorkspaceLayoutStore((state) => state.compactActivePane);
+  const isCompactTerminalVisible = useWorkspaceLayoutStore((state) => state.isCompactTerminalVisible);
+  const toggleChat = useWorkspaceLayoutStore((state) => state.toggleChat);
+  const toggleTerminal = useWorkspaceLayoutStore((state) => state.toggleTerminal);
+  const toggleCompactTerminal = useWorkspaceLayoutStore((state) => state.toggleCompactTerminal);
+  const setChatVisible = useWorkspaceLayoutStore((state) => state.setChatVisible);
+  const setChatSize = useWorkspaceLayoutStore((state) => state.setChatSize);
+  const setCompactPane = useWorkspaceLayoutStore((state) => state.setCompactPane);
+  const setCompactTerminalVisible = useWorkspaceLayoutStore((state) => state.setCompactTerminalVisible);
+  const setTerminalSize = useWorkspaceLayoutStore((state) => state.setTerminalSize);
+  const tabs = useTerminalStore((state) => state.tabs);
+  const activeTabId = useTerminalStore((state) => state.activeTabId);
+  const openTab = useTerminalStore((state) => state.openTab);
+  const isCompactLayout = useMediaQuery('(max-width: 991.98px)');
+  const [searchParams] = useSearchParams();
+  const focus = searchParams.get('focus');
+
+  useWorkspaceFocusSync({ focus, setChatVisible, setCompactPane, setCompactTerminalVisible });
+  useWorkspaceTerminalShortcut({ isCompactLayout, toggleCompactTerminal, toggleTerminal });
+  useWorkspaceTerminalBootstrap({
+    isCompactLayout,
+    isCompactTerminalVisible,
+    isTerminalVisible,
+    tabs,
+    openTab,
+  });
+
+  return {
+    chatSize,
+    terminalSize,
+    isChatVisible,
+    isTerminalVisible,
+    compactActivePane,
+    isCompactTerminalVisible,
+    tabs,
+    activeTabId,
+    isCompactLayout,
+    toggleChat,
+    toggleTerminal,
+    toggleCompactTerminal,
+    setCompactPane,
+    setCompactTerminalVisible,
+    setChatSize,
+    setTerminalSize,
+  };
+}

--- a/dashboard/src/store/workspaceLayoutStore.test.ts
+++ b/dashboard/src/store/workspaceLayoutStore.test.ts
@@ -29,6 +29,8 @@ describe('workspaceLayoutStore', () => {
     expect(state.terminalSize).toBe(DEFAULT_WORKSPACE_LAYOUT.terminalSize);
     expect(state.isChatVisible).toBe(true);
     expect(state.isTerminalVisible).toBe(false);
+    expect(state.compactActivePane).toBe('editor');
+    expect(state.isCompactTerminalVisible).toBe(false);
   });
 
   it('setChatSize clamps values and persists', () => {
@@ -93,6 +95,26 @@ describe('workspaceLayoutStore', () => {
     expect(state.isChatVisible).toBe(false);
     expect(state.isTerminalVisible).toBe(true);
   });
+
+  it('setCompactPane stores the compact active pane and persists it', () => {
+    useWorkspaceLayoutStore.getState().setCompactPane('chat');
+
+    const state = useWorkspaceLayoutStore.getState();
+    expect(state.compactActivePane).toBe('chat');
+
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    const parsed = JSON.parse(raw ?? '{}') as { compactActivePane: string };
+    expect(parsed.compactActivePane).toBe('chat');
+  });
+
+  it('toggleCompactTerminal persists compact terminal visibility', () => {
+    useWorkspaceLayoutStore.getState().toggleCompactTerminal();
+    expect(useWorkspaceLayoutStore.getState().isCompactTerminalVisible).toBe(true);
+
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    const parsed = JSON.parse(raw ?? '{}') as { isCompactTerminalVisible: boolean };
+    expect(parsed.isCompactTerminalVisible).toBe(true);
+  });
 });
 
 describe('normalizeStoredWorkspaceLayout', () => {
@@ -117,6 +139,8 @@ describe('normalizeStoredWorkspaceLayout', () => {
       terminalSize: 'oops',
       isChatVisible: 'yes',
       isTerminalVisible: true,
+      compactActivePane: 'invalid',
+      isCompactTerminalVisible: 'invalid',
     });
 
     const result = normalizeStoredWorkspaceLayout(raw);
@@ -126,6 +150,8 @@ describe('normalizeStoredWorkspaceLayout', () => {
     expect(result.terminalSize).toBe(DEFAULT_WORKSPACE_LAYOUT.terminalSize);
     expect(result.isChatVisible).toBe(DEFAULT_WORKSPACE_LAYOUT.isChatVisible);
     expect(result.isTerminalVisible).toBe(true);
+    expect(result.compactActivePane).toBe('editor');
+    expect(result.isCompactTerminalVisible).toBe(false);
   });
 
   it('preserves valid fields verbatim', () => {
@@ -135,6 +161,8 @@ describe('normalizeStoredWorkspaceLayout', () => {
       terminalSize: 35,
       isChatVisible: false,
       isTerminalVisible: true,
+      compactActivePane: 'chat',
+      isCompactTerminalVisible: true,
     });
 
     expect(normalizeStoredWorkspaceLayout(raw)).toEqual({
@@ -143,6 +171,8 @@ describe('normalizeStoredWorkspaceLayout', () => {
       terminalSize: 35,
       isChatVisible: false,
       isTerminalVisible: true,
+      compactActivePane: 'chat',
+      isCompactTerminalVisible: true,
     });
   });
 });

--- a/dashboard/src/store/workspaceLayoutStore.ts
+++ b/dashboard/src/store/workspaceLayoutStore.ts
@@ -4,12 +4,16 @@ const STORAGE_KEY = 'golem-workspace-layout';
 const MIN_PANEL_SIZE = 10;
 const MAX_PANEL_SIZE = 80;
 
+export type WorkspaceCompactPane = 'editor' | 'chat';
+
 export interface WorkspaceLayoutSnapshot {
   sidebarSize: number;
   chatSize: number;
   terminalSize: number;
   isChatVisible: boolean;
   isTerminalVisible: boolean;
+  compactActivePane: WorkspaceCompactPane;
+  isCompactTerminalVisible: boolean;
 }
 
 export const DEFAULT_WORKSPACE_LAYOUT: WorkspaceLayoutSnapshot = {
@@ -18,6 +22,8 @@ export const DEFAULT_WORKSPACE_LAYOUT: WorkspaceLayoutSnapshot = {
   terminalSize: 30,
   isChatVisible: true,
   isTerminalVisible: false,
+  compactActivePane: 'editor',
+  isCompactTerminalVisible: false,
 };
 
 interface WorkspaceLayoutState extends WorkspaceLayoutSnapshot {
@@ -25,8 +31,11 @@ interface WorkspaceLayoutState extends WorkspaceLayoutSnapshot {
   setTerminalSize: (size: number) => void;
   setChatVisible: (visible: boolean) => void;
   setTerminalVisible: (visible: boolean) => void;
+  setCompactPane: (pane: WorkspaceCompactPane) => void;
+  setCompactTerminalVisible: (visible: boolean) => void;
   toggleChat: () => void;
   toggleTerminal: () => void;
+  toggleCompactTerminal: () => void;
 }
 
 function clampSize(size: number, fallback: number): number {
@@ -66,6 +75,21 @@ function pickBoolean(
   return value;
 }
 
+function isWorkspaceCompactPane(value: unknown): value is WorkspaceCompactPane {
+  return value === 'editor' || value === 'chat';
+}
+
+function pickCompactPane(
+  source: Record<string, unknown>,
+  fallback: WorkspaceCompactPane,
+): WorkspaceCompactPane {
+  const value = source.compactActivePane;
+  if (!isWorkspaceCompactPane(value)) {
+    return fallback;
+  }
+  return value;
+}
+
 /**
  * Parses and sanitizes the persisted workspace layout snapshot from localStorage.
  */
@@ -93,6 +117,12 @@ export function normalizeStoredWorkspaceLayout(raw: string | null): WorkspaceLay
       source,
       'isTerminalVisible',
       DEFAULT_WORKSPACE_LAYOUT.isTerminalVisible,
+    ),
+    compactActivePane: pickCompactPane(source, DEFAULT_WORKSPACE_LAYOUT.compactActivePane),
+    isCompactTerminalVisible: pickBoolean(
+      source,
+      'isCompactTerminalVisible',
+      DEFAULT_WORKSPACE_LAYOUT.isCompactTerminalVisible,
     ),
   };
 }
@@ -125,13 +155,19 @@ function snapshotFromState(state: WorkspaceLayoutState): WorkspaceLayoutSnapshot
     terminalSize: state.terminalSize,
     isChatVisible: state.isChatVisible,
     isTerminalVisible: state.isTerminalVisible,
+    compactActivePane: state.compactActivePane,
+    isCompactTerminalVisible: state.isCompactTerminalVisible,
   };
 }
 
 const initialLayout = readInitialLayout();
 
+function persistNextState(get: () => WorkspaceLayoutState): void {
+  persistSnapshot(snapshotFromState(get()));
+}
+
 /**
- * Persists the workspace panel arrangement for chat and terminal panes.
+ * Persists the workspace panel arrangement for desktop splits and compact pane state.
  */
 export const useWorkspaceLayoutStore = create<WorkspaceLayoutState>((set, get) => ({
   ...initialLayout,
@@ -139,32 +175,47 @@ export const useWorkspaceLayoutStore = create<WorkspaceLayoutState>((set, get) =
   setChatSize: (size: number): void => {
     const next = clampSize(size, DEFAULT_WORKSPACE_LAYOUT.chatSize);
     set({ chatSize: next });
-    persistSnapshot(snapshotFromState(get()));
+    persistNextState(get);
   },
 
   setTerminalSize: (size: number): void => {
     const next = clampSize(size, DEFAULT_WORKSPACE_LAYOUT.terminalSize);
     set({ terminalSize: next });
-    persistSnapshot(snapshotFromState(get()));
+    persistNextState(get);
   },
 
   setChatVisible: (visible: boolean): void => {
     set({ isChatVisible: visible });
-    persistSnapshot(snapshotFromState(get()));
+    persistNextState(get);
   },
 
   setTerminalVisible: (visible: boolean): void => {
     set({ isTerminalVisible: visible });
-    persistSnapshot(snapshotFromState(get()));
+    persistNextState(get);
+  },
+
+  setCompactPane: (pane: WorkspaceCompactPane): void => {
+    set({ compactActivePane: pane });
+    persistNextState(get);
+  },
+
+  setCompactTerminalVisible: (visible: boolean): void => {
+    set({ isCompactTerminalVisible: visible });
+    persistNextState(get);
   },
 
   toggleChat: (): void => {
     set({ isChatVisible: !get().isChatVisible });
-    persistSnapshot(snapshotFromState(get()));
+    persistNextState(get);
   },
 
   toggleTerminal: (): void => {
     set({ isTerminalVisible: !get().isTerminalVisible });
-    persistSnapshot(snapshotFromState(get()));
+    persistNextState(get);
+  },
+
+  toggleCompactTerminal: (): void => {
+    set({ isCompactTerminalVisible: !get().isCompactTerminalVisible });
+    persistNextState(get);
   },
 }));

--- a/dashboard/src/styles/responsive.scss
+++ b/dashboard/src/styles/responsive.scss
@@ -64,4 +64,21 @@
   .form-control {
     font-size: 16px;
   }
+
+  .workspace-page--compact {
+    min-width: 0;
+  }
+
+  .workspace-terminal-offcanvas {
+    width: 100%;
+    max-width: none !important;
+  }
+
+  .workspace-terminal-offcanvas .workspace-terminal-pane {
+    min-height: min(50vh, 24rem);
+  }
+
+  .workspace-terminal-offcanvas .workspace-terminal-body {
+    min-height: min(40vh, 20rem);
+  }
 }

--- a/dashboard/src/styles/workspace.scss
+++ b/dashboard/src/styles/workspace.scss
@@ -1,0 +1,101 @@
+/* Workspace shell overrides and compact layout rules */
+
+.workspace-page {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  min-width: 0;
+  background: rgba(var(--gc-body-bg-rgb), 1);
+}
+
+.workspace-page--compact .workspace-toolbar {
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+
+.workspace-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 0.75rem;
+  border-bottom: 1px solid rgba(var(--gc-border-color-rgb), 0.55);
+  background: rgba(var(--gc-tertiary-bg-rgb), 0.55);
+}
+
+.workspace-toolbar-group {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.workspace-toolbar-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.2rem 0.55rem;
+  font-size: 0.78rem;
+  border-radius: 0.35rem;
+  background: transparent;
+  border: 1px solid rgba(var(--gc-border-color-rgb), 0.5);
+  color: var(--gc-body-color);
+  cursor: pointer;
+}
+
+.workspace-toolbar-button[aria-pressed='true'] {
+  background: rgba(var(--gc-primary-rgb), 0.18);
+  border-color: rgba(var(--gc-primary-rgb), 0.55);
+}
+
+.workspace-main,
+.workspace-compact-main {
+  flex: 1 1 auto;
+  min-height: 0;
+  min-width: 0;
+}
+
+.workspace-compact-main {
+  display: flex;
+  flex-direction: column;
+}
+
+.workspace-center {
+  min-width: 0;
+}
+
+.workspace-editor-pane,
+.workspace-chat-pane,
+.workspace-terminal-pane {
+  height: 100%;
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.workspace-chat-pane {
+  background: rgba(var(--gc-body-bg-rgb), 1);
+}
+
+.workspace-resize-handle {
+  background: rgba(var(--gc-border-color-rgb), 0.6);
+}
+
+.workspace-resize-handle-vertical {
+  width: 4px;
+  cursor: col-resize;
+}
+
+.workspace-resize-handle-horizontal {
+  height: 4px;
+  cursor: row-resize;
+}
+
+.workspace-terminal-offcanvas {
+  overflow: hidden;
+}
+
+.workspace-terminal-offcanvas-body {
+  padding: 0;
+}

--- a/dashboard/tests/e2e/dashboard-mobile-responsive.playwright.ts
+++ b/dashboard/tests/e2e/dashboard-mobile-responsive.playwright.ts
@@ -13,6 +13,7 @@ const MOBILE_ROUTES: MobileRouteExpectation[] = [
   { path: '/diagnostics', visibleText: 'This page shows the effective runtime paths/env' },
   { path: '/logs', visibleText: 'Live stream with virtualized rendering' },
   { path: '/settings', visibleText: 'Select a settings category' },
+  { path: '/workspace', visibleText: 'Open a file, make a quick change' },
 ];
 
 function buildRoutePath(routePath: string): string {

--- a/dashboard/tests/e2e/workspace-layout.playwright.ts
+++ b/dashboard/tests/e2e/workspace-layout.playwright.ts
@@ -5,7 +5,8 @@ test.beforeEach(async ({ page }) => {
   await installDashboardApiMocks(page);
 });
 
-test('workspace page renders with chat visible and terminal hidden by default', async ({ page }) => {
+test('workspace page renders with chat visible and terminal hidden by default on desktop', async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 900 });
   await page.goto('/dashboard/workspace');
 
   const chatToggle = page.locator('[data-testid="workspace-toggle-chat"]');
@@ -25,7 +26,8 @@ test('/ide and /chat redirect to /workspace', async ({ page }) => {
   await expect(page).toHaveURL(/\/workspace/);
 });
 
-test('toggles chat and terminal panels and persists layout through reload', async ({ page }) => {
+test('toggles desktop chat split and terminal panels and persists layout through reload', async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 900 });
   await page.goto('/dashboard/workspace');
 
   const chatToggle = page.locator('[data-testid="workspace-toggle-chat"]');
@@ -53,4 +55,41 @@ test('toggles chat and terminal panels and persists layout through reload', asyn
   await page.reload();
   await expect(chatToggle).toHaveAttribute('aria-pressed', 'false', { timeout: 15_000 });
   await expect(terminalToggle).toHaveAttribute('aria-pressed', 'true');
+});
+
+test('renders compact workspace mode on mobile and switches between editor and chat', async ({ page }) => {
+  await page.setViewportSize({ width: 375, height: 667 });
+  await page.goto('/dashboard/workspace');
+
+  await expect(page.locator('[data-testid="workspace-page-compact"]')).toBeVisible();
+  await expect(page.locator('[data-testid="workspace-compact-pane-editor"]')).toHaveAttribute('aria-pressed', 'true');
+  await expect(page.locator('[data-testid="workspace-compact-pane-chat"]')).toHaveAttribute('aria-pressed', 'false');
+  await expect(page.locator('[data-testid="workspace-toggle-chat"]')).toHaveCount(0);
+
+  await page.locator('[data-testid="workspace-compact-pane-chat"]').click();
+  await expect(page.locator('[data-testid="workspace-compact-pane-chat"]')).toHaveAttribute('aria-pressed', 'true');
+  await expect(page.locator('[data-testid="workspace-chat-pane"]')).toBeVisible();
+
+  await page.locator('[data-testid="workspace-compact-pane-editor"]').click();
+  await expect(page.locator('[data-testid="workspace-editor-pane"]')).toBeVisible();
+});
+
+test('opens mobile terminal as bottom sheet and supports focus route for chat', async ({ page }) => {
+  await page.setViewportSize({ width: 375, height: 667 });
+  await page.goto('/dashboard/workspace?focus=chat');
+
+  await expect(page.locator('[data-testid="workspace-compact-pane-chat"]')).toHaveAttribute('aria-pressed', 'true');
+  await expect(page.locator('[data-testid="workspace-chat-pane"]')).toBeVisible();
+
+  const terminalToggle = page.locator('[data-testid="workspace-toggle-terminal"]');
+  await expect(terminalToggle).toHaveAttribute('aria-pressed', 'false');
+
+  await terminalToggle.click();
+  await expect(terminalToggle).toHaveAttribute('aria-pressed', 'true');
+  await expect(page.getByRole('heading', { name: 'Terminal' })).toBeVisible();
+  await expect(page.locator('.workspace-terminal-offcanvas')).toBeVisible();
+  await expect(page.locator('.workspace-terminal-offcanvas [data-testid="workspace-terminal-pane"]')).toBeVisible();
+
+  await page.locator('.workspace-terminal-offcanvas').getByRole('button', { name: 'Close', exact: true }).click();
+  await expect(terminalToggle).toHaveAttribute('aria-pressed', 'false');
 });


### PR DESCRIPTION
## Summary
- add an adaptive dashboard workspace shell that preserves the desktop split layout while switching mobile/narrow viewports to a single-focus editor/chat workflow with a terminal bottom sheet
- persist compact workspace state separately from desktop split state and honor `/workspace?focus=chat|editor|terminal` deep links in the new mobile shell
- extend workspace coverage with targeted Vitest and Playwright checks for compact pane switching, mobile terminal overlay behavior, redirects, persistence, and mobile overflow safety
- compatibility: desktop workspace behavior remains split-layout based; mobile behavior intentionally changes to focused-pane navigation for usability
- feature flags/runtime toggles: no new feature flags or runtime toggles were introduced
- observability/tracing: no telemetry, tracing, or logging contracts were changed
- dashboard/API surface: dashboard-only change; no backend API contract changes
- test coverage: updated dashboard unit/component coverage and added mobile workspace Playwright coverage

## Architecture
```text
WorkspacePage
  -> useWorkspacePageState
       -> useWorkspaceFocusSync
       -> useWorkspaceTerminalShortcut
       -> useWorkspaceTerminalBootstrap
  -> CompactWorkspaceLayout | DesktopWorkspaceLayout
       -> WorkspaceEditorShell
       -> WorkspaceChatShell
       -> WorkspaceTerminalContent
            -> TerminalTabs
            -> TerminalPane
```

### Key design decisions
- Keep `react-resizable-panels` only for the desktop shell so touch-sized layouts are not forced into unusable split panes.
- Store compact workspace intent (`compactActivePane`, `isCompactTerminalVisible`) alongside existing desktop layout state so desktop sizes and mobile pane focus do not interfere with each other.
- Reuse the existing query-param entry points (`focus=chat|editor`) and extend them to `focus=terminal` instead of introducing a second routing scheme.
- Implement the mobile terminal as a bottom offcanvas to preserve editor/chat focus while still allowing terminal access without shrinking the main viewport.
- Split workspace rendering/state helpers into dedicated files to satisfy dashboard file-size constraints and keep the responsive logic testable.

### Files changed
| Area | Files | What |
| --- | --- | --- |
| Dashboard shell | `dashboard/src/components/layout/DashboardLayout.tsx`, `dashboard/src/components/ui/overlay.tsx`, `dashboard/src/main.tsx` | Treat `/workspace` as a shell route, add bottom offcanvas placement support, and load workspace-specific styles |
| Workspace state | `dashboard/src/store/workspaceLayoutStore.ts`, `dashboard/src/store/workspaceLayoutStore.test.ts` | Add persisted compact pane/mobile terminal state with normalization and persistence tests |
| Workspace UI | `dashboard/src/pages/WorkspacePage.tsx`, `dashboard/src/pages/workspace/WorkspaceLayouts.tsx`, `dashboard/src/pages/workspace/useWorkspacePageState.ts`, `dashboard/src/styles/workspace.scss`, `dashboard/src/styles/responsive.scss` | Implement compact/mobile workspace layouts, desktop layout preservation, focus syncing, terminal bootstrap, and responsive styling |
| Unit/component tests | `dashboard/src/pages/WorkspacePage.test.tsx` | Cover compact layout rendering, pane switching, compact terminal toggling, and deep-link behavior |
| Playwright | `dashboard/tests/e2e/workspace-layout.playwright.ts`, `dashboard/tests/e2e/dashboard-mobile-responsive.playwright.ts` | Add workspace mobile/desktop behavior checks and include `/workspace` in the mobile overflow suite |

### Configuration (none)
```json
{
  "runtimeConfigChanges": [],
  "apiContractChanges": [],
  "featureFlags": []
}
```
