### PR TITLE
fix(voice): preserve queued voice-only response for blank prefix

### DIFF
--- a/src/main/java/me/golemcore/bot/domain/system/OutgoingResponsePreparationSystem.java
+++ b/src/main/java/me/golemcore/bot/domain/system/OutgoingResponsePreparationSystem.java
@@ -174,7 +174,16 @@ public class OutgoingResponsePreparationSystem implements AgentSystem {
                 setOutgoingResponse(context, outgoing);
                 return context;
             }
-            // Prefix with blank content after stripping — nothing to send.
+            // Prefix with blank content after stripping: preserve tool-queued voice-only
+            // responses.
+            if (hasVoice) {
+                OutgoingResponse outgoing = OutgoingResponse.builder()
+                        .text(null)
+                        .voiceRequested(true)
+                        .voiceText(voiceText)
+                        .build();
+                setOutgoingResponse(context, outgoing);
+            }
             return context;
         }
 

--- a/src/test/java/me/golemcore/bot/domain/system/OutgoingResponsePreparationSystemTest.java
+++ b/src/test/java/me/golemcore/bot/domain/system/OutgoingResponsePreparationSystemTest.java
@@ -472,6 +472,25 @@ class OutgoingResponsePreparationSystemTest {
     }
 
     @Test
+    void shouldKeepVoiceOnlyResponseWhenVoicePrefixContentIsBlankButToolQueuedVoice() {
+        AgentContext context = buildContext();
+        context.setAttribute(ContextAttributes.LLM_RESPONSE,
+                LlmResponse.builder().content(VOICE_PREFIX + "   ").build());
+        context.setAttribute(ContextAttributes.FINAL_ANSWER_READY, true);
+        context.setVoiceRequested(true);
+        context.setVoiceText("Custom voice text from tool");
+
+        AgentContext result = system.process(context);
+
+        OutgoingResponse outgoing = result.getAttribute(ContextAttributes.OUTGOING_RESPONSE);
+        assertNotNull(outgoing);
+        assertNull(outgoing.getText());
+        assertTrue(outgoing.isVoiceRequested());
+        assertEquals("Custom voice text from tool", outgoing.getVoiceText());
+        assertNull(result.getAttribute(ContextAttributes.LLM_ERROR));
+    }
+
+    @Test
     void shouldHandleVoicePrefixWithLeadingWhitespace() {
         AgentContext context = buildContext();
         context.setAttribute(ContextAttributes.LLM_RESPONSE,


### PR DESCRIPTION
## Summary
- preserve tool-queued voice-only responses when the LLM final text is only the voice prefix plus whitespace
- keep the existing blank-prefix behavior unchanged when no queued voice payload exists
- add a narrow regression test in `OutgoingResponsePreparationSystemTest` to lock the voice-only contract

## Architecture
```text
Tool / LLM final response
  -> OutgoingResponsePreparationSystem.process(context)
     -> detect voice prefix in final text
     -> strip prefix
     -> if stripped text is non-blank: build normal outgoing voice response
     -> if stripped text is blank and tool already queued voice text: build voice-only OutgoingResponse
  -> ResponseRoutingSystem
     -> route the preserved OutgoingResponse to the channel voice path
```

### Key design decisions
- keep the fix in `OutgoingResponsePreparationSystem` because that class owns the final outbound response normalization contract
- preserve the existing no-op behavior for blank voice-prefix responses that do not carry queued voice data, avoiding any broader routing change
- cover the regression with a single observable test that asserts the resulting `OutgoingResponse` instead of internal implementation details
- avoid new context flags or configuration because the required state already exists in the current context voice fields

### Files changed
| Area | Files | What |
| --- | --- | --- |
| Voice response preparation | `src/main/java/me/golemcore/bot/domain/system/OutgoingResponsePreparationSystem.java` | Preserve a voice-only outgoing response when blank voice-prefix content would otherwise discard a tool-queued voice payload |
| Regression coverage | `src/test/java/me/golemcore/bot/domain/system/OutgoingResponsePreparationSystemTest.java` | Add focused coverage for blank voice-prefix content with queued voice text |

### Configuration
No runtime configuration changes.

Compatibility behavior: existing handling for blank voice-prefix responses without queued voice data is unchanged.

Observability/tracing impact: none.

Dashboard/API surface changes: none.

Test coverage: adds focused regression coverage for the blank voice-prefix plus queued voice-text scenario, while existing related voice test suites remain green in current surefire reports.
